### PR TITLE
Only parse line 1 output of 'ip get route'

### DIFF
--- a/templates/common/common.sh
+++ b/templates/common/common.sh
@@ -21,7 +21,7 @@ function get_ip_address_from_network {
   # for now we expect that controller-0 is always there and has this hostname
   # format
   local controller_ip=$(getent -s hosts:files hosts controller-0.${network} | awk '{print $1}')
-  local ip=$(ip route get ${controller_ip} | awk '{print $5}')
+  local ip=$(ip route get ${controller_ip} | head -1 | awk '{print $5}')
   if [ -z "${ip}" ] ; then
     exit
   fi


### PR DESCRIPTION
This is needed because sometimes the `ip route get` command returns more than one line of output.  For instance, in environment it gives this:

```
[core@nfv-worker-0 ~]$ ip route get 172.17.0.175               
172.17.0.175 dev internalapi src 172.17.0.100 uid 1000                                                                                                                                                                                                
    cache expires 399sec mtu 1500
```

Which results in `1500` polluting the configuration fed to the containers.