### PR TITLE
[sample]Make sure passwordSelectors are defaulted

### DIFF
--- a/config/samples/nova_v1beta1_nova.yaml
+++ b/config/samples/nova_v1beta1_nova.yaml
@@ -8,6 +8,9 @@ spec:
   apiMessageBusInstance: not-implemented-yet
   keystoneInstance: keystone
   secret: osp-secret
+  # NOTE(gibi): defaulting structs only work if we provide {} value. If the
+  # field is left out then it will not be defaulted.
+  passwordSelector: {}
   # NOTE(gibi): if apiServiceTemplate and schedlerServiceTemplate is not
   # specified still a CRs for those services are created with default
   # configuration.

--- a/config/samples/nova_v1beta1_nova_only_cell0.yaml
+++ b/config/samples/nova_v1beta1_nova_only_cell0.yaml
@@ -9,6 +9,9 @@ spec:
   apiMessageBusInstance: default-security-context
   keystoneInstance: keystone
   secret: osp-secret
+  # NOTE(gibi): defaulting structs only work if we provide {} value. If the
+  # field is left out then it will not be defaulted.
+  passwordSelector: {}
   # NOTE(gibi): if apiServiceTemplate and schedlerServiceTemplate is not
   # specified still a CRs for those services are created with default
   # configuration.


### PR DESCRIPTION
Defaulting structs only work if the value `{}` is passed to the field. If the struct field is left out from the input then the struct will get defaulted by golang not by kubebuilder so the kubebuilder default values will not added.

Note that if the struct field is left out from the input but the controller reconciling the input does an Update on the instance then that Update will apply the defaults as it will use the `{}` value for the struct field.