### PR TITLE
Connect osp worker nodes to podified ctrl plane

### DIFF
--- a/pkg/controller/novacompute/novacompute_controller.go
+++ b/pkg/controller/novacompute/novacompute_controller.go
@@ -333,6 +333,17 @@ func newDaemonset(cr *novav1.NovaCompute, cmName string, templatesConfigHash str
 				Name:  "TEMPLATES_VOLUME",
 				Value: "/tmp/container-templates",
 			},
+			{
+				// TODO: mschuppert- change to get the info per route
+				// for now we get the keystoneAPI from common-config
+				Name: "CTRL_PLANE_ENDPOINT",
+				ValueFrom: &corev1.EnvVarSource{
+					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "common-config"},
+						Key:                  "keystoneAPI",
+					},
+				},
+			},
 		},
 		VolumeMounts: []corev1.VolumeMount{},
 	}
@@ -392,6 +403,17 @@ func newDaemonset(cr *novav1.NovaCompute, cmName string, templatesConfigHash str
 			{
 				Name:  "KOLLA_CONFIG_STRATEGY",
 				Value: "COPY_ALWAYS",
+			},
+			{
+				// TODO: mschuppert- change to get the info per route
+				// for now we get the keystoneAPI from common-config
+				Name: "CTRL_PLANE_ENDPOINT",
+				ValueFrom: &corev1.EnvVarSource{
+					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "common-config"},
+						Key:                  "keystoneAPI",
+					},
+				},
 			},
 		},
 		VolumeMounts: []corev1.VolumeMount{},

--- a/pkg/controller/novamigrationtarget/novamigrationtarget_controller.go
+++ b/pkg/controller/novamigrationtarget/novamigrationtarget_controller.go
@@ -346,6 +346,17 @@ func newDaemonset(cr *novav1.NovaMigrationTarget, cmName string, templatesConfig
 				Name:  "TEMPLATES_VOLUME",
 				Value: "/tmp/container-templates",
 			},
+			{
+				// TODO: mschuppert- change to get the info per route
+				// for now we get the keystoneAPI from common-config
+				Name: "CTRL_PLANE_ENDPOINT",
+				ValueFrom: &corev1.EnvVarSource{
+					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "common-config"},
+						Key:                  "keystoneAPI",
+					},
+				},
+			},
 		},
 		VolumeMounts: []corev1.VolumeMount{},
 	}
@@ -410,6 +421,17 @@ func newDaemonset(cr *novav1.NovaMigrationTarget, cmName string, templatesConfig
 			{
 				Name:  "SECRET_HASH",
 				Value: secretHash,
+			},
+			{
+				// TODO: mschuppert- change to get the info per route
+				// for now we get the keystoneAPI from common-config
+				Name: "CTRL_PLANE_ENDPOINT",
+				ValueFrom: &corev1.EnvVarSource{
+					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "common-config"},
+						Key:                  "keystoneAPI",
+					},
+				},
 			},
 		},
 		VolumeMounts: []corev1.VolumeMount{},

