### PR TITLE
[envtest]Remove the mention of AfterEach

### DIFF
--- a/test/functional/nova_controller_test.go
+++ b/test/functional/nova_controller_test.go
@@ -46,8 +46,8 @@ var _ = Describe("Nova controller", func() {
 		// https://book.kubebuilder.io/reference/envtest.html#namespace-usage-limitation
 		namespace = uuid.New().String()
 		CreateNamespace(namespace)
-		// We still request the delete of the Namespace in AfterEach to
-		// properly cleanup if we run the test in an existing cluster.
+		// We still request the delete of the Namespace to properly cleanup if
+		// we run the test in an existing cluster.
 		DeferCleanup(DeleteNamespace, namespace)
 		// NOTE(gibi): ConfigMap generation looks up the local templates
 		// directory via ENV, so provide it

--- a/test/functional/novaapi_controller_test.go
+++ b/test/functional/novaapi_controller_test.go
@@ -40,8 +40,8 @@ var _ = Describe("NovaAPI controller", func() {
 		// https://book.kubebuilder.io/reference/envtest.html#namespace-usage-limitation
 		namespace = uuid.New().String()
 		CreateNamespace(namespace)
-		// We still request the delete of the Namespace in AfterEach to
-		// properly cleanup if we run the test in an existing cluster.
+		// We still request the delete of the Namespace to properly cleanup if
+		// we run the test in an existing cluster.
 		DeferCleanup(DeleteNamespace, namespace)
 		// NOTE(gibi): ConfigMap generation looks up the local templates
 		// directory via ENV, so provide it

--- a/test/functional/novacell_controller_test.go
+++ b/test/functional/novacell_controller_test.go
@@ -39,8 +39,8 @@ var _ = Describe("NovaCell controller", func() {
 		// https://book.kubebuilder.io/reference/envtest.html#namespace-usage-limitation
 		namespace = uuid.New().String()
 		CreateNamespace(namespace)
-		// We still request the delete of the Namespace in AfterEach to
-		// properly cleanup if we run the test in an existing cluster.
+		// We still request the delete of the Namespace to properly cleanup if
+		// we run the test in an existing cluster.
 		DeferCleanup(DeleteNamespace, namespace)
 		// NOTE(gibi): ConfigMap generation looks up the local templates
 		// directory via ENV, so provide it

--- a/test/functional/novaconductor_controller_test.go
+++ b/test/functional/novaconductor_controller_test.go
@@ -38,8 +38,8 @@ var _ = Describe("NovaConductor controller", func() {
 		// https://book.kubebuilder.io/reference/envtest.html#namespace-usage-limitation
 		namespace = uuid.New().String()
 		CreateNamespace(namespace)
-		// We still request the delete of the Namespace in AfterEach to
-		// properly cleanup if we run the test in an existing cluster.
+		// We still request the delete of the Namespace to properly cleanup if
+		// we run the test in an existing cluster.
 		DeferCleanup(DeleteNamespace, namespace)
 		// NOTE(gibi): ConfigMap generation looks up the local templates
 		// directory via ENV, so provide it


### PR DESCRIPTION
We replaced AfterEach with DeferCleanup but some comment was still
referring to AfterEach. So this patch rewrites those comments.