### PR TITLE
Reduce status update conflict

### DIFF
--- a/controllers/nova_controller.go
+++ b/controllers/nova_controller.go
@@ -157,15 +157,6 @@ func (r *NovaReconciler) initConditions(
 			),
 		)
 		instance.Status.Conditions.Init(&cl)
-
-		// Register overall status immediately to have an early feedback e.g.
-		// in the cli
-		if err := r.Client.Status().Update(ctx, instance); err != nil {
-			util.LogErrorForObject(
-				h, err, "Failed to initialize Conditions", instance)
-			return err
-		}
-
 	}
 	return nil
 }

--- a/controllers/nova_controller.go
+++ b/controllers/nova_controller.go
@@ -264,7 +264,9 @@ func (r *NovaReconciler) reconcileNormal(
 	// cell0 is ready as top level services needs cell0 to register in
 	cell0ReadyCond := cell0.Status.Conditions.Get(condition.ReadyCondition)
 	if cell0ReadyCond == nil || cell0ReadyCond.Status != corev1.ConditionTrue {
-		return ctrl.Result{RequeueAfter: r.RequeueTimeout}, nil
+		// It is OK to return success as NovaCell expected to change to Ready
+		// and we are watching NovaCell
+		return ctrl.Result{}, nil
 	}
 
 	// TODO(gibi): Pass down a narroved secret that only hold

--- a/controllers/nova_controller.go
+++ b/controllers/nova_controller.go
@@ -111,8 +111,10 @@ func (r *NovaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 			patch := client.MergeFrom(h.GetBeforeObject())
 
 			err := r.Client.Status().Patch(ctx, instance, patch)
-			if err != nil && !k8s_errors.IsNotFound(err) {
-				util.LogErrorForObject(h, err, "Update status", instance)
+			if k8s_errors.IsConflict(err) {
+				util.LogForObject(h, "Status update conflict", instance)
+			} else if err != nil && !k8s_errors.IsNotFound(err) {
+				util.LogErrorForObject(h, err, "Status update failed", instance)
 			}
 		}
 	}()

--- a/controllers/nova_controller.go
+++ b/controllers/nova_controller.go
@@ -57,7 +57,7 @@ type NovaReconciler struct {
 //
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.12.2/pkg/reconcile
-func (r *NovaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *NovaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {
 	l := log.FromContext(ctx)
 	l.Info("Reconciling ", "request", req)
 
@@ -105,16 +105,22 @@ func (r *NovaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		}
 		if err := h.SetAfter(instance); err != nil {
 			util.LogErrorForObject(h, err, "Set after and calc patch/diff", instance)
+			_err = err
+			return
 		}
 
 		if changed := h.GetChanges()["status"]; changed {
 			patch := client.MergeFrom(h.GetBeforeObject())
 
-			err := r.Client.Status().Patch(ctx, instance, patch)
+			err = r.Client.Status().Patch(ctx, instance, patch)
 			if k8s_errors.IsConflict(err) {
 				util.LogForObject(h, "Status update conflict", instance)
+				_err = err
+				return
 			} else if err != nil && !k8s_errors.IsNotFound(err) {
 				util.LogErrorForObject(h, err, "Status update failed", instance)
+				_err = err
+				return
 			}
 		}
 	}()

--- a/controllers/novaapi_controller.go
+++ b/controllers/novaapi_controller.go
@@ -117,8 +117,10 @@ func (r *NovaAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			patch := client.MergeFrom(h.GetBeforeObject())
 
 			err := r.Client.Status().Patch(ctx, instance, patch)
-			if err != nil && !k8s_errors.IsNotFound(err) {
-				util.LogErrorForObject(h, err, "Update status", instance)
+			if k8s_errors.IsConflict(err) {
+				util.LogForObject(h, "Status update conflict", instance)
+			} else if err != nil && !k8s_errors.IsNotFound(err) {
+				util.LogErrorForObject(h, err, "Status update failed", instance)
 			}
 		}
 	}()

--- a/controllers/novaapi_controller.go
+++ b/controllers/novaapi_controller.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	common "github.com/openstack-k8s-operators/lib-common/modules/common"
@@ -108,13 +109,18 @@ func (r *NovaAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			instance.Status.Conditions.MarkTrue(
 				condition.ReadyCondition, condition.ReadyMessage)
 		}
-		err := r.Client.Status().Update(ctx, instance)
-		if err != nil && !k8s_errors.IsNotFound(err) {
-			util.LogErrorForObject(
-				h, err, "Failed to update status at the end of reconciliation", instance)
+		if err := h.SetAfter(instance); err != nil {
+			util.LogErrorForObject(h, err, "Set after and calc patch/diff", instance)
 		}
-		util.LogForObject(
-			h, "Updated status at the end of reconciliation", instance)
+
+		if changed := h.GetChanges()["status"]; changed {
+			patch := client.MergeFrom(h.GetBeforeObject())
+
+			err := r.Client.Status().Patch(ctx, instance, patch)
+			if err != nil && !k8s_errors.IsNotFound(err) {
+				util.LogErrorForObject(h, err, "Update status", instance)
+			}
+		}
 	}()
 
 	return r.reconcileNormal(ctx, h, instance)
@@ -230,8 +236,6 @@ func (r *NovaAPIReconciler) reconcileNormal(
 	}
 	if val, ok := instance.Status.Hash[common.InputHashName]; !ok || val != inputHash {
 		instance.Status.Hash[common.InputHashName] = inputHash
-		// TODO(gibi): Do we need to persist the change right away here? Or it
-		// is OK to let the our defered update at the end do the persisting.
 	}
 
 	instance.Status.Conditions.MarkTrue(condition.ServiceConfigReadyCondition, condition.ServiceConfigReadyMessage)

--- a/controllers/novaapi_controller.go
+++ b/controllers/novaapi_controller.go
@@ -167,15 +167,6 @@ func (r *NovaAPIReconciler) initConditions(
 		)
 
 		instance.Status.Conditions.Init(&cl)
-
-		// Register overall status immediately to have an early feedback e.g.
-		// in the cli
-		if err := r.Client.Status().Update(ctx, instance); err != nil {
-			util.LogErrorForObject(
-				h, err, "Failed to initialize Conditions", instance)
-			return err
-		}
-
 	}
 	return nil
 }

--- a/controllers/novaapi_controller.go
+++ b/controllers/novaapi_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 
+	v1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -285,7 +286,9 @@ func (r *NovaAPIReconciler) reconcileNormal(
 			condition.RequestedReason,
 			condition.SeverityInfo,
 			condition.DeploymentReadyRunningMessage))
