### PR TITLE
Move nodeSelector and tolerations to match compute-node-operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ NOTE:
 This is optional, a prebuild operator from quay.io/openstack-k8s-operators/nova-operator could be used, e.g. quay.io/openstack-k8s-operators/nova-operator:v0.0.1 .
 
 Create CRDs
-    
-    oc create -f deploy/crds/nova_v1_virtlogd_crd.yaml
-    oc create -f deploy/crds/nova_v1_libvirtd_crd.yaml
-    oc create -f deploy/crds/nova_v1_novacompute_crd.yaml
-    oc create -f deploy/crds/nova_v1_iscsid_crd.yaml
-    oc create -f deploy/crds/nova_v1_novamigrationtarget_crd.yaml
+
+    oc create -f deploy/crds/nova.openstack.org_libvirtds_crd.yaml
+    oc create -f deploy/crds/nova.openstack.org_virtlogds_crd.yaml
+    oc create -f deploy/crds/nova.openstack.org_novacomputes_crd.yaml
+    oc create -f deploy/crds/nova.openstack.org_iscsids_crd.yaml
+    oc create -f deploy/crds/nova.openstack.org_novamigrationtargets_crd.yaml
 
 Build the image, using your custom registry you have write access to
 
@@ -40,11 +40,11 @@ Replace `image:` in deploy/operator.yaml with your custom registry
 
 Create CRDs
     
-    oc create -f deploy/crds/nova_v1_virtlogd_crd.yaml
-    oc create -f deploy/crds/nova_v1_libvirtd_crd.yaml
-    oc create -f deploy/crds/nova_v1_novacompute_crd.yaml
-    oc create -f deploy/crds/nova_v1_iscsid_crd.yaml
-    oc create -f deploy/crds/nova_v1_novamigrationtarget_crd.yaml
+    oc create -f deploy/crds/nova.openstack.org_libvirtds_crd.yaml
+    oc create -f deploy/crds/nova.openstack.org_virtlogds_crd.yaml
+    oc create -f deploy/crds/nova.openstack.org_novacomputes_crd.yaml
+    oc create -f deploy/crds/nova.openstack.org_iscsids_crd.yaml
+    oc create -f deploy/crds/nova.openstack.org_novamigrationtargets_crd.yaml
 
 Create namespace
 
@@ -71,9 +71,9 @@ If necessary check logs with
 
 Create custom resource for a compute node
 
-`deploy/crds/nova_v1_novacompute_cr.yaml` and `deploy/crds/nova_v1_virtlogd_cr.yaml` use a patched nova-libvirt image with added cgroups tools which are required for the libvirtd.sh wrapper script. 
+`deploy/crds/nova.openstack.org_libvirtd_cr.yaml` and `deploy/crds/nova.openstack.org_virtlogd_cr.yaml` use a patched nova-libvirt image with added cgroups tools which are required for the libvirtd.sh wrapper script. 
 
-`deploy/crds/nova_v1_virtlogd_cr.yaml` and `deploy/crds/nova_v1_libvirtd_cr.yaml`:
+`deploy/crds/nova.openstack.org_virtlogd_cr.yaml`:
 
     apiVersion: nova.openstack.org/v1
     kind: Virtlogd
@@ -82,10 +82,10 @@ Create custom resource for a compute node
       namespace: openstack
     spec:
       novaLibvirtImage: quay.io/openstack-k8s-operators/nova-libvirt:latest
-      label: compute
       serviceAccount: nova-operator
+      roleName: worker-osp
 
-`deploy/crds/nova_v1_libvirtd_cr.yaml`:
+`deploy/crds/nova.openstack.org_libvirtd_cr.yaml`:
 
     apiVersion: nova.openstack.org/v1
     kind: Libvirtd
@@ -94,13 +94,12 @@ Create custom resource for a compute node
       namespace: openstack
     spec:
       novaLibvirtImage: quay.io/openstack-k8s-operators/nova-libvirt:latest
-      label: compute
       serviceAccount: nova-operator
+      roleName: worker-osp
 
+Update `deploy/crds/nova.openstack.org_iscsid_cr.yaml`, `deploy/crds/nova.openstack.org_novamigrationtarget_cr.yaml` and `deploy/crds/nova.openstack.org_novacompute_cr.yaml` with the details of the images and the OpenStack environment.
 
-Update `deploy/crds/nova_v1_iscsid_cr.yaml`, `deploy/crds/nova_v1_novamigrationtarget_cr.yaml` and `deploy/crds/nova_v1_novacompute_cr.yaml` with the details of the images and the OpenStack environment.
-
-`deploy/crds/nova_v1_iscsid_cr.yaml`:
+`deploy/crds/nova.openstack.org_iscsid_cr.yaml`:
 
     apiVersion: nova.openstack.org/v1
     kind: Iscsid
@@ -109,10 +108,10 @@ Update `deploy/crds/nova_v1_iscsid_cr.yaml`, `deploy/crds/nova_v1_novamigrationt
       namespace: openstack
     spec:
       iscsidImage: docker.io/tripleotrain/rhel-binary-iscsid:current-tripleo
-      label: compute
       serviceAccount: nova-operator
+      roleName: worker-osp
 
-`deploy/crds/nova_v1_novamigrationtarget_cr.yaml`:
+`deploy/crds/nova.openstack.org_novamigrationtarget_cr.yaml`:
 
     apiVersion: nova.openstack.org/v1
     kind: NovaMigrationTarget
@@ -122,10 +121,10 @@ Update `deploy/crds/nova_v1_iscsid_cr.yaml`, `deploy/crds/nova_v1_novamigrationt
     spec:
       sshdPort: 2022
       novaComputeImage: docker.io/tripleotrain/rhel-binary-nova-compute:current-tripleo
-      label: compute
       serviceAccount: nova-operator
+      roleName: worker-osp
 
-`deploy/crds/nova_v1_novacompute_cr.yaml`:
+`deploy/crds/nova.openstack.org_novacompute_cr.yaml`:
 
     apiVersion: nova.openstack.org/v1
     kind: NovaCompute
