### PR TITLE
Align scc perms in deploy/role.yaml

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -77,3 +77,12 @@ rules:
   - securitycontextconstraints
   verbs:
   - use
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - list
+  - get
+  - watch
+  - create


### PR DESCRIPTION
This aligns the SCC permissions in deploy/role.yaml with
what we do for OLM in the csv-generator.

Need to discuss a better way to keep these aligned, possibly with
either shared generators or testing.