### PR TITLE
Rework pod volume mounts

### DIFF
--- a/pkg/controller/iscsid/iscsid_controller.go
+++ b/pkg/controller/iscsid/iscsid_controller.go
@@ -126,8 +126,6 @@ func (r *ReconcileIscsid) Reconcile(request reconcile.Request) (reconcile.Result
 }
 
 func newDaemonset(cr *novav1.Iscsid, cmName string) *appsv1.DaemonSet {
-        var bidirectional corev1.MountPropagationMode = corev1.MountPropagationBidirectional
-        var hostToContainer corev1.MountPropagationMode = corev1.MountPropagationHostToContainer
         var trueVar bool = true
 
         daemonSet := appsv1.DaemonSet{
@@ -208,7 +206,7 @@ func newDaemonset(cr *novav1.Iscsid, cmName string) *appsv1.DaemonSet {
                         {
                                 Name:      "lib-modules-volume",
                                 MountPath: "/lib/modules",
-                                MountPropagation: &hostToContainer,
+                                ReadOnly:  true,
                         },
                         {
                                 Name:      "dev-volume",
@@ -225,7 +223,6 @@ func newDaemonset(cr *novav1.Iscsid, cmName string) *appsv1.DaemonSet {
                         {
                                 Name:      "var-lib-iscsi-volume",
                                 MountPath: "/var/lib/iscsi",
-                                MountPropagation: &bidirectional,
                         },
                 },
         }

--- a/pkg/controller/libvirtd/libvirtd_controller.go
+++ b/pkg/controller/libvirtd/libvirtd_controller.go
@@ -212,7 +212,6 @@ func (r *ReconcileLibvirtd) setDaemonsetHash(instance *novav1.Libvirtd, hashStr 
 
 func newDaemonset(cr *novav1.Libvirtd, cmName string, configHash string) *appsv1.DaemonSet {
         var bidirectional corev1.MountPropagationMode = corev1.MountPropagationBidirectional
-        var hostToContainer corev1.MountPropagationMode = corev1.MountPropagationHostToContainer
         var trueVar bool = true
         var falseVar bool = false
         var configVolumeDefaultMode int32 = 0644
@@ -348,36 +347,27 @@ func newDaemonset(cr *novav1.Libvirtd, cmName string, configHash string) *appsv1
                         {
                                 Name:      "etc-libvirt-qemu",
                                 MountPath: "/etc/libvirt/qemu",
-                                MountPropagation: &bidirectional,
                         },
                         {
                                 Name:      "lib-modules",
                                 MountPath: "/lib/modules",
-                                MountPropagation: &hostToContainer,
+                                ReadOnly:  true,
                         },
                         {
                                 Name:      "dev",
                                 MountPath: "/dev",
-                                MountPropagation: &bidirectional,
                         },
                         {
                                 Name:      "run",
                                 MountPath: "/run",
-                                MountPropagation: &bidirectional,
                         },
                         {
                                 Name:      "sys-fs-cgroup",
                                 MountPath: "/sys/fs/cgroup",
                         },
                         {
-                                Name:      "var-run-libvirt",
-                                MountPath: "/var/run/libvirt",
-                                MountPropagation: &bidirectional,
-                        },
-                        {
                                 Name:      "libvirt-log",
                                 MountPath: "/var/log/libvirt",
-                                MountPropagation: &bidirectional,
                         },
                         {
                                 Name:      "var-lib-nova",
@@ -392,7 +382,6 @@ func newDaemonset(cr *novav1.Libvirtd, cmName string, configHash string) *appsv1
                         {
                                 Name:      "var-lib-vhost-sockets",
                                 MountPath: "/var/lib/vhost_sockets",
-                                MountPropagation: &bidirectional,
                         },
                         {
                                 Name:      "nova-config",
@@ -408,7 +397,7 @@ func newDaemonset(cr *novav1.Libvirtd, cmName string, configHash string) *appsv1
                         Name: "etc-libvirt-qemu",
                         VolumeSource: corev1.VolumeSource{
                                 HostPath: &corev1.HostPathVolumeSource{
-                                        Path: "/opt/osp/etc/libvirt/qemu",
+                                        Path: "/etc/libvirt/qemu",
                                         Type: &dirOrCreate,
                                 },
                         },

--- a/pkg/controller/novacompute/novacompute_controller.go
+++ b/pkg/controller/novacompute/novacompute_controller.go
@@ -237,7 +237,6 @@ func (r *ReconcileNovaCompute) setDaemonsetHash(instance *novav1.NovaCompute, ha
 
 func newDaemonset(cr *novav1.NovaCompute, cmName string, configHash string) *appsv1.DaemonSet {
         var bidirectional corev1.MountPropagationMode = corev1.MountPropagationBidirectional
-        var hostToContainer corev1.MountPropagationMode = corev1.MountPropagationHostToContainer
         var trueVar bool = true
         var configVolumeDefaultMode int32 = 0644
         var dirOrCreate corev1.HostPathType = corev1.HostPathDirectoryOrCreate
@@ -329,7 +328,6 @@ func newDaemonset(cr *novav1.NovaCompute, cmName string, configHash string) *app
                         {
                                 Name:      "var-lib-nova-volume",
                                 MountPath: "/var/lib/nova",
-                                MountPropagation: &bidirectional,
                         },
                         {
                                 Name:      "nova-config-vol",
@@ -369,15 +367,8 @@ func newDaemonset(cr *novav1.NovaCompute, cmName string, configHash string) *app
                 },
                 VolumeMounts: []corev1.VolumeMount{
                         {
-                                Name:      cmName,
-                                ReadOnly:  true,
-                                MountPath: "/etc/my.cnf.d/tripleo.cnf",
-                                SubPath:   "tripleo.cnf",
-                        },
-                        {
                                 Name:      "etc-libvirt-qemu-volume",
                                 MountPath: "/etc/libvirt/qemu",
-                                MountPropagation: &bidirectional,
                         },
                         {
                                 Name:      "etc-machine-id",
@@ -392,22 +383,20 @@ func newDaemonset(cr *novav1.NovaCompute, cmName string, configHash string) *app
                         {
                                 Name:      "boot-volume",
                                 MountPath: "/boot",
-                                MountPropagation: &hostToContainer,
+                                ReadOnly:  true,
                         },
                         {
                                 Name:      "dev-volume",
                                 MountPath: "/dev",
-                                MountPropagation: &hostToContainer,
                         },
                         {
                                 Name:      "lib-modules-volume",
                                 MountPath: "/lib/modules",
-                                MountPropagation: &hostToContainer,
+                                ReadOnly:  true,
                         },
                         {
                                 Name:      "run-volume",
                                 MountPath: "/run",
-                                MountPropagation: &hostToContainer,
                         },
                         {
                                 Name:      "sys-fs-cgroup-volume",
@@ -415,14 +404,8 @@ func newDaemonset(cr *novav1.NovaCompute, cmName string, configHash string) *app
                                 ReadOnly:  true,
                         },
                         {
-                                Name:      "run-libvirt-volume",
-                                MountPath: "/var/run/libvirt",
-                                MountPropagation: &bidirectional,
-                        },
-                        {
                                 Name:      "nova-log-volume",
                                 MountPath: "/var/log/nova",
-                                MountPropagation: &bidirectional,
                         },
                         {
                                 Name:      "var-lib-nova-volume",
@@ -437,7 +420,6 @@ func newDaemonset(cr *novav1.NovaCompute, cmName string, configHash string) *app
                         {
                                 Name:      "var-lib-iscsi-volume",
                                 MountPath: "/var/lib/iscsi",
-                                MountPropagation: &bidirectional,
                         },
                         {
                                 Name:      "nova-config-vol",
@@ -461,7 +443,7 @@ func newDaemonset(cr *novav1.NovaCompute, cmName string, configHash string) *app
                         Name: "etc-libvirt-qemu-volume",
                         VolumeSource: corev1.VolumeSource{
                                 HostPath: &corev1.HostPathVolumeSource{
-                                        Path: "/opt/osp/etc/libvirt/qemu",
+                                        Path: "/etc/libvirt/qemu",
                                         Type: &dirOrCreate,
                                 },
                         },
@@ -511,15 +493,6 @@ func newDaemonset(cr *novav1.NovaCompute, cmName string, configHash string) *app
                         VolumeSource: corev1.VolumeSource{
                                 HostPath: &corev1.HostPathVolumeSource{
                                         Path: "/sys/fs/cgroup",
-                                },
-                        },
-                },
-                {
-                        Name: "run-libvirt-volume",
-                        VolumeSource: corev1.VolumeSource{
-                                HostPath: &corev1.HostPathVolumeSource{
-                                        Path: "/var/run/libvirt",
-                                        Type: &dirOrCreate,
                                 },
                         },
                 },

--- a/pkg/controller/novamigrationtarget/novamigrationtarget_controller.go
+++ b/pkg/controller/novamigrationtarget/novamigrationtarget_controller.go
@@ -238,7 +238,7 @@ func (r *ReconcileNovaMigrationTarget) setDaemonsetHash(instance *novav1.NovaMig
 }
 
 func newDaemonset(cr *novav1.NovaMigrationTarget, cmName string, configHash string) *appsv1.DaemonSet {
-        var bidirectional corev1.MountPropagationMode = corev1.MountPropagationBidirectional
+        var hostToContainer corev1.MountPropagationMode = corev1.MountPropagationHostToContainer
         var trueVar bool = true
         var userId int64 = 0
         var configVolumeDefaultMode int32 = 0600
@@ -319,7 +319,6 @@ func newDaemonset(cr *novav1.NovaMigrationTarget, cmName string, configHash stri
                         {
                                 Name:      "var-lib-nova",
                                 MountPath: "/var/lib/nova",
-                                MountPropagation: &bidirectional,
                         },
                         {
                                 Name:      cmName,
@@ -394,22 +393,22 @@ func newDaemonset(cr *novav1.NovaMigrationTarget, cmName string, configHash stri
                         {
                                 Name:      "var-lib-nova",
                                 MountPath: "/var/lib/nova",
-                                MountPropagation: &bidirectional,
+                                MountPropagation: &hostToContainer,
                         },
                         {
                                 Name:      "run-libvirt",
                                 MountPath: "/run/libvirt",
-                                MountPropagation: &bidirectional,
+                                ReadOnly:  true,
                         },
                         {
                                 Name:      "ssh-config-vol",
                                 MountPath: "/etc/ssh",
-                                //ReadOnly:  true,
+                                ReadOnly:  true,
                         },
                         {
                                 Name:      "nova-config-vol",
                                 MountPath: "/etc/nova/migration",
-                                //ReadOnly:  true,
+                                ReadOnly:  true,
                         },
                 },
         }

--- a/pkg/controller/virtlogd/virtlogd_controller.go
+++ b/pkg/controller/virtlogd/virtlogd_controller.go
@@ -170,8 +170,6 @@ func (r *ReconcileVirtlogd) Reconcile(request reconcile.Request) (reconcile.Resu
 }
 
 func newDaemonset(cr *novav1.Virtlogd, cmName string) *appsv1.DaemonSet {
-
-        var bidirectional corev1.MountPropagationMode = corev1.MountPropagationBidirectional
         var hostToContainer corev1.MountPropagationMode = corev1.MountPropagationHostToContainer
         var trueVar bool = true
         var configVolumeDefaultMode int32 = 0644
@@ -258,17 +256,15 @@ func newDaemonset(cr *novav1.Virtlogd, cmName string) *appsv1.DaemonSet {
                         {
                                 Name:      "etc-libvirt-qemu-volume",
                                 MountPath: "/etc/libvirt/qemu",
-                                MountPropagation: &bidirectional,
                         },
                         {
                                 Name:      "lib-modules-volume",
                                 MountPath: "/lib/modules",
-                                MountPropagation: &hostToContainer,
+                                ReadOnly:  true,
                         },
                         {
                                 Name:      "dev-volume",
                                 MountPath: "/dev",
-                                MountPropagation: &hostToContainer,
                         },
                         {
                                 Name:      "sys-fs-cgroup-volume",
@@ -278,27 +274,20 @@ func newDaemonset(cr *novav1.Virtlogd, cmName string) *appsv1.DaemonSet {
                         {
                                 Name:      "run-volume",
                                 MountPath: "/run",
-                                MountPropagation: &hostToContainer,
-                        },
-                        {
-                                Name:      "run-libvirt-volume",
-                                MountPath: "/var/run/libvirt",
-                                MountPropagation: &bidirectional,
                         },
                         {
                                 Name:      "libvirt-log-volume",
                                 MountPath: "/var/log/libvirt",
-                                MountPropagation: &bidirectional,
                         },
                         {
                                 Name:      "var-lib-nova-volume",
                                 MountPath: "/var/lib/nova",
-                                MountPropagation: &bidirectional,
+                                MountPropagation: &hostToContainer,
                         },
                         {
                                 Name:      "var-lib-libvirt-volume",
                                 MountPath: "/var/lib/libvirt",
-                                MountPropagation: &bidirectional,
+                                MountPropagation: &hostToContainer,
                         },
                 },
         }


### PR DESCRIPTION
Right now some volumes were mounted with Bidirectional
mountPropagation option, which resulted in issues when pods get
re-created. E.g. the default terminationMessagePath is
/dev/termination-log and serviceAccount token gets mount per
default to /var/run/secrets/kubernetes.io/serviceaccount inside
the container. If /dev and /run (where /var/run is a ling to /run)
gets mounted with mountPropagation: Bidirectional results in errors
due to information is removed from the host dir.

This change reworks the used volume mounts and options:
* removed var-run-libvirt as /var/run is a link to /run and /run
  gets mounted
* moved /opt/osp/etc/libvirt/qemu to default location in
  /etc/libvirt/qemu
* removed mount of my.cf.d/tripleo.cnf as computes don't need
  and will have DB access
* bidirectional mount is now only used in nova-compute and
  libvirtd pod as this is required for some volume drivers
* changed /boot and /lib/modules to be readonly mounts
* removed MountPropagation from /run and /dev mount as they are
  not required and resulted in the above mentioned errors on pod
  re-create.