@@ -150,8 +149,8 @@ Update `deploy/crds/nova_v1_iscsid_cr.yaml`, `deploy/crds/nova_v1_novamigrationt
       #novaComputeCPUSharedSet: 0-3
 
       novaComputeImage: docker.io/tripleotrain/rhel-binary-nova-compute:current-tripleo
-      label: compute
       serviceAccount: nova-operator
+      roleName: worker-osp
 
 If instances with CPU pinning are used, the cores which are set for novaComputeCPUDedicatedSet should be excluded from
 the kernel scheduler. With this it is sure that the core is exclusive for the pinned instances.
@@ -174,19 +173,22 @@ In this example core range 4-7 are isolated using `isolcpus`:
 
 Apply the CRs:
 
-    oc apply -f deploy/crds/nova_v1_virtlogd_cr.yaml
-    oc apply -f deploy/crds/nova_v1_libvirtd_cr.yaml
-    oc apply -f deploy/crds/nova_v1_iscsid_cr.yaml
-    oc apply -f deploy/crds/nova_v1_novamigrationtarget_cr.yaml
-    oc apply -f deploy/crds/nova_v1_novacompute_cr.yaml
+    oc apply -f deploy/crds/nova.openstack.org_virtlogd_cr.yaml
+    oc apply -f deploy/crds/nova.openstack.org_libvirtd_cr.yaml
+    oc apply -f deploy/crds/nova.openstack.org_iscsid_cr.yaml
+    oc apply -f deploy/crds/nova.openstack.org_novamigrationtarget_cr.yaml
+    oc apply -f deploy/crds/nova.openstack.org_novacompute_cr.yaml
 
-    oc get pods
+    oc get pods -n openstack
     NAME                           READY   STATUS    RESTARTS   AGE
     nova-operator-ffd64796-vshg6   1/1     Running   0          119s
 
-    oc get ds
-    NAME           DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR    AGE
-    nova-compute   0         0         0       0            0           daemon=compute   118s
+    NAME                    DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR                         AGE
+    iscsid                  0         0         0       0            0           node-role.kubernetes.io/worker-osp=   88m
+    libvirtd                0         0         0       0            0           node-role.kubernetes.io/worker-osp=   12m
+    nova-compute            0         0         0       0            0           node-role.kubernetes.io/worker-osp=   12m
+    nova-migration-target   0         0         0       0            0           node-role.kubernetes.io/worker-osp=   12m
+    virtlogd                0         0         0       0            0           node-role.kubernetes.io/worker-osp=   12m
 
 ### Create required common-config configMap
 
@@ -212,78 +214,44 @@ Note: Right now the operator does not handle config updates to the common-config
 
 !! Make sure we have the OSP needed network configs on the worker nodes. The workers need to be able to reach the internalapi, storage and tenant network !!
 
+
+Install the compute-node-operator from and create a machineset for the worker-osp role. When deployed the OSP worker is installed with additional worker-osp role:
+
     $ oc get nodes
-    NAME       STATUS   ROLES    AGE   VERSION
-    master-0   Ready    master   8d    v1.14.6+8e46c0036
-    worker-0   Ready    worker   8d    v1.14.6+8e46c0036
-    worker-1   Ready    worker   8d    v1.14.6+8e46c0036
+    NAME       STATUS   ROLES               AGE     VERSION
+    master-0   Ready    master,worker       4h19m   v1.17.1
+    master-1   Ready    master,worker       4h19m   v1.17.1
+    master-2   Ready    master,worker       4h19m   v1.17.1
+    worker-0   Ready    worker              4h3m    v1.17.1
+    worker-1   Ready    worker              4h4m    v1.17.1
+    worker-2   Ready    worker,worker-osp   76m     v1.17.1
 
-Label a worker node as compute
 
-    # oc label nodes worker-0 daemon=compute --overwrite
-    node/worker-0 labeled
+    oc get daemonset -n openstack
+    NAME                    DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR                         AGE
+    iscsid                  1         1         1       1            1           node-role.kubernetes.io/worker-osp=   88m
+    libvirtd                1         1         1       1            1           node-role.kubernetes.io/worker-osp=   12m
+    nova-compute            1         1         1       1            1           node-role.kubernetes.io/worker-osp=   12m
+    nova-migration-target   1         1         1       1            1           node-role.kubernetes.io/worker-osp=   12m
+    virtlogd                1         1         1       1            1           node-role.kubernetes.io/worker-osp=   12m
 
-    oc get daemonset
-    NAME                    DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR    AGE
-    iscsid                  1         1         1       1            1           daemon=compute   69m
-    libvirtd                1         1         1       1            1           daemon=compute   43m
-    neutron-ovsagent        1         1         1       1            1           daemon=compute   5d23h
-    nova-compute            1         1         1       1            1           daemon=compute   54m
-    nova-migration-target   1         1         1       1            1           daemon=compute   54m
-    virtlogd                1         1         1       1            1           daemon=compute   68m
-
-    oc get pods
+    oc get pods -n openstack
     NAME                                READY   STATUS    RESTARTS   AGE
-    iscsid-hq2h4                        1/1     Running   1          70m
+    iscsid-hq2h4                        1/1     Running   0          70m
     libvirtd-6wtsb                      1/1     Running   0          44m
-    nova-compute-dlxdx                  1/1     Running   1          54m
-    nova-migration-target-kt4vq         1/1     Running   1          54m
-    nova-operator-57465b7dbf-rqrfn      1/1     Running   1          45m
-    virtlogd-5cz7f                      1/1     Running   1          69m
+    nova-compute-dlxdx                  1/1     Running   0          54m
+    nova-migration-target-kt4vq         1/1     Running   0          54m
+    nova-operator-57465b7dbf-rqrfn      1/1     Running   0          45m
+    virtlogd-5cz7f                      1/1     Running   0          69m
 
-    oc get pods nova-compute-dlxdx -o yaml | grep nodeName
-      nodeName: worker-0
+    oc get pods -n openstack nova-compute-dlxdx -o yaml | grep nodeName
+      nodeName: worker-2
 
-Label 2nd worker node
-
-    oc label nodes worker-1 daemon=compute --overwrite
-    node/worker-1 labeled
-
-    oc get daemonset
-    NAME                    DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR    AGE
-    iscsid                  2         2         2       2            2           daemon=compute   69m
-    libvirtd                2         2         2       2            2           daemon=compute   43m
-    neutron-ovsagent        2         2         2       2            2           daemon=compute   5d23h
-    nova-compute            2         2         2       2            2           daemon=compute   54m
-    nova-migration-target   2         2         2       2            2           daemon=compute   54m
-    virtlogd                2         2         2       2            2           daemon=compute   68m
-
-    oc get pods
-    NAME                                READY   STATUS    RESTARTS   AGE
-    iscsid-hq2h4                        1/1     Running   1          70m
-    iscsid-ltqxl                        1/1     Running   1          66m
-    libvirtd-6wtsb                      1/1     Running   0          44m
-    libvirtd-ddrr2                      1/1     Running   0          44m
-    neutron-operator-855c5b58bf-vhxvn   1/1     Running   4          5d2h
-    neutron-ovsagent-hs4ck              1/1     Running   8          5d23h
-    neutron-ovsagent-tqrfl              1/1     Running   9          5d23h
-    nova-compute-dlxdx                  1/1     Running   1          54m
-    nova-compute-zcczn                  1/1     Running   1          54m
-    nova-migration-target-kt4vq         1/1     Running   1          54m
-    nova-migration-target-tb9xt         1/1     Running   1          54m
-    nova-operator-57465b7dbf-rqrfn      1/1     Running   1          45m
-    virtlogd-5cz7f                      1/1     Running   1          69m
-    virtlogd-mpm6g                      1/1     Running   1          69m
-
-    oc get pods -o custom-columns='NAME:metadata.name,NODE:spec.nodeName'
-    NAME                   NODE
-    nova-compute-dlxdx     worker-0
-    nova-compute-zcczn     worker-1
-    ...
+Now the compute number can be scaled up using the compute-node-operator CR!
 
 If need get into nova-compute container of daemonset via:
 
-    oc exec nova-compute-dr6j5 -i -t -- bash -il
+    oc rsh nova-compute-dlxdx
 
 ## POST steps to add compute workers to the cell
 
@@ -307,9 +275,7 @@ If need get into nova-compute container of daemonset via:
     +-----------+--------------------------------------+------------------------+
     | Cell Name |              Cell UUID               |        Hostname        |
     +-----------+--------------------------------------+------------------------+
-    |  default  | ba9981ae-1e79-4b20-a6ff-0416f986af3b | compute-0.redhat.local |
-    |  default  | ba9981ae-1e79-4b20-a6ff-0416f986af3b | compute-1.redhat.local |
-    |  default  | ba9981ae-1e79-4b20-a6ff-0416f986af3b |        worker-0        |
+    |  default  | ba9981ae-1e79-4b20-a6ff-0416f986af3b |        worker-2        |
     |  default  | ba9981ae-1e79-4b20-a6ff-0416f986af3b |        worker-1        |
     +-----------+--------------------------------------+------------------------+
 
@@ -325,10 +291,8 @@ If need get into nova-compute container of daemonset via:
     +-----------+-------------+---------------+---------------------------+----------------+----------------------------------------+
     | internal  | available   |               | controller-0.redhat.local | nova-conductor | enabled :-) 2020-01-20T13:54:35.000000 |
     | internal  | available   |               | controller-0.redhat.local | nova-scheduler | enabled :-) 2020-01-20T13:54:34.000000 |
-    | nova      | available   |               | compute-1.redhat.local    | nova-compute   | enabled :-) 2020-01-20T13:54:40.000000 |
-    | nova      | available   |               | compute-0.redhat.local    | nova-compute   | enabled :-) 2020-01-20T13:54:42.000000 |
-    | ocp       | available   |               | worker-0                  | nova-compute   | enabled :-) 2020-01-20T13:54:32.000000 |
-    | ocp       | available   |               | worker-1                  | nova-compute   | enabled :-) 2020-01-20T13:54:35.000000 |
+    | ocp       | available   |               | worker-2                  | nova-compute   | enabled :-) 2020-01-20T13:54:32.000000 |
+    | ocp       | available   |               | worker-1                  | nova-compute   | enabled :-) 2020-01-20T13:54:32.000000 |
     +-----------+-------------+---------------+---------------------------+----------------+----------------------------------------+
 
 #### Check nova compute service shows as up on the worker nodes
@@ -339,10 +303,8 @@ If need get into nova-compute container of daemonset via:
     +---------------------------+----------+-------+
     | controller-0.redhat.local | internal | up    |
     | controller-0.redhat.local | internal | up    |
-    | compute-0.redhat.local    | nova     | up    |
-    | compute-1.redhat.local    | nova     | up    |
-    | worker-0                  | ocp      | up    |
     | worker-1                  | ocp      | up    |
+    | worker-2                  | ocp      | up    |
     +---------------------------+----------+-------+
 
 ## Start an instance and verify network connectivity works
@@ -360,8 +322,8 @@ NOTE: selinux needs to be disabled on the compute worker nodes to start an insta
     +--------------------------------------+-------+--------+-------------+-----------------------+----------+
     | ID                                   | Name  | Status | Power State | Networks              | Host     |
     +--------------------------------------+-------+--------+-------------+-----------------------+----------+
-    | 55eb5cef-2580-48b8-a3ee-d27e96979fac | test2 | ACTIVE | Running     | private=192.168.0.58  | worker-0 |
-    | 516a6b9c-a88d-4718-96bc-83d4315249fc | test  | ACTIVE | Running     | private=192.168.0.117 | worker-1 |
+    | 55eb5cef-2580-48b8-a3ee-d27e96979fac | test2 | ACTIVE | Running     | private=192.168.0.58  | worker-1 |
+    | 516a6b9c-a88d-4718-96bc-83d4315249fc | test  | ACTIVE | Running     | private=192.168.0.117 | worker-2 |
     +--------------------------------------+-------+--------+-------------+-----------------------+----------+
 
 ### Check tenant network connectivity from inside the dhcp namespace 
@@ -414,22 +376,22 @@ Note: If it fails it might be that you need to apply OpenStack security rules!
 
 First delete all instances running on the OCP worker AZ
 
-    oc delete -f deploy/crds/nova_v1_novacompute_cr.yaml
-    oc delete -f deploy/crds/nova_v1_libvirtd_cr.yaml
-    oc delete -f deploy/crds/nova_v1_virtlogd_cr.yaml
-    oc delete -f deploy/crds/nova_v1_iscsid_cr.yaml
-    oc delete -f deploy/crds/nova_v1_novamigrationtarget_cr.yaml
+    oc delete -f deploy/crds/nova.openstack.org_virtlogd_cr.yaml
+    oc delete -f deploy/crds/nova.openstack.org_libvirtd_cr.yaml
+    oc delete -f deploy/crds/nova.openstack.org_iscsid_cr.yaml
+    oc delete -f deploy/crds/nova.openstack.org_novamigrationtarget_cr.yaml
+    oc delete -f deploy/crds/nova.openstack.org_novacompute_cr.yaml
     oc delete -f deploy/operator.yaml
     oc delete -f deploy/role.yaml
     oc delete -f deploy/role_binding.yaml
     oc delete -f deploy/service_account.yaml
     oc delete -f deploy/scc.yaml
     oc delete -f deploy/namespace.yaml
-    oc delete -f deploy/crds/nova_v1_novacompute_crd.yaml
-    oc delete -f deploy/crds/nova_v1_libvirtd_crd.yaml
-    oc delete -f deploy/crds/nova_v1_virtlogd_crd.yaml
-    oc delete -f deploy/crds/nova_v1_iscsid_crd.yaml
-    oc delete -f deploy/crds/nova_v1_novamigrationtarget_crd.yaml
+    oc delete -f deploy/crds/nova.openstack.org_libvirtds_crd.yaml
+    oc delete -f deploy/crds/nova.openstack.org_virtlogds_crd.yaml
+    oc delete -f deploy/crds/nova.openstack.org_novacomputes_crd.yaml
+    oc delete -f deploy/crds/nova.openstack.org_iscsids_crd.yaml
+    oc delete -f deploy/crds/nova.openstack.org_novamigrationtargets_crd.yaml
 
 ## Formatting
 

--- a/deploy/crds/nova.openstack.org_iscsid_cr.yaml
+++ b/deploy/crds/nova.openstack.org_iscsid_cr.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: openstack
 spec:
   iscsidImage: docker.io/tripleotrain/rhel-binary-iscsid:current-tripleo
-  label: compute
   serviceAccount: nova-operator
+  roleName: worker-osp

--- a/deploy/crds/nova.openstack.org_iscsids_crd.yaml
+++ b/deploy/crds/nova.openstack.org_iscsids_crd.yaml
@@ -1,58 +1,65 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: virtlogds.nova.openstack.org
+  name: iscsids.nova.openstack.org
 spec:
   group: nova.openstack.org
   names:
-    kind: Virtlogd
-    listKind: VirtlogdList
-    plural: virtlogds
-    singular: virtlogd
+    kind: Iscsid
+    listKind: IscsidList
+    plural: iscsids
+    singular: iscsid
   scope: Namespaced
   subresources:
     status: {}
   validation:
     openAPIV3Schema:
+      description: Iscsid is the Schema for the iscsids API
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
         spec:
+          description: IscsidSpec defines the desired state of Iscsid
           properties:
-            label:
-              description: Label is the value of the 'daemon=' label to set on a node
-                that should run the daemon
-              type: string
-            novaLibvirtImage:
+            iscsidImage:
               description: Image is the Docker image to run for the daemon
+              type: string
+            roleName:
+              description: Name of the worker role created for OSP computes
               type: string
             serviceAccount:
               description: service account used to create pods
               type: string
           required:
-          - label
-          - novaLibvirtImage
+          - iscsidImage
+          - roleName
           - serviceAccount
           type: object
         status:
+          description: IscsidStatus defines the observed state of Iscsid
           properties:
             count:
               description: Count is the number of nodes the daemon is deployed to
               format: int32
               type: integer
+            daemonsetHash:
+              description: Daemonset hash used to detect changes
+              type: string
           required:
           - count
+          - daemonsetHash
           type: object
+      type: object
   version: v1
   versions:
   - name: v1

--- a/deploy/crds/nova.openstack.org_libvirtd_cr.yaml
+++ b/deploy/crds/nova.openstack.org_libvirtd_cr.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: openstack
 spec:
   novaLibvirtImage: quay.io/openstack-k8s-operators/nova-libvirt:latest
-  label: compute
   serviceAccount: nova-operator
+  roleName: worker-osp

--- a/deploy/crds/nova.openstack.org_libvirtds_crd.yaml
+++ b/deploy/crds/nova.openstack.org_libvirtds_crd.yaml
@@ -1,50 +1,52 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: iscsids.nova.openstack.org
+  name: libvirtds.nova.openstack.org
 spec:
   group: nova.openstack.org
   names:
-    kind: Iscsid
-    listKind: IscsidList
-    plural: iscsids
-    singular: iscsid
+    kind: Libvirtd
+    listKind: LibvirtdList
+    plural: libvirtds
+    singular: libvirtd
   scope: Namespaced
   subresources:
     status: {}
   validation:
     openAPIV3Schema:
+      description: Libvirtd is the Schema for the libvirtds API
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
         spec:
+          description: LibvirtdSpec defines the desired state of Libvirtd
           properties:
-            iscsidImage:
+            novaLibvirtImage:
               description: Image is the Docker image to run for the daemon
               type: string
-            label:
-              description: Label is the value of the 'daemon=' label to set on a node
-                that should run the daemon
+            roleName:
+              description: Name of the worker role created for OSP computes
               type: string
             serviceAccount:
               description: service account used to create pods
               type: string
           required:
-          - label
-          - iscsidImage
+          - novaLibvirtImage
+          - roleName
           - serviceAccount
           type: object
         status:
+          description: LibvirtdStatus defines the observed state of Libvirtd
           properties:
             count:
               description: Count is the number of nodes the daemon is deployed to
@@ -57,6 +59,7 @@ spec:
           - count
           - daemonsetHash
           type: object
+      type: object
   version: v1
   versions:
   - name: v1

--- a/deploy/crds/nova.openstack.org_novacompute_cr.yaml
+++ b/deploy/crds/nova.openstack.org_novacompute_cr.yaml
@@ -20,5 +20,5 @@ spec:
   novaComputeCPUSharedSet: 0-3
 
   novaComputeImage: docker.io/tripleotrain/rhel-binary-nova-compute:current-tripleo
-  label: compute
   serviceAccount: nova-operator
+  roleName: worker-osp

--- a/deploy/crds/nova.openstack.org_novacomputes_crd.yaml
+++ b/deploy/crds/nova.openstack.org_novacomputes_crd.yaml
@@ -14,30 +14,28 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
+      description: NovaCompute is the Schema for the novacomputes API
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
         spec:
+          description: NovaComputeSpec defines the desired state of NovaCompute
           properties:
             cinderPassword:
               description: Cinder API Admin Password
               type: string
             internalAPIVip:
               description: Control Plane InternalAPI VIP String
-              type: string
-            label:
-              description: Label is the value of the 'daemon=' label to set on a node
-                that should run the daemon
               type: string
             memcacheServers:
               description: Memcache Servers String
@@ -70,22 +68,26 @@ spec:
             rabbitTransportURL:
               description: RabbitMQ transport URL String
               type: string
+            roleName:
+              description: Name of the worker role created for OSP computes
+              type: string
             serviceAccount:
               description: service account used to create pods
               type: string
           required:
-          - label
-          - novaComputeImage
-          - publicVip
-          - internalAPIVip
-          - rabbitTransportURL
           - cinderPassword
-          - novaPassword
+          - internalAPIVip
           - neutronPassword
+          - novaComputeImage
+          - novaPassword
           - placementPassword
+          - publicVip
+          - rabbitTransportURL
+          - roleName
           - serviceAccount
           type: object
         status:
+          description: NovaComputeStatus defines the observed state of NovaCompute
           properties:
             count:
               description: Count is the number of nodes the daemon is deployed to
@@ -98,6 +100,7 @@ spec:
           - count
           - daemonsetHash
           type: object
+      type: object
   version: v1
   versions:
   - name: v1

--- a/deploy/crds/nova.openstack.org_novamigrationtarget_cr.yaml
+++ b/deploy/crds/nova.openstack.org_novamigrationtarget_cr.yaml
@@ -7,5 +7,5 @@ spec:
   sshdPort: 2022
 
   novaComputeImage: docker.io/tripleotrain/rhel-binary-nova-compute:current-tripleo
-  label: compute
   serviceAccount: nova-operator
+  roleName: worker-osp

--- a/deploy/crds/nova.openstack.org_novamigrationtargets_crd.yaml
+++ b/deploy/crds/nova.openstack.org_novamigrationtargets_crd.yaml
@@ -1,50 +1,58 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: libvirtds.nova.openstack.org
+  name: novamigrationtargets.nova.openstack.org
 spec:
   group: nova.openstack.org
   names:
-    kind: Libvirtd
-    listKind: LibvirtdList
-    plural: libvirtds
-    singular: libvirtd
+    kind: NovaMigrationTarget
+    listKind: NovaMigrationTargetList
+    plural: novamigrationtargets
+    singular: novamigrationtarget
   scope: Namespaced
   subresources:
     status: {}
   validation:
     openAPIV3Schema:
+      description: NovaMigrationTarget is the Schema for the novamigrationtargets
+        API
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
         spec:
+          description: NovaMigrationTargetSpec defines the desired state of NovaMigrationTarget
           properties:
-            label:
-              description: Label is the value of the 'daemon=' label to set on a node
-                that should run the daemon
+            novaComputeImage:
+              description: container image to run for the daemon
               type: string
-            novaLibvirtImage:
-              description: Image is the Docker image to run for the daemon
+            roleName:
+              description: Name of the worker role created for OSP computes
               type: string
             serviceAccount:
               description: service account used to create pods
               type: string
+            sshdPort:
+              description: SSHD port
+              format: int32
+              type: integer
           required:
-          - label
-          - novaLibvirtImage
+          - novaComputeImage
+          - roleName
           - serviceAccount
+          - sshdPort
           type: object
         status:
+          description: NovaMigrationTargetStatus defines the observed state of NovaMigrationTarget
           properties:
             count:
               description: Count is the number of nodes the daemon is deployed to
@@ -57,6 +65,7 @@ spec:
           - count
           - daemonsetHash
           type: object
+      type: object
   version: v1
   versions:
   - name: v1

--- a/deploy/crds/nova.openstack.org_virtlogd_cr.yaml
+++ b/deploy/crds/nova.openstack.org_virtlogd_cr.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: openstack
 spec:
   novaLibvirtImage: quay.io/openstack-k8s-operators/nova-libvirt:latest
-  label: compute
   serviceAccount: nova-operator
+  roleName: worker-osp

--- a/deploy/crds/nova.openstack.org_virtlogds_crd.yaml
+++ b/deploy/crds/nova.openstack.org_virtlogds_crd.yaml
@@ -1,67 +1,61 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: novamigrationtargets.nova.openstack.org
+  name: virtlogds.nova.openstack.org
 spec:
   group: nova.openstack.org
   names:
-    kind: NovaMigrationTarget
-    listKind: NovaMigrationTargetList
-    plural: novamigrationtargets
-    singular: novamigrationtarget
+    kind: Virtlogd
+    listKind: VirtlogdList
+    plural: virtlogds
+    singular: virtlogd
   scope: Namespaced
   subresources:
     status: {}
   validation:
     openAPIV3Schema:
+      description: Virtlogd is the Schema for the virtlogds API
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
         spec:
+          description: VirtlogdSpec defines the desired state of Virtlogd
           properties:
-            label:
-              description: Label is the value of the 'daemon=' label to set on a node
-                that should run the daemon
+            novaLibvirtImage:
+              description: Image is the Docker image to run for the daemon
               type: string
-            novaComputeImage:
-              description: container image to run for the daemon
+            roleName:
+              description: Name of the worker role created for OSP computes
               type: string
             serviceAccount:
               description: service account used to create pods
               type: string
-            sshdPort:
-              description: SSHD port
-              format: int32
-              type: integer
           required:
-          - label
-          - novaComputeImage
-          - sshdPort
+          - novaLibvirtImage
+          - roleName
           - serviceAccount
           type: object
         status:
+          description: VirtlogdStatus defines the observed state of Virtlogd
           properties:
             count:
               description: Count is the number of nodes the daemon is deployed to
               format: int32
               type: integer
-            daemonsetHash:
-              description: Daemonset hash used to detect changes
-              type: string
           required:
           - count
-          - daemonsetHash
           type: object
+      type: object
   version: v1
   versions:
   - name: v1

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,6 @@ require (
 	github.com/openstack-k8s-operators/lib-common v0.0.0-20200506095056-36244492b7a8
 	github.com/operator-framework/operator-sdk v0.17.0
 	github.com/spf13/pflag v1.0.5
-	golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975
-	golang.org/x/tools v0.0.0-20200504022951-6b6965ac5dd1 // indirect
 	k8s.io/api v0.17.4
 	k8s.io/apimachinery v0.17.4
 	k8s.io/client-go v12.0.0+incompatible

--- a/pkg/apis/nova/v1/iscsid_types.go
+++ b/pkg/apis/nova/v1/iscsid_types.go
@@ -9,12 +9,12 @@ import (
 // IscsidSpec defines the desired state of Iscsid
 // +k8s:openapi-gen=true
 type IscsidSpec struct {
-	// Label is the value of the 'daemon=' label to set on a node that should run the daemon
-	Label string `json:"label"`
 	// Image is the Docker image to run for the daemon
 	IscsidImage string `json:"iscsidImage"`
 	// service account used to create pods
 	ServiceAccount string `json:"serviceAccount"`
+        // Name of the worker role created for OSP computes
+        RoleName string `json:"roleName"`
 }
 
 // IscsidStatus defines the observed state of Iscsid

--- a/pkg/apis/nova/v1/libvirtd_types.go
+++ b/pkg/apis/nova/v1/libvirtd_types.go
@@ -7,14 +7,12 @@ import (
 // LibvirtdSpec defines the desired state of Libvirtd
 // +k8s:openapi-gen=true
 type LibvirtdSpec struct {
-	// Label is the value of the 'daemon=' label to set on a node that should run the daemon
-	Label string `json:"label"`
-
 	// Image is the Docker image to run for the daemon
 	NovaLibvirtImage string `json:"novaLibvirtImage"`
-
 	// service account used to create pods
 	ServiceAccount string `json:"serviceAccount"`
+        // Name of the worker role created for OSP computes
+        RoleName string `json:"roleName"`
 }
 
 // LibvirtdStatus defines the observed state of Libvirtd

--- a/pkg/apis/nova/v1/novacompute_types.go
+++ b/pkg/apis/nova/v1/novacompute_types.go
@@ -7,8 +7,6 @@ import (
 // NovaComputeSpec defines the desired state of NovaCompute
 // +k8s:openapi-gen=true
 type NovaComputeSpec struct {
-	// Label is the value of the 'daemon=' label to set on a node that should run the daemon
-	Label string `json:"label"`
 	// container image to run for the daemon
 	NovaComputeImage string `json:"novaComputeImage"`
 	// Control Plane public VIP String
@@ -37,6 +35,8 @@ type NovaComputeSpec struct {
 	PlacementPassword string `json:"placementPassword"`
 	// service account used to create pods
 	ServiceAccount string `json:"serviceAccount"`
+        // Name of the worker role created for OSP computes
+        RoleName string `json:"roleName"`
 }
 
 // NovaComputeStatus defines the observed state of NovaCompute

--- a/pkg/apis/nova/v1/novamigrationtarget_types.go
+++ b/pkg/apis/nova/v1/novamigrationtarget_types.go
@@ -7,14 +7,14 @@ import (
 // NovaMigrationTargetSpec defines the desired state of NovaMigrationTarget
 // +k8s:openapi-gen=true
 type NovaMigrationTargetSpec struct {
-	// Label is the value of the 'daemon=' label to set on a node that should run the daemon
-	Label string `json:"label"`
 	// container image to run for the daemon
 	NovaComputeImage string `json:"novaComputeImage"`
 	// SSHD port
 	SshdPort int32 `json:"sshdPort"`
 	// service account used to create pods
 	ServiceAccount string `json:"serviceAccount"`
+        // Name of the worker role created for OSP computes
+        RoleName string `json:"roleName"`
 }
 
 // NovaMigrationTargetStatus defines the observed state of NovaMigrationTarget

--- a/pkg/apis/nova/v1/virtlogd_types.go
+++ b/pkg/apis/nova/v1/virtlogd_types.go
@@ -7,14 +7,12 @@ import (
 // VirtlogdSpec defines the desired state of Virtlogd
 // +k8s:openapi-gen=true
 type VirtlogdSpec struct {
-	// Label is the value of the 'daemon=' label to set on a node that should run the daemon
-	Label string `json:"label"`
-
 	// Image is the Docker image to run for the daemon
 	NovaLibvirtImage string `json:"novaLibvirtImage"`
-
 	// service account used to create pods
 	ServiceAccount string `json:"serviceAccount"`
+        // Name of the worker role created for OSP computes
+        RoleName string `json:"roleName"`
 }
 
 // VirtlogdStatus defines the observed state of Virtlogd

--- a/pkg/common/compute_nodeselector.go
+++ b/pkg/common/compute_nodeselector.go
@@ -1,0 +1,9 @@
+package common
+
+// GetComputeWorkerNodeSelector - returns the NodeSelector for all compute worker DS
+func GetComputeWorkerNodeSelector(roleName string) map[string]string {
+
+	// Change nodeSelector
+	nodeSelector := "node-role.kubernetes.io/" + roleName
+	return map[string]string{nodeSelector: ""}
+}

--- a/pkg/common/compute_tolarations.go
+++ b/pkg/common/compute_tolarations.go
@@ -1,0 +1,19 @@
+package common
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// GetComputeWorkerTolerations - common Volumes used by many service pods
+func GetComputeWorkerTolerations(roleName string) []corev1.Toleration {
+
+	return []corev1.Toleration{
+		// Add toleration
+		{
+			Operator: "Equal",
+			Effect:   "NoSchedule",
+			Key:      "dedicated",
+			Value:    roleName,
+		},
+	}
+}

--- a/pkg/controller/iscsid/iscsid_controller.go
+++ b/pkg/controller/iscsid/iscsid_controller.go
@@ -219,7 +219,7 @@ func newDaemonset(cr *novav1.Iscsid, cmName string, templatesConfigHash string) 
 					Labels: map[string]string{"daemonset": cr.Name + "-daemonset"},
 				},
 				Spec: corev1.PodSpec{
-					NodeSelector:       map[string]string{"daemon": cr.Spec.Label},
+					NodeSelector:       common.GetComputeWorkerNodeSelector(cr.Spec.RoleName),
 					HostNetwork:        true,
 					HostPID:            true,
 					DNSPolicy:          "ClusterFirstWithHostNet",
@@ -231,10 +231,10 @@ func newDaemonset(cr *novav1.Iscsid, cmName string, templatesConfigHash string) 
 		},
 	}
 
-	tolerationSpec := corev1.Toleration{
-		Operator: "Exists",
+	// add compute worker nodes tolerations
+	for _, toleration := range common.GetComputeWorkerTolerations(cr.Spec.RoleName) {
+		daemonSet.Spec.Template.Spec.Tolerations = append(daemonSet.Spec.Template.Spec.Tolerations, toleration)
 	}
-	daemonSet.Spec.Template.Spec.Tolerations = append(daemonSet.Spec.Template.Spec.Tolerations, tolerationSpec)
 
 	containerSpec := corev1.Container{
 		Name:  "iscsid",

--- a/pkg/controller/libvirtd/libvirtd_controller.go
+++ b/pkg/controller/libvirtd/libvirtd_controller.go
@@ -262,7 +262,7 @@ func newDaemonset(cr *novav1.Libvirtd, cmName string, templatesConfigHash string
 					Labels: map[string]string{"daemonset": cr.Name + "-daemonset"},
 				},
 				Spec: corev1.PodSpec{
-					NodeSelector:       map[string]string{"daemon": cr.Spec.Label},
+					NodeSelector:       common.GetComputeWorkerNodeSelector(cr.Spec.RoleName),
 					HostNetwork:        true,
 					HostPID:            true,
 					DNSPolicy:          "ClusterFirstWithHostNet",
@@ -275,10 +275,10 @@ func newDaemonset(cr *novav1.Libvirtd, cmName string, templatesConfigHash string
 		},
 	}
 
-	tolerationSpec := corev1.Toleration{
-		Operator: "Exists",
+	// add compute worker nodes tolerations
+	for _, toleration := range common.GetComputeWorkerTolerations(cr.Spec.RoleName) {
+		daemonSet.Spec.Template.Spec.Tolerations = append(daemonSet.Spec.Template.Spec.Tolerations, toleration)
 	}
-	daemonSet.Spec.Template.Spec.Tolerations = append(daemonSet.Spec.Template.Spec.Tolerations, tolerationSpec)
 
 	containerSpec := corev1.Container{
 		Name:  "libvirtd",

--- a/pkg/controller/novacompute/novacompute_controller.go
+++ b/pkg/controller/novacompute/novacompute_controller.go
@@ -288,7 +288,7 @@ func newDaemonset(cr *novav1.NovaCompute, cmName string, templatesConfigHash str
 					Labels: map[string]string{"daemonset": cr.Name + "-daemonset"},
 				},
 				Spec: corev1.PodSpec{
-					NodeSelector:       map[string]string{"daemon": cr.Spec.Label},
+					NodeSelector:       common.GetComputeWorkerNodeSelector(cr.Spec.RoleName),
 					HostNetwork:        true,
 					HostPID:            true,
 					DNSPolicy:          "ClusterFirstWithHostNet",
@@ -302,10 +302,10 @@ func newDaemonset(cr *novav1.NovaCompute, cmName string, templatesConfigHash str
 		},
 	}
 
-	tolerationSpec := corev1.Toleration{
-		Operator: "Exists",
+	// add compute worker nodes tolerations
+	for _, toleration := range common.GetComputeWorkerTolerations(cr.Spec.RoleName) {
+		daemonSet.Spec.Template.Spec.Tolerations = append(daemonSet.Spec.Template.Spec.Tolerations, toleration)
 	}
-	daemonSet.Spec.Template.Spec.Tolerations = append(daemonSet.Spec.Template.Spec.Tolerations, tolerationSpec)
 
 	// Add hosts entries rendered from the the config map to the hosts file of the containers in the pod
 	// TODO:

--- a/pkg/controller/novamigrationtarget/novamigrationtarget_controller.go
+++ b/pkg/controller/novamigrationtarget/novamigrationtarget_controller.go
@@ -315,7 +315,7 @@ func newDaemonset(cr *novav1.NovaMigrationTarget, cmName string, templatesConfig
 					Labels: map[string]string{"daemonset": cr.Name + "-daemonset"},
 				},
 				Spec: corev1.PodSpec{
-					NodeSelector:       map[string]string{"daemon": cr.Spec.Label},
+					NodeSelector:       common.GetComputeWorkerNodeSelector(cr.Spec.RoleName),
 					HostNetwork:        true,
 					HostPID:            true,
 					DNSPolicy:          "ClusterFirstWithHostNet",
@@ -329,10 +329,10 @@ func newDaemonset(cr *novav1.NovaMigrationTarget, cmName string, templatesConfig
 		},
 	}
 
-	tolerationSpec := corev1.Toleration{
-		Operator: "Exists",
+	// add compute worker nodes tolerations
+	for _, toleration := range common.GetComputeWorkerTolerations(cr.Spec.RoleName) {
+		daemonSet.Spec.Template.Spec.Tolerations = append(daemonSet.Spec.Template.Spec.Tolerations, toleration)
 	}
-	daemonSet.Spec.Template.Spec.Tolerations = append(daemonSet.Spec.Template.Spec.Tolerations, tolerationSpec)
 
 	initContainerSpec := corev1.Container{
 		Name:  "init",

--- a/pkg/controller/virtlogd/virtlogd_controller.go
+++ b/pkg/controller/virtlogd/virtlogd_controller.go
@@ -205,7 +205,7 @@ func newDaemonset(cr *novav1.Virtlogd, cmName string, templatesConfigHash string
 					Labels: map[string]string{"daemonset": cr.Name + "-daemonset"},
 				},
 				Spec: corev1.PodSpec{
-					NodeSelector:       map[string]string{"daemon": cr.Spec.Label},
+					NodeSelector:       common.GetComputeWorkerNodeSelector(cr.Spec.RoleName),
 					HostNetwork:        true,
 					HostPID:            true,
 					DNSPolicy:          "ClusterFirstWithHostNet",
@@ -218,10 +218,10 @@ func newDaemonset(cr *novav1.Virtlogd, cmName string, templatesConfigHash string
 		},
 	}
 
-	tolerationSpec := corev1.Toleration{
-		Operator: "Exists",
+	// add compute worker nodes tolerations
+	for _, toleration := range common.GetComputeWorkerTolerations(cr.Spec.RoleName) {
+		daemonSet.Spec.Template.Spec.Tolerations = append(daemonSet.Spec.Template.Spec.Tolerations, toleration)
 	}
-	daemonSet.Spec.Template.Spec.Tolerations = append(daemonSet.Spec.Template.Spec.Tolerations, tolerationSpec)
 
 	containerSpec := corev1.Container{
 		Name:  "virtlogd",

--- a/test/crd_validation_test.go
+++ b/test/crd_validation_test.go
@@ -19,11 +19,11 @@ import (
 func TestSampleCustomResources(t *testing.T) {
 	root := "./../deploy/crds"
 	crdCrMap := map[string]string{
-		"nova_v1_iscsid_crd.yaml":              "nova_v1_iscsid_cr",
-		"nova_v1_libvirtd_crd.yaml":            "nova_v1_libvirtd_cr",
-		"nova_v1_novacompute_crd.yaml":         "nova_v1_novacompute_cr",
-		"nova_v1_novamigrationtarget_crd.yaml": "nova_v1_novamigrationtarget_cr",
-		"nova_v1_virtlogd_crd.yaml":            "nova_v1_virtlogd_cr",
+		"nova.openstack.org_iscsids_crd.yaml":              "nova.openstack.org_iscsid_cr",
+		"nova.openstack.org_libvirtds_crd.yaml":            "nova.openstack.org_libvirtd_cr",
+		"nova.openstack.org_novacomputes_crd.yaml":         "nova.openstack.org_novacompute_cr",
+		"nova.openstack.org_novamigrationtargets_crd.yaml": "nova.openstack.org_novamigrationtarget_cr",
+		"nova.openstack.org_virtlogds_crd.yaml":            "nova.openstack.org_virtlogd_cr",
 	}
 	for crd, prefix := range crdCrMap {
 		validateCustomResources(t, root, crd, prefix)
@@ -54,11 +54,11 @@ func validateCustomResources(t *testing.T, root string, crd string, prefix strin
 func TestCompleteCRD(t *testing.T) {
 	root := "./../deploy/crds"
 	crdStructMap := map[string]interface{}{
-		"nova_v1_iscsid_crd.yaml":              &v1.Iscsid{},
-		"nova_v1_libvirtd_crd.yaml":            &v1.Libvirtd{},
-		"nova_v1_novacompute_crd.yaml":         &v1.NovaCompute{},
-		"nova_v1_novamigrationtarget_crd.yaml": &v1.NovaMigrationTarget{},
-		"nova_v1_virtlogd_crd.yaml":            &v1.Virtlogd{},
+		"nova.openstack.org_iscsids_crd.yaml":              &v1.Iscsid{},
+		"nova.openstack.org_libvirtds_crd.yaml":            &v1.Libvirtd{},
+		"nova.openstack.org_novacomputes_crd.yaml":         &v1.NovaCompute{},
+		"nova.openstack.org_novamigrationtargets_crd.yaml": &v1.NovaMigrationTarget{},
+		"nova.openstack.org_virtlogds_crd.yaml":            &v1.Virtlogd{},
 	}
 	for crd, obj := range crdStructMap {
 		schema := getSchema(t, fmt.Sprintf("%s/%s", root, crd))


### PR DESCRIPTION
The compute-node-operator adds the followng label/taints to the osp
worker node

* label
node-role.kubernetes.io/<roleName>: ""

* taints
  - effect: NoSchedule
    key: dedicated
    value: <roleName>

This patch
* adds the roleName as parameter to the CRDs for the compute
services and modifies the nodeSelector/tolerations to match this. All
controllers use common fuctions for both that if things change/get added
can be done from one place to all compute controllers.
* removes the former used label parameter from the CRDs
* updates the README.md

Also:
* With SDK 0.17 the CR and CRD file name format changed. This moves
the files to have the correct format.
* removes two entries from go.mod as they are not required with the
move to ssh lib to lib-common.