### PR TITLE
Add liveness and readiness probes

### DIFF
--- a/pkg/novaapi/deployment.go
+++ b/pkg/novaapi/deployment.go
@@ -26,6 +26,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // StatefulSet - returns the StatefulSet definition for the nova-api service
@@ -65,28 +66,12 @@ func StatefulSet(
 		}
 	} else {
 		args = append(args, nova.KollaServiceCommand)
-		// TODO(gibi): user the proper http-get probes once the service is
-		// exposed
-		livenessProbe.Exec = &corev1.ExecAction{
-			Command: []string{
-				"/bin/true",
-			},
+		livenessProbe.HTTPGet = &corev1.HTTPGetAction{
+			Port: intstr.IntOrString{Type: intstr.Int, IntVal: int32(APIServicePort)},
 		}
-
-		readinessProbe.Exec = &corev1.ExecAction{
-			Command: []string{
-				"/bin/true",
-			},
+		readinessProbe.HTTPGet = &corev1.HTTPGetAction{
+			Port: intstr.IntOrString{Type: intstr.Int, IntVal: int32(APIServicePort)},
 		}
-		// //
-		// // https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
-		// //
-		// livenessProbe.HTTPGet = &corev1.HTTPGetAction{
-		// 	Port: intstr.IntOrString{Type: intstr.Int, IntVal: int32(APIServicePort)},
-		// }
-		// readinessProbe.HTTPGet = &corev1.HTTPGetAction{
-		// 	Port: intstr.IntOrString{Type: intstr.Int, IntVal: int32(APIServicePort)},
-		// }
 	}
 
 	nodeSelector := map[string]string{}

--- a/test/functional/novaapi_controller_test.go
+++ b/test/functional/novaapi_controller_test.go
@@ -312,6 +312,9 @@ var _ = Describe("NovaAPI controller", func() {
 			Expect(container.VolumeMounts).To(HaveLen(2))
 			Expect(container.Image).To(Equal(ContainerImage))
 
+			Expect(container.LivenessProbe.HTTPGet.Port.IntVal).To(Equal(int32(8774)))
+			Expect(container.ReadinessProbe.HTTPGet.Port.IntVal).To(Equal(int32(8774)))
+
 		})
 
 		When("the StatefulSet has at least one Replica ready", func() {

--- a/test/functional/novaconductor_controller_test.go
+++ b/test/functional/novaconductor_controller_test.go
@@ -392,6 +392,14 @@ var _ = Describe("NovaConductor controller", func() {
 					condition.DeploymentReadyCondition,
 					corev1.ConditionFalse,
 				)
+				ss := GetStatefulSet(statefulSetName)
+				Expect(ss.Spec.Template.Spec.Containers).To(HaveLen(1))
+				container := ss.Spec.Template.Spec.Containers[0]
+				Expect(container.LivenessProbe.Exec.Command).To(
+					Equal([]string{"/usr/bin/pgrep", "-r", "DRST", "nova-conductor"}))
+				Expect(container.ReadinessProbe.Exec.Command).To(
+					Equal([]string{"/usr/bin/pgrep", "-r", "DRST", "nova-conductor"}))
+
 				SimulateStatefulSetReplicaReady(statefulSetName)
 				ExpectCondition(
 					novaConductorName,


### PR DESCRIPTION
For nova-api both for readiness and liveness a HTTP GET is sent to the `/` to see if the service can respond.

For nova-conductor we can only check that the nova-conductor process exists. When https://review.opendev.org/q/topic:per-process-healthchecks merges upstream we can have a better nova-conductor probe.

Closes: #82 
Depends-on: #132 