### PR TITLE
[WIP] enable selinux in libvirtd pod

### DIFF
--- a/pkg/controller/libvirtd/libvirtd_controller.go
+++ b/pkg/controller/libvirtd/libvirtd_controller.go
@@ -264,6 +264,12 @@ func newDaemonset(cr *novav1.Libvirtd, cmName string, templatesConfigHash string
 					Containers:         []corev1.Container{},
 					Tolerations:        []corev1.Toleration{},
 					ServiceAccountName: cr.Spec.ServiceAccount,
+					SecurityContext: &corev1.PodSecurityContext{
+						SELinuxOptions: &corev1.SELinuxOptions{
+							Type:  "spc_t",
+							Level: "s0",
+						},
+					},
 				},
 			},
 		},
@@ -311,7 +317,10 @@ func newDaemonset(cr *novav1.Libvirtd, cmName string, templatesConfigHash string
 				},
 			},
 		},
-		Command: []string{},
+		Command: []string{
+			"/bin/sleep", "86400",
+		},
+		//Command: []string{},
 		SecurityContext: &corev1.SecurityContext{
 			Privileged:             &trueVar,
 			ReadOnlyRootFilesystem: &falseVar,

--- a/pkg/libvirtd/volumes.go
+++ b/pkg/libvirtd/volumes.go
@@ -14,6 +14,14 @@ func GetVolumes(cmName string) []corev1.Volume {
 
 	return []corev1.Volume{
 		{
+			Name: "etc-selinux-config",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "/etc/selinux/config",
+				},
+			},
+		},
+		{
 			Name: "etc-libvirt-qemu",
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
@@ -47,6 +55,14 @@ func GetVolumes(cmName string) []corev1.Volume {
 			},
 		},
 		{
+			Name: "sys-fs-selinux",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "/sys/fs/selinux",
+				},
+			},
+		},
+		{
 			Name: "var-run-libvirt",
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
@@ -69,6 +85,15 @@ func GetVolumes(cmName string) []corev1.Volume {
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
 					Path: "/var/lib/libvirt",
+					Type: &dirOrCreate,
+				},
+			},
+		},
+		{
+			Name: "var-cache-libvirt",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "/var/cache/libvirt",
 					Type: &dirOrCreate,
 				},
 			},
@@ -147,6 +172,11 @@ func GetVolumeMounts(cmName string) []corev1.VolumeMount {
 
 	return []corev1.VolumeMount{
 		{
+			Name:      "etc-selinux-config",
+			MountPath: "/etc/selinux/config",
+			ReadOnly:  true,
+		},
+		{
 			Name:      "etc-libvirt-qemu",
 			MountPath: "/etc/libvirt/qemu",
 		},
@@ -168,6 +198,10 @@ func GetVolumeMounts(cmName string) []corev1.VolumeMount {
 			MountPath: "/sys/fs/cgroup",
 		},
 		{
+			Name:      "sys-fs-selinux",
+			MountPath: "/sys/fs/selinux",
+		},
+		{
 			Name:      "libvirt-log",
 			MountPath: "/var/log/libvirt",
 		},
@@ -179,6 +213,11 @@ func GetVolumeMounts(cmName string) []corev1.VolumeMount {
 		{
 			Name:             "var-lib-libvirt",
 			MountPath:        "/var/lib/libvirt",
+			MountPropagation: &bidirectional,
+		},
+		{
+			Name:             "var-cache-libvirt",
+			MountPath:        "/var/cache/libvirt",
 			MountPropagation: &bidirectional,
 		},
 		{

--- a/pkg/novacompute/volumes.go
+++ b/pkg/novacompute/volumes.go
@@ -71,6 +71,22 @@ func GetVolumes(cmName string) []corev1.Volume {
 			},
 		},
 		{
+			Name: "sys-class-net",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "/sys/class/net",
+				},
+			},
+		},
+		{
+			Name: "sys-bus-pci",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "/sys/bus/pci",
+				},
+			},
+		},
+		{
 			Name: "var-lib-nova",
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
@@ -213,6 +229,16 @@ func GetVolumeMounts(cmName string) []corev1.VolumeMount {
 		{
 			Name:      "sys-fs-cgroup",
 			MountPath: "/sys/fs/cgroup",
+			ReadOnly:  true,
+		},
+		{
+			Name:      "sys-class-net",
+			MountPath: "/sys/class/net",
+			ReadOnly:  true,
+		},
+		{
+			Name:      "sys-bus-pci",
+			MountPath: "/sys/bus/pci",
 			ReadOnly:  true,
 		},
 		{


### PR DESCRIPTION
To be able to have svirt protection of the created VMs on the compute nodes
libvirtd needs to run with the following parameters as in [1] and related bz
[2] to enable svirt protection on todays OSP:
    "net": "host",
    "pid": "host",
    "privileged": true,
    "security_opt": [
        "label=level:s0",
        "label=type:spc_t",
        "label=filetype:container_ro_file_t"
    ],

container_ro_file_t is required for /usr/bin/libvirtd and /usr/libexec/qemu-kvm
to allow creating instances.

WIP as while it is possible to configure a PodSecurityContext and set SELinuxOptions
[3] for Type: spc_t and Level: s0, it is not possible to set the filetype used for
a pod or container of a pod:

https://bugzilla.redhat.com/show_bug.cgi?id=1862360

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1831544
[2] https://bugzilla.redhat.com/show_bug.cgi?id=1851843#c10
[3] https://godoc.org/k8s.io/api/core/v1#SELinuxOptions