### PR TITLE
Allow nova-operator to use nova scc to validate spec

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -73,7 +73,7 @@ rules:
 - apiGroups:
   - security.openshift.io
   resourceNames:
-  - nova-operator
+  - nova
   resources:
   - securitycontextconstraints
   verbs:

--- a/tools/csv-generator.go
+++ b/tools/csv-generator.go
@@ -463,7 +463,7 @@ func getOperatorClusterRules() *[]rbacv1.PolicyRule {
 				"deployments/finalizers",
 			},
 			ResourceNames: []string{
-				"nova-operator",
+				"nova",
 			},
 			Verbs: []string{
 				"update",
@@ -493,11 +493,10 @@ func getOperatorClusterRules() *[]rbacv1.PolicyRule {
 				"securitycontextconstraints",
 			},
 			ResourceNames: []string{
-				"nova-operator",
+				"nova",
 			},
 			Verbs: []string{
-				"delete",
-				"update",
+				"use",
 			},
 		},
 		{


### PR DESCRIPTION
The nova-operator sa creates the daemonset and requires to be
allowed to use the nova scc to validate the schema.