### PR TITLE
Generate meaningful sub CR names

### DIFF
--- a/config/samples/nova_v1beta1_nova-multi-cell.yaml
+++ b/config/samples/nova_v1beta1_nova-multi-cell.yaml
@@ -1,7 +1,7 @@
 apiVersion: nova.openstack.org/v1beta1
 kind: Nova
 metadata:
-  name: nova-multi-cell-sample
+  name: nova
 spec:
   # This is the name of the single MariaDB CR we deploy today
   # The Service is labelled with app=mariadb,cr=mariadb-<MariaDB.Name>

--- a/config/samples/nova_v1beta1_nova.yaml
+++ b/config/samples/nova_v1beta1_nova.yaml
@@ -1,7 +1,7 @@
 apiVersion: nova.openstack.org/v1beta1
 kind: Nova
 metadata:
-  name: nova-minimal-example
+  name: nova
 spec:
   apiDatabaseInstance: openstack
   apiDatabaseUser: nova_api

--- a/config/samples/nova_v1beta1_nova_only_cell0.yaml
+++ b/config/samples/nova_v1beta1_nova_only_cell0.yaml
@@ -1,7 +1,7 @@
 apiVersion: nova.openstack.org/v1beta1
 kind: Nova
 metadata:
-  name: nova-only-cell0
+  name: nova
 spec:
   apiDatabaseInstance: openstack
   # This is a MariaDB limitation that the DB user is always the name of the DB

--- a/controllers/nova_controller.go
+++ b/controllers/nova_controller.go
@@ -371,7 +371,7 @@ func (r *NovaReconciler) reconcileNovaAPI(
 ) (ctrl.Result, error) {
 	api := &novav1.NovaAPI{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      instance.Name,
+			Name:      instance.Name + "-api",
 			Namespace: instance.Namespace,
 		},
 	}

--- a/controllers/novacell_controller.go
+++ b/controllers/novacell_controller.go
@@ -199,7 +199,7 @@ func (r *NovaCellReconciler) reconcileNovaConductor(
 ) (ctrl.Result, error) {
 	conductor := &novav1.NovaConductor{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      instance.Name,
+			Name:      instance.Name + "-conductor",
 			Namespace: instance.Namespace,
 		},
 	}

--- a/pkg/novaconductor/dbsync.go
+++ b/pkg/novaconductor/dbsync.go
@@ -77,7 +77,7 @@ func CellDBSyncJob(
 
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      instance.Name + "-cell-db-sync",
+			Name:      instance.Name + "-db-sync",
 			Namespace: instance.Namespace,
 			Labels:    labels,
 		},
@@ -92,7 +92,7 @@ func CellDBSyncJob(
 					),
 					Containers: []corev1.Container{
 						{
-							Name: instance.Name + "-cell-db-sync",
+							Name: instance.Name + "-db-sync",
 							Command: []string{
 								"/bin/bash",
 							},

--- a/test/functional/nova_controller_test.go
+++ b/test/functional/nova_controller_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 package functional_test
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/google/uuid"
@@ -72,19 +71,19 @@ var _ = Describe("Nova controller", func() {
 		}
 		cell0Name = types.NamespacedName{
 			Namespace: namespace,
-			Name:      novaName.Name + "-" + "cell0",
+			Name:      novaName.Name + "-cell0",
 		}
 		cell0ConductorName = types.NamespacedName{
 			Namespace: namespace,
-			Name:      cell0Name.Name,
+			Name:      cell0Name.Name + "-conductor",
 		}
 		cell0DBSyncJobName = types.NamespacedName{
 			Namespace: namespace,
-			Name:      fmt.Sprintf("%s-cell-db-sync", cell0ConductorName.Name),
+			Name:      cell0ConductorName.Name + "-db-sync",
 		}
 		novaAPIName = types.NamespacedName{
 			Namespace: namespace,
-			Name:      novaName.Name,
+			Name:      novaName.Name + "-api",
 		}
 		novaAPIdeploymentName = types.NamespacedName{
 			Namespace: namespace,

--- a/test/functional/novacell_controller_test.go
+++ b/test/functional/novacell_controller_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 package functional_test
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/google/uuid"
@@ -100,7 +99,9 @@ var _ = Describe("NovaCell controller", func() {
 			)
 			DeferCleanup(DeleteNovaCell, novaCellName)
 			novaConductorName = types.NamespacedName{
-				Namespace: namespace, Name: novaCellName.Name}
+				Namespace: namespace,
+				Name:      novaCellName.Name + "-conductor",
+			}
 		})
 
 		It("creates the NovaConductor and tracks its readiness", func() {
@@ -127,7 +128,8 @@ var _ = Describe("NovaCell controller", func() {
 				)
 				novaConductorDBSyncJobName = types.NamespacedName{
 					Namespace: namespace,
-					Name:      fmt.Sprintf("%s-cell-db-sync", novaConductorName.Name)}
+					Name:      novaConductorName.Name + "-db-sync",
+				}
 				SimulateJobSuccess(novaConductorDBSyncJobName)
 
 				ExpectCondition(

--- a/test/functional/novaconductor_controller_test.go
+++ b/test/functional/novaconductor_controller_test.go
@@ -279,7 +279,7 @@ var _ = Describe("NovaConductor controller", func() {
 
 			jobName = types.NamespacedName{
 				Namespace: namespace,
-				Name:      fmt.Sprintf("%s-cell-db-sync", novaConductorName.Name),
+				Name:      novaConductorName.Name + "-db-sync",
 			}
 
 		})
@@ -411,7 +411,8 @@ var _ = Describe("NovaConductor controller", func() {
 
 			jobName = types.NamespacedName{
 				Namespace: namespace,
-				Name:      fmt.Sprintf("%s-cell-db-sync", novaConductorName.Name)}
+				Name:      novaConductorName.Name + "-db-sync",
+			}
 		})
 
 		It("does not delete the DB sync job after it finished", func() {


### PR DESCRIPTION
For example if the Nova CR is named "nova" by the client, then the following sub CR names will be generated:
- MariaDBDatabase: nova-api, nova-cell0
- NovaCell: nova-cell0 
  - NovaConductor: nova-cell0-conductor
    - Job: nova-cell0-db-sync
-  NovaAPI: nova-api
    - Deployment: nova-api

Closes: #102