### PR TITLE
Fix role to allow set finalizer

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -10,6 +10,7 @@ rules:
   resources:
   - pods
   - services
+  - services/finalizers
   - endpoints
   - persistentvolumeclaims
   - events

--- a/tools/csv-generator.go
+++ b/tools/csv-generator.go
@@ -246,6 +246,7 @@ func getOperatorRules() *[]rbacv1.PolicyRule {
 			Resources: []string{
 				"pods",
 				"services",
+				"services/finalizers",
 				"endpoints",
 				"persistentvolumeclaims",
 				"events",


### PR DESCRIPTION
This fix the issue where the ServiceMonitor object create on
operator start fails with:

`{"level":"info","ts":1592920265.5644455,"logger":"cmd","msg":"Could not create ServiceMonitor object","error":"servicemonitors.monitoring.coreos.com \"nova-operator-metrics\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>"}`