### PR TITLE
Support separate MariaDB instance for nova_api and nova cell DBs

### DIFF
--- a/api/v1beta1/novaapi_types.go
+++ b/api/v1beta1/novaapi_types.go
@@ -110,6 +110,15 @@ type NovaAPISpec struct {
 	APIMessageBusHostname string `json:"apiMessageBusHostname"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default="nova"
+	// APIDatabaseUser - username to use when accessing the cell0 DB
+	Cell0DatabaseUser string `json:"cell0DatabaseUser,omitempty"`
+
+	// +kubebuilder:validation:Required
+	// APIDatabaseHostname - hostname to use when accessing the cell0 DB
+	Cell0DatabaseHostname string `json:"cell0DatabaseHostname"`
+
+	// +kubebuilder:validation:Optional
 	// Debug - enable debug for different deploy stages. If an init container
 	// is used, it runs and the actual action pod gets started with sleep
 	// infinity

--- a/api/v1beta1/novacell_types.go
+++ b/api/v1beta1/novacell_types.go
@@ -32,6 +32,11 @@ type NovaCellTemplate struct {
 	// Service instance used as the DB of this cell.
 	CellDatabaseInstance string `json:"cellDatabaseInstance"`
 
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default="nova"
+	// CellDatabaseUser - username to use when accessing the give cell DB
+	CellDatabaseUser string `json:"cellDatabaseUser,omitempty"`
+
 	// +kubebuilder:validation:Required
 	// CellMessageBusInstance is the name of the RabbitMqCluster CR to select
 	// the Message Bus Service instance used by the nova services to

--- a/config/crd/bases/nova.openstack.org_nova.yaml
+++ b/config/crd/bases/nova.openstack.org_nova.yaml
@@ -129,6 +129,11 @@ spec:
                         CR to select the DB Service instance used as the DB of this
                         cell.
                       type: string
+                    cellDatabaseUser:
+                      default: nova
+                      description: CellDatabaseUser - username to use when accessing
+                        the give cell DB
+                      type: string
                     cellMessageBusInstance:
                       description: CellMessageBusInstance is the name of the RabbitMqCluster
                         CR to select the Message Bus Service instance used by the

--- a/config/crd/bases/nova.openstack.org_novaapis.yaml
+++ b/config/crd/bases/nova.openstack.org_novaapis.yaml
@@ -53,6 +53,15 @@ spec:
                 description: APIMessageBusUser - username to use when accessing the
                   API message bus
                 type: string
+              cell0DatabaseHostname:
+                description: APIDatabaseHostname - hostname to use when accessing
+                  the cell0 DB
+                type: string
+              cell0DatabaseUser:
+                default: nova
+                description: APIDatabaseUser - username to use when accessing the
+                  cell0 DB
+                type: string
               containerImage:
                 description: The service specific Container Image URL
                 type: string
@@ -181,6 +190,7 @@ spec:
             required:
             - apiDatabaseHostname
             - apiMessageBusHostname
+            - cell0DatabaseHostname
             - containerImage
             - keystoneAuthURL
             - secret

--- a/config/samples/nova_v1beta1_nova-multi-cell.yaml
+++ b/config/samples/nova_v1beta1_nova-multi-cell.yaml
@@ -6,6 +6,7 @@ spec:
   # This is the name of the single MariaDB CR we deploy today
   # The Service is labelled with app=mariadb,cr=mariadb-<MariaDB.Name>
   apiDatabaseInstance: openstack
+  apiDatabaseUser: nova_api
   # This is the name of the single RabbitMqCluster CR we deploy today
   # The Service is labelled with
   # app.kubernetes.io/component=rabbitmq, app.kubernetes.io/name=<RabbitMqCluster.Name>
@@ -25,7 +26,6 @@ spec:
     apiDatabase: NovaAPIDatabasePassword
     apiMessageBus: NovaAPIMessageBusPassword
   serviceUser: nova
-  apiDatabaseUser: nova
   apiMessageBusUser: nova
   debug:
     stopDBSync: False
@@ -92,6 +92,7 @@ spec:
   cellTemplates:
     cell0:
       cellDatabaseInstance: mariadb-cell0
+      cellDatabaseUser: nova_cell0
       cellMessageBusInstance: rabbitmq-cell0
       # cell0 alway needs access to the API DB and MQ as it hosts the super
       # conductor. It will inherit the API DB and MQ access from the Nova CR
@@ -121,6 +122,7 @@ spec:
       noVNCProxyServiceTemplate: null
     cell1:
       cellDatabaseInstance: mariadb-cell1
+      cellDatabaseUser: nova_cell1
       cellMessageBusInstance: rabbitmq-cell1
       # cell1 will have upcalls support. It will inherit the API DB and MQ
       # access from the Nova CR that creates it.
@@ -166,6 +168,7 @@ spec:
             memory: 64Mi
     cell2:
       cellDatabaseInstance: mariadb-cell2
+      cellDatabaseUser: nova_cell2
       cellMessageBusInstance: rabbitmq-cell2
       # cell2 will not get the API DB and MQ connection if from the Nova CR
       hasAPIAccess: false

--- a/config/samples/nova_v1beta1_nova.yaml
+++ b/config/samples/nova_v1beta1_nova.yaml
@@ -4,6 +4,7 @@ metadata:
   name: nova-minimal-example
 spec:
   apiDatabaseInstance: openstack
+  apiDatabaseUser: nova_api
   apiMessageBusInstance: default-security-context
   keystoneInstance: keystone
   secret: osp-secret
@@ -29,6 +30,7 @@ spec:
   cellTemplates:
     cell0:
       cellDatabaseInstance: mariadb-cell0
+      cellDatabaseUser: nova_cell0
       cellMessageBusInstance: rabbitmq-cell0
       # cell0 always needs API access as it hosts the super conductor
       hasAPIAccess: True
@@ -39,6 +41,7 @@ spec:
       noVNCProxyServiceTemplate: null
     cell1:
       cellDatabaseInstance: mariadb-cell1
+      cellDatabaseUser: nova_cell1
       cellMessageBusInstance: rabbitmq-cell1
       hasAPIAccess: True
       # In this example we have metadata at the top level

--- a/config/samples/nova_v1beta1_nova_only_cell0.yaml
+++ b/config/samples/nova_v1beta1_nova_only_cell0.yaml
@@ -4,6 +4,8 @@ metadata:
   name: nova-only-cell0
 spec:
   apiDatabaseInstance: openstack
+  # This is a MariaDB limitation that the DB user is always the name of the DB
+  apiDatabaseUser: nova_api
   apiMessageBusInstance: default-security-context
   keystoneInstance: keystone
   secret: osp-secret
@@ -29,6 +31,8 @@ spec:
   cellTemplates:
     cell0:
       cellDatabaseInstance: openstack
+      # This is a MariaDB limitation that the DB user is always the name of the DB
+      cellDatabaseUser: nova_cell0
       # NOTE(gibi): cell0 has no message bus but all the other cells requires
       # message bus so it is a required field today.
       cellMessageBusInstance: unused

--- a/controllers/novacell_controller.go
+++ b/controllers/novacell_controller.go
@@ -31,7 +31,6 @@ import (
 	util "github.com/openstack-k8s-operators/lib-common/modules/common/util"
 
 	novav1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
-	"github.com/openstack-k8s-operators/nova-operator/pkg/nova"
 )
 
 // NovaCellReconciler reconciles a NovaCell object
@@ -211,13 +210,9 @@ func (r *NovaCellReconciler) reconcileNovaConductor(
 			instance.Spec.CellName,
 			instance.Spec.Secret,
 			cellDatabaseHostname,
-			// TODO(gibi): this is a limitation of the current MariaDBDatabase
-			// implementation, it always assumes that the
-			// DatabaseUser == DatabaseName
-			"nova_"+instance.Spec.CellName,
+			instance.Spec.CellDatabaseUser,
 			instance.Spec.APIDatabaseHostname,
-			// ditto
-			nova.NovaAPIDatabaseName,
+			instance.Spec.APIDatabaseUser,
 			instance.Spec.Debug,
 		)
 

--- a/pkg/novaapi/deployment.go
+++ b/pkg/novaapi/deployment.go
@@ -44,12 +44,9 @@ func Deployment(
 		Secret:                              instance.Spec.Secret,
 		DatabasePasswordSelector:            instance.Spec.PasswordSelectors.APIDatabase,
 		KeystoneServiceUserPasswordSelector: instance.Spec.PasswordSelectors.Service,
-		// TODO(gibi): this should come as a separate input from the Spec
-		// instead for reusing the API DB stuff for cell
-		Cell0DatabaseHostname: instance.Spec.APIDatabaseHostname,
-		// TODO(gibi): ditto. This is a hack now
-		Cell0DatabaseUser: nova.NovaCell0DatabaseName,
-		Cell0DatabaseName: nova.NovaCell0DatabaseName,
+		Cell0DatabaseHostname:               instance.Spec.Cell0DatabaseHostname,
+		Cell0DatabaseUser:                   instance.Spec.Cell0DatabaseUser,
+		Cell0DatabaseName:                   nova.NovaCell0DatabaseName,
 		// TODO(gibi): this is a hack until we implement proper secret handling
 		// per cell.
 		Cell0DatabasePasswordSelector: "NovaCell0DatabasePassword",

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -339,16 +339,21 @@ func NovaConditionGetter(name types.NamespacedName) condition.Conditions {
 
 // CreateDBService creates a k8s Service object that matches with the
 // expectations of lib-common database module as a Service for the MariaDB
-func CreateDBService(namespace string, spec corev1.ServiceSpec) types.NamespacedName {
-	// TODO(gibi): Do we depend on the name?
-	serviceName := "not-openstack"
+func CreateDBService(namespace string, mariadbCRName string, spec corev1.ServiceSpec) types.NamespacedName {
+	// The Name is used as the hostname to access the service. So
+	// we generate something unique for the MariaDB CR it represents
+	// so we can assert that the correct Service is selected.
+	serviceName := "hostname-for-" + mariadbCRName
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      serviceName,
 			Namespace: namespace,
 			// NOTE(gibi): The lib-common databvase module looks up the
 			// Service exposed by MariaDB via these labels.
-			Labels: map[string]string{"app": "mariadb", "cr": "mariadb-openstack"},
+			Labels: map[string]string{
+				"app": "mariadb",
+				"cr":  "mariadb-" + mariadbCRName,
+			},
 		},
 		Spec: spec,
 	}


### PR DESCRIPTION
[CRD][Nova] Support different DB Services

In a real multi cell deployment it is recommended to use separate DB
services for different cells. This patch adds support to separate the
DB service for the nova_api DB from each nova cell DB (including cell0).

To support this the NovAPISpec now takes Cell0DatabaseHostname as an
input top of the existing APIDatabaseHostname field. When nova is
deployed via the Nova CR the APIDatabaseInstance name can be provided
in NovaSpec while each NovaCellTemplate in NovaSpec.cellsTemplates has
its own CellDatabaseInstance field to specific the name of the DB
service used by the given cell. The Nova controller automatically fills
the Cell0DatabaseHostname of the NovaAPISpec so that the nova-api
service has access not just the nova_api DB but also the nova_cell0 DB
as well.

Closes: https://github.com/openstack-k8s-operators/nova-operator/issues/91
Closes: https://github.com/openstack-k8s-operators/nova-operator/issues/89

Depends-on #87 