### PR TITLE
Enable ReadinessProbe and LivenessProbe container healthchecks

### DIFF
--- a/pkg/controller/iscsid/iscsid_controller.go
+++ b/pkg/controller/iscsid/iscsid_controller.go
@@ -239,18 +239,31 @@ func newDaemonset(cr *novav1.Iscsid, cmName string, templatesConfigHash string) 
 	containerSpec := corev1.Container{
 		Name:  "iscsid",
 		Image: cr.Spec.IscsidImage,
-		//ReadinessProbe: &corev1.Probe{
-		//        Handler: corev1.Handler{
-		//                Exec: &corev1.ExecAction{
-		//                        Command: []string{
-		//                                "/openstack/healthcheck", "libvirtd",
-		//                        },
-		//                },
-		//        },
-		//        InitialDelaySeconds: 30,
-		//        PeriodSeconds:       30,
-		//        TimeoutSeconds:      1,
-		//},
+		ReadinessProbe: &corev1.Probe{
+			Handler: corev1.Handler{
+				Exec: &corev1.ExecAction{
+					Command: []string{
+						"/openstack/healthcheck",
+					},
+				},
+			},
+			InitialDelaySeconds: 5,
+			PeriodSeconds:       15,
+			TimeoutSeconds:      3,
+		},
+                LivenessProbe: &corev1.Probe{
+                        Handler: corev1.Handler{
+                               Exec: &corev1.ExecAction{
+                                       Command: []string{
+                                               "/openstack/healthcheck",
+                                       },
+                               },
+                       },
+                       InitialDelaySeconds: 30,
+                       PeriodSeconds:       60,
+                       TimeoutSeconds:      3,
+                       FailureThreshold:    5,
+                },
 		Command: []string{},
 		SecurityContext: &corev1.SecurityContext{
 			Privileged: &trueVar,

--- a/pkg/controller/libvirtd/libvirtd_controller.go
+++ b/pkg/controller/libvirtd/libvirtd_controller.go
@@ -283,18 +283,31 @@ func newDaemonset(cr *novav1.Libvirtd, cmName string, templatesConfigHash string
 	containerSpec := corev1.Container{
 		Name:  "libvirtd",
 		Image: cr.Spec.NovaLibvirtImage,
-		//ReadinessProbe: &corev1.Probe{
-		//        Handler: corev1.Handler{
-		//                Exec: &corev1.ExecAction{
-		//                        Command: []string{
-		//                                "/openstack/healthcheck", "libvirtd",
-		//                        },
-		//                },
-		//        },
-		//        InitialDelaySeconds: 30,
-		//        PeriodSeconds:       30,
-		//        TimeoutSeconds:      1,
-		//},
+		ReadinessProbe: &corev1.Probe{
+			Handler: corev1.Handler{
+				Exec: &corev1.ExecAction{
+					Command: []string{
+						"/openstack/healthcheck", "libvirtd",
+					},
+				},
+			},
+			InitialDelaySeconds: 5,
+			PeriodSeconds:       15,
+			TimeoutSeconds:      3,
+		},
+                LivenessProbe: &corev1.Probe{
+                        Handler: corev1.Handler{
+                               Exec: &corev1.ExecAction{
+                                       Command: []string{
+                                               "/openstack/healthcheck", "libvirtd",
+                                       },
+                               },
+                       },
+                       InitialDelaySeconds: 30,
+                       PeriodSeconds:       60,
+                       TimeoutSeconds:      3,
+                       FailureThreshold:    5,
+                },
 		Lifecycle: &corev1.Lifecycle{
 			PreStop: &corev1.Handler{
 				Exec: &corev1.ExecAction{

--- a/pkg/controller/novacompute/novacompute_controller.go
+++ b/pkg/controller/novacompute/novacompute_controller.go
@@ -351,18 +351,31 @@ func newDaemonset(cr *novav1.NovaCompute, cmName string, templatesConfigHash str
 	containerSpec := corev1.Container{
 		Name:  "nova-compute",
 		Image: cr.Spec.NovaComputeImage,
-		//ReadinessProbe: &corev1.Probe{
-		//        Handler: corev1.Handler{
-		//                Exec: &corev1.ExecAction{
-		//                        Command: []string{
-		//                                "/openstack/healthcheck",
-		//                        },
-		//                },
-		//        },
-		//        InitialDelaySeconds: 30,
-		//        PeriodSeconds:       30,
-		//        TimeoutSeconds:      1,
-		//},
+		ReadinessProbe: &corev1.Probe{
+			Handler: corev1.Handler{
+				Exec: &corev1.ExecAction{
+					Command: []string{
+						"/openstack/healthcheck",
+					},
+				},
+			},
+			InitialDelaySeconds: 30,
+			PeriodSeconds:       30,
+			TimeoutSeconds:      3,
+		},
+                LivenessProbe: &corev1.Probe{
+                        Handler: corev1.Handler{
+                               Exec: &corev1.ExecAction{
+                                       Command: []string{
+                                               "/openstack/healthcheck",
+                                       },
+                               },
+                       },
+                       InitialDelaySeconds: 30,
+                       PeriodSeconds:       60,
+                       TimeoutSeconds:      3,
+                       FailureThreshold:    5,
+                },
 		Command: []string{},
 		SecurityContext: &corev1.SecurityContext{
 			Privileged: &trueVar,

--- a/pkg/controller/novamigrationtarget/novamigrationtarget_controller.go
+++ b/pkg/controller/novamigrationtarget/novamigrationtarget_controller.go
@@ -371,18 +371,31 @@ func newDaemonset(cr *novav1.NovaMigrationTarget, cmName string, templatesConfig
 	containerSpec := corev1.Container{
 		Name:  "nova-migration-target",
 		Image: cr.Spec.NovaComputeImage,
-		//ReadinessProbe: &corev1.Probe{
-		//        Handler: corev1.Handler{
-		//                Exec: &corev1.ExecAction{
-		//                        Command: []string{
-		//                                "/openstack/healthcheck",
-		//                        },
-		//                },
-		//        },
-		//        InitialDelaySeconds: 30,
-		//        PeriodSeconds:       30,
-		//        TimeoutSeconds:      1,
-		//},
+		ReadinessProbe: &corev1.Probe{
+			Handler: corev1.Handler{
+				Exec: &corev1.ExecAction{
+					Command: []string{
+						"/openstack/healthcheck",
+					},
+				},
+			},
+			InitialDelaySeconds: 5,
+			PeriodSeconds:       15,
+			TimeoutSeconds:      3,
+		},
+                LivenessProbe: &corev1.Probe{
+                        Handler: corev1.Handler{
+                               Exec: &corev1.ExecAction{
+                                       Command: []string{
+                                               "/openstack/healthcheck",
+                                       },
+                               },
+                       },
+                       InitialDelaySeconds: 30,
+                       PeriodSeconds:       60,
+                       TimeoutSeconds:      3,
+                       FailureThreshold:    5,
+                },
 		SecurityContext: &corev1.SecurityContext{
 			RunAsUser:  &userID,
 			Privileged: &trueVar,

--- a/pkg/controller/virtlogd/virtlogd_controller.go
+++ b/pkg/controller/virtlogd/virtlogd_controller.go
@@ -226,19 +226,31 @@ func newDaemonset(cr *novav1.Virtlogd, cmName string, templatesConfigHash string
 	containerSpec := corev1.Container{
 		Name:  "virtlogd",
 		Image: cr.Spec.NovaLibvirtImage,
-		//NOTE: removed for now as after some time it left a lot of parallel lsof processes running, need to investigate
-		//ReadinessProbe: &corev1.Probe{
-		//        Handler: corev1.Handler{
-		//                Exec: &corev1.ExecAction{
-		//                        Command: []string{
-		//                                "/openstack/healthcheck", "virtlogd",
-		//                        },
-		//                },
-		//        },
-		//        InitialDelaySeconds: 30,
-		//        PeriodSeconds:       30,
-		//        TimeoutSeconds:      1,
-		//},
+		ReadinessProbe: &corev1.Probe{
+			Handler: corev1.Handler{
+				Exec: &corev1.ExecAction{
+					Command: []string{
+						"/openstack/healthcheck", "virtlogd",
+					},
+				},
+			},
+			InitialDelaySeconds: 5,
+			PeriodSeconds:       15,
+			TimeoutSeconds:      3,
+		},
+                LivenessProbe: &corev1.Probe{
+                        Handler: corev1.Handler{
+				Exec: &corev1.ExecAction{
+					Command: []string{
+						"/openstack/healthcheck", "virtlogd",
+					},
+				},
+			},
+			InitialDelaySeconds: 30,
+			PeriodSeconds:       60,
+			TimeoutSeconds:      3,
+                        FailureThreshold:    5,
+                },
 		Command: []string{},
 		SecurityContext: &corev1.SecurityContext{
 			Privileged: &trueVar,


### PR DESCRIPTION
This enables the container healthchecks where the tripleo
/openstack/healthcheck scripts are used.