--- a/pkg/novacompute/configmap.go
+++ b/pkg/novacompute/configmap.go
@@ -10,8 +10,8 @@ import (
 )
 
 type novaComputeConfigOptions struct {
-	PublicVip                  string
-	InternalAPIVip             string
+	KeystoneAPI                string
+	GlanceAPI                  string
 	MemcacheServers            string
 	CinderPassword             string
 	NovaPassword               string
@@ -46,8 +46,8 @@ func ScriptsConfigMap(cr *novav1.NovaCompute, cmName string) *corev1.ConfigMap {
 // TemplatesConfigMap - mandatory settings config map
 func TemplatesConfigMap(cr *novav1.NovaCompute, commonConfigMap *corev1.ConfigMap, ospSecrets *corev1.Secret, cmName string) *corev1.ConfigMap {
 	opts := novaComputeConfigOptions{
-		commonConfigMap.Data["internalAPIVip"],
-		commonConfigMap.Data["publicVip"],
+		commonConfigMap.Data["keystoneAPI"],
+		commonConfigMap.Data["glanceAPI"],
 		commonConfigMap.Data["memcacheServers"],
 		string(ospSecrets.Data["CinderPassword"]),
 		string(ospSecrets.Data["NovaPassword"]),

--- a/templates/common/common.sh
+++ b/templates/common/common.sh
@@ -27,3 +27,18 @@ function get_ip_address_from_network {
   fi
   echo ${ip}
 }
+
+function get_ctrl_plane_ipaddress {
+  # get the host from the http url
+  local ctrl_plane_endpoint=$(echo $1 | awk -F[/:] '{print $4}')
+
+  # get ip from host
+  local ctrl_plane_ip=$(getent hosts ${ctrl_plane_endpoint} | awk '{print $1}')
+
+  # get local ip
+  local ip=$(ip route get ${ctrl_plane_ip} | head -1 | awk '{print $7}')
+  if [ -z "${ip}" ] ; then
+    exit
+  fi
+  echo ${ip}
+}

--- a/templates/novacompute/bin/init.sh
+++ b/templates/novacompute/bin/init.sh
@@ -40,7 +40,7 @@ mkdir -p ${CONFIG_VOLUME}/etc/nova
 cp -L ${TEMPLATES_VOLUME}/* ${CONFIG_VOLUME}/etc/nova/
 
 # configure host specific mandatory settings
-LOCAL_IP=$(get_ip_address_from_network "internalapi")
+LOCAL_IP=$(get_ctrl_plane_ipaddress ${CTRL_PLANE_ENDPOINT})
 crudini --set ${CONFIG_VOLUME}/etc/nova/nova.conf DEFAULT my_ip ${LOCAL_IP}
 crudini --set ${CONFIG_VOLUME}/etc/nova/nova.conf libvirt live_migration_inbound_addr ${LOCAL_IP}
 crudini --set ${CONFIG_VOLUME}/etc/nova/nova.conf vnc server_listen ${LOCAL_IP}

--- a/templates/novacompute/config/nova.conf
+++ b/templates/novacompute/config/nova.conf
@@ -92,14 +92,16 @@ allow_resize_to_same_host=False
 # Determine if instance should boot or fail on VIF plugging timeout. For more
 # information, refer to the documentation. (boolean value)
 #vif_plugging_is_fatal=true
-vif_plugging_is_fatal=True
+# TODO: (mschuppert) - for now set to false until the multi bridge support is also in OCP
+vif_plugging_is_fatal=False
 
 #
 # Timeout for Neutron VIF plugging event message arrival. For more information,
 # refer to the documentation. (integer value)
 # Minimum value: 0
 #vif_plugging_timeout=300
-vif_plugging_timeout=300
+# TODO: (mschuppert) - for now set low timeout until the multi bridge support is also in OCP
+vif_plugging_timeout=10
 
 # Path to '/etc/network/interfaces' template. For more information, refer to the
 # documentation. (string value)
@@ -1866,7 +1868,6 @@ dhcp_domain=
 # The SQLAlchemy connection string to use to connect to the database. Do not set
 # this for the ``nova-compute`` service (string value)
 #connection=mysql://nova:nova@localhost/nova
-connection=mysql+pymysql://nova_api:{{.NovaPassword}}@{{.InternalAPIVip}}/nova_api?read_default_file=/etc/my.cnf.d/tripleo.cnf&read_default_group=tripleo
 
 # Optional URL parameters to append onto the connection URL at connect time;
 # specify as param1=value1&param2=value2& (string value)
@@ -2047,7 +2048,7 @@ memcache_servers={{.MemcacheServers}}
 # Info to match when looking for cinder in the service catalog. For more
 # information, refer to the documentation. (string value)
 #catalog_info=volumev3::publicURL
-catalog_info=volumev3:cinderv3:internalURL
+#catalog_info=volumev3:cinderv3:internalURL
 
 #
 # If this option is set then it will override service catalog lookup with
@@ -2059,7 +2060,7 @@ catalog_info=volumev3:cinderv3:internalURL
 # Region name of this node. This is used when picking the URL in the service
 # catalog. For more information, refer to the documentation. (string value)
 #os_region_name=<None>
-os_region_name=regionOne
+#os_region_name=regionOne
 
 #
 # Number of times cinderclient should retry on any failed http call.
@@ -2100,14 +2101,14 @@ os_region_name=regionOne
 # Authentication type to load (string value)
 # Deprecated group;name - [cinder]/auth_plugin
 #auth_type=<None>
-auth_type=v3password
+#auth_type=v3password
 
 # Config Section from which to load plugin specific options (string value)
 #auth_section=<None>
 
 # Authentication URL (string value)
 #auth_url=<None>
-auth_url=http://{{.InternalAPIVip}}:5000/v3
+#auth_url={{.KeystoneAPI}}/v3
 
 # Scope for system operations (string value)
 #system_scope=<None>
@@ -2123,14 +2124,14 @@ auth_url=http://{{.InternalAPIVip}}:5000/v3
 
 # Project name to scope to (string value)
 #project_name=<None>
-project_name=service
+#project_name=service
 
 # Domain ID containing project (string value)
 #project_domain_id=<None>
 
 # Domain name containing project (string value)
 #project_domain_name=<None>
-project_domain_name=Default
+#project_domain_name=Default
 
 # Trust ID (string value)
 #trust_id=<None>
@@ -2151,18 +2152,18 @@ project_domain_name=Default
 # Username (string value)
 # Deprecated group;name - [cinder]/user_name
 #username=<None>
-username=cinder
+#username=cinder
 
 # User's domain id (string value)
 #user_domain_id=<None>
 
 # User's domain name (string value)
 #user_domain_name=<None>
-user_domain_name=Default
+#user_domain_name=Default
 
 # User's password (string value)
 #password=<None>
-password={{.CinderPassword}}
+#password={{.CinderPassword}}
 
 # Tenant ID (string value)
 #tenant_id=<None>
@@ -2171,7 +2172,7 @@ password={{.CinderPassword}}
 #tenant_name=<None>
 
 
-region_name=regionOne
+#region_name=regionOne
 [compute]
 
 #
@@ -2342,7 +2343,6 @@ live_migration_wait_for_vif_plug=True
 # Deprecated group;name - [DATABASE]/sql_connection
 # Deprecated group;name - [sql]/connection
 #connection=<None>
-connection=mysql+pymysql://nova:{{.NovaPassword}}@{{.InternalAPIVip}}/nova?read_default_file=/etc/my.cnf.d/tripleo.cnf&read_default_group=tripleo
 
 # The SQLAlchemy connection string to use to connect to the slave database
 # (string value)
@@ -2657,7 +2657,7 @@ db_max_retries=-1
 # List of glance api servers endpoints available to nova. For more information,
 # refer to the documentation. (list value)
 #api_servers=<None>
-api_servers=http://{{.InternalAPIVip}}:9292
+api_servers={{.GlanceAPI}}
 
 #
 # Enable glance operation retries. For more information, refer to the
@@ -3240,7 +3240,7 @@ backend=nova.keymgr.conf_key_mgr.ConfKeyManager
 # users may not be able to reach that endpoint (string value)
 # Deprecated group;name - [keystone_authtoken]/auth_uri
 #www_authenticate_uri=<None>
-www_authenticate_uri=http://{{.InternalAPIVip}}:5000
+www_authenticate_uri={{.KeystoneAPI}}
 
 # DEPRECATED: Complete "public" Identity API endpoint. This endpoint should not
 # be an "admin" endpoint, as it should be accessible by all end users.
@@ -3389,7 +3389,7 @@ auth_type=password
 #auth_section=<None>
 
 
-auth_url=http://{{.InternalAPIVip}}:5000
+auth_url={{.KeystoneAPI}}
 username=nova
 password={{.NovaPassword}}
 user_domain_name=Default
@@ -4026,7 +4026,7 @@ tx_queue_size=512
 # Default name for the Open vSwitch integration bridge. For more information,
 # refer to the documentation. (string value)
 #ovs_bridge=br-int
-ovs_bridge=br-int
+ovs_bridge=br-int-osp
 
 #
 # Default name for the floating IP pool. For more information, refer to the
@@ -4098,7 +4098,7 @@ auth_type=v3password
 
 # Authentication URL (string value)
 #auth_url=<None>
-auth_url=http://{{.InternalAPIVip}}:5000/v3
+auth_url={{.KeystoneAPI}}/v3
 
 # Scope for system operations (string value)
 #system_scope=<None>
@@ -4806,7 +4806,7 @@ auth_type=password
 
 # Authentication URL (string value)
 #auth_url=<None>
-auth_url=http://{{.InternalAPIVip}}:5000
+auth_url={{.KeystoneAPI}}
 
 # Scope for system operations (string value)
 #system_scope=<None>
@@ -5428,7 +5428,7 @@ auth_type=password
 
 # Authentication URL (string value)
 #auth_url=<None>
-auth_url=http://{{.InternalAPIVip}}:5000
+auth_url={{.KeystoneAPI}}
 
 # Scope for system operations (string value)
 #system_scope=<None>
@@ -5958,7 +5958,7 @@ server_proxyclient_address=POD_IP_INTERNALAPI
 # Public address of noVNC VNC console proxy. For more information, refer to the
 # documentation. (uri value)
 #novncproxy_base_url=http://127.0.0.1:6080/vnc_auto.html
-novncproxy_base_url=http://{{.PublicVip}}:6080/vnc_auto.html
+# TODO mschuppert , for now disable
 
 # DEPRECATED:
 # IP address or hostname that the XVP VNC console proxy should bind to. For more

--- a/templates/novamigrationtarget/bin/init.sh
+++ b/templates/novamigrationtarget/bin/init.sh
@@ -43,6 +43,6 @@ chown root:root ${CONFIG_VOLUME}/etc/ssh/*
 chmod 600 ${CONFIG_VOLUME}/etc/ssh/*
 
 # Set the local IP in sshd_config
-LOCAL_IP=$(get_ip_address_from_network "internalapi")
+LOCAL_IP=$(get_ctrl_plane_ipaddress ${CTRL_PLANE_ENDPOINT})
 sed -i "s/LOCAL_IP/$LOCAL_IP/g" ${CONFIG_VOLUME}/etc/ssh/sshd_config
 


### PR DESCRIPTION
This is an intermediate change to connect osp worker nodes to a
podified ctrl plane deployed via dev-tools. It still requires the
common-conf and secrets as before.

Also disables vif_plugging_is_fatal until multi bridge support is
also added in OCP.

To set local ip for now we pass the keystoneAPI url from the
common-config to the nova-compute and migration target, extract
the host and use ip route to get the local endpoint. In future
we'll check the routs in OCP.