### PR TITLE
Use different accounts to run nova-operator and OSP service pods

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -152,9 +152,9 @@ func main() {
 	addMetrics(ctx, cfg)
 
 	log.Info("Creating SCC for nova-operator.")
-	err = ensureSCCExists(mgr.GetClient(), namespace, "nova-operator")
+	err = ensureSCCExists(mgr.GetClient(), namespace, "nova")
 	if err != nil {
-		log.Error(err, "Failed to create SCC for nova-operator.")
+		log.Error(err, "Failed to create SCC for nova.")
 		os.Exit(1)
 	}
 
@@ -238,7 +238,7 @@ func serveCRMetrics(cfg *rest.Config, operatorNs string) error {
 	return nil
 }
 
-const sccName = "nova-operator"
+const sccName = "nova"
 
 // EnsureSCCExists ensures the security context constraint for nova-operator exists
 func ensureSCCExists(c client.Client, saNamespace, saName string) error {

--- a/deploy/crds/nova.openstack.org_iscsid_cr.yaml
+++ b/deploy/crds/nova.openstack.org_iscsid_cr.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: openstack
 spec:
   iscsidImage: docker.io/tripleotrain/rhel-binary-iscsid:current-tripleo
-  serviceAccount: nova-operator
+  serviceAccount: nova
   roleName: worker-osp

--- a/deploy/crds/nova.openstack.org_libvirtd_cr.yaml
+++ b/deploy/crds/nova.openstack.org_libvirtd_cr.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: openstack
 spec:
   novaLibvirtImage: quay.io/openstack-k8s-operators/nova-libvirt:latest
-  serviceAccount: nova-operator
+  serviceAccount: nova
   roleName: worker-osp

--- a/deploy/crds/nova.openstack.org_novacompute_cr.yaml
+++ b/deploy/crds/nova.openstack.org_novacompute_cr.yaml
@@ -10,5 +10,5 @@ spec:
   novaComputeCPUSharedSet: 0-3
 
   novaComputeImage: docker.io/tripleotrain/rhel-binary-nova-compute:current-tripleo
-  serviceAccount: nova-operator
+  serviceAccount: nova
   roleName: worker-osp

--- a/deploy/crds/nova.openstack.org_novamigrationtarget_cr.yaml
+++ b/deploy/crds/nova.openstack.org_novamigrationtarget_cr.yaml
@@ -8,5 +8,5 @@ spec:
   sshdPort: 2022
 
   novaComputeImage: docker.io/tripleotrain/rhel-binary-nova-compute:current-tripleo
-  serviceAccount: nova-operator
+  serviceAccount: nova
   roleName: worker-osp

--- a/deploy/crds/nova.openstack.org_virtlogd_cr.yaml
+++ b/deploy/crds/nova.openstack.org_virtlogd_cr.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: openstack
 spec:
   novaLibvirtImage: quay.io/openstack-k8s-operators/nova-libvirt:latest
-  serviceAccount: nova-operator
+  serviceAccount: nova
   roleName: worker-osp

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -78,3 +78,23 @@ rules:
   - securitycontextconstraints
   verbs:
   - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: nova
+  namespace: openstack
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -10,3 +10,16 @@ roleRef:
   kind: Role
   name: nova-operator
   apiGroup: rbac.authorization.k8s.io
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: nova
+  namespace: openstack
+subjects:
+- kind: ServiceAccount
+  name: nova
+roleRef:
+  kind: Role
+  name: nova
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/scc.yaml
+++ b/deploy/scc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: SecurityContextConstraints
 metadata:
-  name: nova-operator
+  name: nova
 allowPrivilegedContainer: true
 allowPrivilegeEscalation: true
 allowHostDirVolumePlugin: true
@@ -28,7 +28,7 @@ seccompProfiles:
 supplementalGroups:
   type: RunAsAny
 users:
-- system:serviceaccount:openstack:nova-operator
+- system:serviceaccount:openstack:nova
 groups: []
 volumes:
 - '*'

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -3,3 +3,9 @@ kind: ServiceAccount
 metadata:
   name: nova-operator
   namespace: openstack
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nova
+  namespace: openstack

--- a/go.sum
+++ b/go.sum
@@ -1236,7 +1236,6 @@ k8s.io/apimachinery v0.17.2/go.mod h1:b9qmWdKlLuU9EBh+06BtLcSf/Mu89rWL33naRxs1uZ
 k8s.io/apimachinery v0.17.3/go.mod h1:gxLnyZcGNdZTCLnq3fgzyg2A5BVCHTNDFrw8AmuJ+0g=
 k8s.io/apimachinery v0.17.4 h1:UzM+38cPUJnzqSQ+E1PY4YxMHIzQyCg29LOoGfo79Zw=
 k8s.io/apimachinery v0.17.4/go.mod h1:gxLnyZcGNdZTCLnq3fgzyg2A5BVCHTNDFrw8AmuJ+0g=
-k8s.io/apimachinery v0.18.3 h1:pOGcbVAhxADgUYnjS08EFXs9QMl8qaH5U4fr5LGUrSk=
 k8s.io/apiserver v0.0.0-20190918160949-bfa5e2e684ad/go.mod h1:XPCXEwhjaFN29a8NldXA901ElnKeKLrLtREO9ZhFyhg=
 k8s.io/apiserver v0.16.7/go.mod h1:/5zSatF30/L9zYfMTl55jzzOnx7r/gGv5a5wtRp8yAw=
 k8s.io/apiserver v0.17.0/go.mod h1:ABM+9x/prjINN6iiffRVNCBR2Wk7uY4z+EtEGZD48cg=

--- a/tools/csv-generator.go
+++ b/tools/csv-generator.go
@@ -88,6 +88,7 @@ Install and configure OpenStack Nova containers.
 
 	clusterRules := getOperatorClusterRules()
 	rules := getOperatorRules()
+	serviceRules := getServiceRules()
 
 	strategySpec := csvv1.StrategyDetailsDeployment{
 		ClusterPermissions: []csvv1.StrategyDeploymentPermissions{
@@ -100,6 +101,10 @@ Install and configure OpenStack Nova containers.
 			{
 				ServiceAccountName: "nova-operator",
 				Rules:              *rules,
+			},
+			{
+				ServiceAccountName: "nova",
+				Rules:              *serviceRules,
 			},
 		},
 		DeploymentSpecs: []csvv1.StrategyDeploymentSpec{
@@ -322,6 +327,22 @@ func getOperatorRules() *[]rbacv1.PolicyRule {
 				"libvirtds",
 				"iscsids",
 				"novamigrationtargets",
+			},
+			Verbs: []string{
+				"*",
+			},
+		},
+	}
+}
+
+func getServiceRules() *[]rbacv1.PolicyRule {
+	return &[]rbacv1.PolicyRule{
+		{
+			APIGroups: []string{
+				"",
+			},
+			Resources: []string{
+				"pods",
 			},
 			Verbs: []string{
 				"*",


### PR DESCRIPTION
This changes to run the OSP service pods using nova
serviceAccount.