-		return ctrl.Result{RequeueAfter: r.RequeueTimeout}, nil
+		// It is OK to return success as we are watching for Deployment changes
+		return ctrl.Result{}, nil
+
 	}
 
 	return ctrl.Result{}, nil
@@ -363,5 +366,6 @@ func (r *NovaAPIReconciler) generateServiceConfigMaps(
 func (r *NovaAPIReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&novav1.NovaAPI{}).
+		Owns(&v1.Deployment{}).
 		Complete(r)
 }

--- a/controllers/novacell_controller.go
+++ b/controllers/novacell_controller.go
@@ -106,8 +106,10 @@ func (r *NovaCellReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			patch := client.MergeFrom(h.GetBeforeObject())
 
 			err := r.Client.Status().Patch(ctx, instance, patch)
-			if err != nil && !k8s_errors.IsNotFound(err) {
-				util.LogErrorForObject(h, err, "Update status", instance)
+			if k8s_errors.IsConflict(err) {
+				util.LogForObject(h, "Status update conflict", instance)
+			} else if err != nil && !k8s_errors.IsNotFound(err) {
+				util.LogErrorForObject(h, err, "Status update failed", instance)
 			}
 		}
 	}()

--- a/controllers/novacell_controller.go
+++ b/controllers/novacell_controller.go
@@ -136,15 +136,6 @@ func (r *NovaCellReconciler) initConditions(
 			),
 		)
 		instance.Status.Conditions.Init(&cl)
-
-		// Register overall status immediately to have an early feedback e.g.
-		// in the cli
-		if err := r.Client.Status().Update(ctx, instance); err != nil {
-			util.LogErrorForObject(
-				h, err, "Failed to initialize Conditions", instance)
-			return err
-		}
-
 	}
 	return nil
 }

--- a/controllers/novacell_controller.go
+++ b/controllers/novacell_controller.go
@@ -52,7 +52,7 @@ type NovaCellReconciler struct {
 //
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.12.2/pkg/reconcile
-func (r *NovaCellReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *NovaCellReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {
 	l := log.FromContext(ctx)
 	l.Info("Reconciling ", "request", req)
 
@@ -100,16 +100,22 @@ func (r *NovaCellReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 		if err := h.SetAfter(instance); err != nil {
 			util.LogErrorForObject(h, err, "Set after and calc patch/diff", instance)
+			_err = err
+			return
 		}
 
 		if changed := h.GetChanges()["status"]; changed {
 			patch := client.MergeFrom(h.GetBeforeObject())
 
-			err := r.Client.Status().Patch(ctx, instance, patch)
+			err = r.Client.Status().Patch(ctx, instance, patch)
 			if k8s_errors.IsConflict(err) {
 				util.LogForObject(h, "Status update conflict", instance)
+				_err = err
+				return
 			} else if err != nil && !k8s_errors.IsNotFound(err) {
 				util.LogErrorForObject(h, err, "Status update failed", instance)
+				_err = err
+				return
 			}
 		}
 	}()

--- a/controllers/novaconductor_controller.go
+++ b/controllers/novaconductor_controller.go
@@ -114,8 +114,10 @@ func (r *NovaConductorReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			patch := client.MergeFrom(h.GetBeforeObject())
 
 			err := r.Client.Status().Patch(ctx, instance, patch)
-			if err != nil && !k8s_errors.IsNotFound(err) {
-				util.LogErrorForObject(h, err, "Update status", instance)
+			if k8s_errors.IsConflict(err) {
+				util.LogForObject(h, "Status update conflict", instance)
+			} else if err != nil && !k8s_errors.IsNotFound(err) {
+				util.LogErrorForObject(h, err, "Satus update failed", instance)
 			}
 		}
 	}()

--- a/controllers/novaconductor_controller.go
+++ b/controllers/novaconductor_controller.go
@@ -161,15 +161,6 @@ func (r *NovaConductorReconciler) initConditions(
 		)
 
 		instance.Status.Conditions.Init(&cl)
-
-		// Register overall status immediately to have an early feedback e.g.
-		// in the cli
-		if err := r.Client.Status().Update(ctx, instance); err != nil {
-			util.LogErrorForObject(
-				h, err, "Failed to initialize Conditions", instance)
-			return err
-		}
-
 	}
 	return nil
 }


### PR DESCRIPTION
Do couple of improvement that makes Status update conflict less likely:
- Only update Status at the end of Reconcile
- Replace Update() with Patch()
- Report error from deferred Status update
- Remove unnecessary RequeueAfter