### PR TITLE
update default images to stable/zed

### DIFF
--- a/api/v1beta1/nova_types.go
+++ b/api/v1beta1/nova_types.go
@@ -49,7 +49,7 @@ type NovaSpec struct {
 	APIMessageBusInstance string `json:"apiMessageBusInstance"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={cell0: {cellDatabaseInstance: openstack, cellDatabaseUser: nova_cell0, cellMessageBusInstance: unused, hasAPIAccess: true, conductorServiceTemplate: {containerImage: "quay.io/tripleowallabycentos9/openstack-nova-conductor:current-tripleo"}}}
+	// +kubebuilder:default={cell0: {cellDatabaseInstance: openstack, cellDatabaseUser: nova_cell0, cellMessageBusInstance: unused, hasAPIAccess: true, conductorServiceTemplate: {containerImage: "quay.io/tripleozedcentos9/openstack-nova-conductor:current-tripleo"}}}
 	// Cells is a mapping of cell names to NovaCellTemplate objects defining
 	// the cells in the deployment. The "cell0" cell is a mandatory cell in
 	// every deployment. Moreover any real deployment needs at least one
@@ -89,7 +89,7 @@ type NovaSpec struct {
 	Debug Debug `json:"debug,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={containerImage: "quay.io/tripleowallabycentos9/openstack-nova-api:current-tripleo"}
+	// +kubebuilder:default={containerImage: "quay.io/tripleozedcentos9/openstack-nova-api:current-tripleo"}
 	// APIServiceTemplate - define the nova-api service
 	APIServiceTemplate NovaAPITemplate `json:"apiServiceTemplate"`
 

--- a/api/v1beta1/novaapi_types.go
+++ b/api/v1beta1/novaapi_types.go
@@ -33,7 +33,7 @@ import (
 // are duplicated.
 type NovaAPITemplate struct {
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="quay.io/tripleowallabycentos9/openstack-nova-api:current-tripleo"
+	// +kubebuilder:default="quay.io/tripleozedcentos9/openstack-nova-api:current-tripleo"
 	// ContainerImage - The service specific Container Image URL
 	ContainerImage string `json:"containerImage,omitempty"`
 

--- a/api/v1beta1/novaconductor_types.go
+++ b/api/v1beta1/novaconductor_types.go
@@ -29,7 +29,7 @@ import (
 // create a NovaConductor via higher level CRDs.
 type NovaConductorTemplate struct {
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="quay.io/tripleowallabycentos9/openstack-nova-conductor:current-tripleo"
+	// +kubebuilder:default="quay.io/tripleozedcentos9/openstack-nova-conductor:current-tripleo"
 	// The service specific Container Image URL
 	ContainerImage string `json:"containerImage"`
 

--- a/api/v1beta1/novametadata_types.go
+++ b/api/v1beta1/novametadata_types.go
@@ -29,7 +29,7 @@ import (
 // create a NovaMetadata via higher level CRDs.
 type NovaMetadataTemplate struct {
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="quay.io/tripleowallabycentos9/openstack-nova-metadata:current-tripleo"
+	// +kubebuilder:default="quay.io/tripleozedcentos9/openstack-nova-metadata:current-tripleo"
 	// The service specific Container Image URL
 	ContainerImage string `json:"containerImage"`
 

--- a/api/v1beta1/novanovncproxy_types.go
+++ b/api/v1beta1/novanovncproxy_types.go
@@ -29,7 +29,7 @@ import (
 // create a NovaNoVNCProxy via higher level CRDs.
 type NovaNoVNCProxyTemplate struct {
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="quay.io/tripleowallabycentos9/openstack-nova-novncproxy:current-tripleo"
+	// +kubebuilder:default="quay.io/tripleozedcentos9/openstack-nova-novncproxy:current-tripleo"
 	// The service specific Container Image URL
 	ContainerImage string `json:"containerImage"`
 

--- a/api/v1beta1/novascheduler_types.go
+++ b/api/v1beta1/novascheduler_types.go
@@ -29,7 +29,7 @@ import (
 // create a NovaScheduler via higher level CRDs.
 type NovaSchedulerTemplate struct {
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="quay.io/tripleowallabycentos9/openstack-nova-scheduler:current-tripleo"
+	// +kubebuilder:default="quay.io/tripleozedcentos9/openstack-nova-scheduler:current-tripleo"
 	// The service specific Container Image URL
 	ContainerImage string `json:"containerImage"`
 

--- a/config/crd/bases/nova.openstack.org_nova.yaml
+++ b/config/crd/bases/nova.openstack.org_nova.yaml
@@ -58,11 +58,11 @@ spec:
                 type: string
               apiServiceTemplate:
                 default:
-                  containerImage: quay.io/tripleowallabycentos9/openstack-nova-api:current-tripleo
+                  containerImage: quay.io/tripleozedcentos9/openstack-nova-api:current-tripleo
                 description: APIServiceTemplate - define the nova-api service
                 properties:
                   containerImage:
-                    default: quay.io/tripleowallabycentos9/openstack-nova-api:current-tripleo
+                    default: quay.io/tripleozedcentos9/openstack-nova-api:current-tripleo
                     description: ContainerImage - The service specific Container Image
                       URL
                     type: string
@@ -151,7 +151,7 @@ spec:
                         deployment for the cell.
                       properties:
                         containerImage:
-                          default: quay.io/tripleowallabycentos9/openstack-nova-conductor:current-tripleo
+                          default: quay.io/tripleozedcentos9/openstack-nova-conductor:current-tripleo
                           description: The service specific Container Image URL
                           type: string
                         customServiceConfig:
@@ -221,7 +221,7 @@ spec:
                         serive dedicated for the cell.
                       properties:
                         containerImage:
-                          default: quay.io/tripleowallabycentos9/openstack-nova-metadata:current-tripleo
+                          default: quay.io/tripleozedcentos9/openstack-nova-metadata:current-tripleo
                           description: The service specific Container Image URL
                           type: string
                         customServiceConfig:
@@ -287,7 +287,7 @@ spec:
                         serive dedicated for the cell.
                       properties:
                         containerImage:
-                          default: quay.io/tripleowallabycentos9/openstack-nova-novncproxy:current-tripleo
+                          default: quay.io/tripleozedcentos9/openstack-nova-novncproxy:current-tripleo
                           description: The service specific Container Image URL
                           type: string
                         customServiceConfig:
@@ -358,7 +358,7 @@ spec:
                     cellDatabaseUser: nova_cell0
                     cellMessageBusInstance: unused
                     conductorServiceTemplate:
-                      containerImage: quay.io/tripleowallabycentos9/openstack-nova-conductor:current-tripleo
+                      containerImage: quay.io/tripleozedcentos9/openstack-nova-conductor:current-tripleo
                     hasAPIAccess: true
                 description: Cells is a mapping of cell names to NovaCellTemplate
                   objects defining the cells in the deployment. The "cell0" cell is
@@ -403,7 +403,7 @@ spec:
                   that is global for the deployment serving all the cells.
                 properties:
                   containerImage:
-                    default: quay.io/tripleowallabycentos9/openstack-nova-metadata:current-tripleo
+                    default: quay.io/tripleozedcentos9/openstack-nova-metadata:current-tripleo
                     description: The service specific Container Image URL
                     type: string
                   customServiceConfig:
@@ -499,7 +499,7 @@ spec:
                 description: SchedulerServiceTemplate- define the nova-scheduler service
                 properties:
                   containerImage:
-                    default: quay.io/tripleowallabycentos9/openstack-nova-scheduler:current-tripleo
+                    default: quay.io/tripleozedcentos9/openstack-nova-scheduler:current-tripleo
                     description: The service specific Container Image URL
                     type: string
                   customServiceConfig:

--- a/config/crd/bases/nova.openstack.org_novacells.yaml
+++ b/config/crd/bases/nova.openstack.org_novacells.yaml
@@ -86,7 +86,7 @@ spec:
                   deployment for the cell
                 properties:
                   containerImage:
-                    default: quay.io/tripleowallabycentos9/openstack-nova-conductor:current-tripleo
+                    default: quay.io/tripleozedcentos9/openstack-nova-conductor:current-tripleo
                     description: The service specific Container Image URL
                     type: string
                   customServiceConfig:
@@ -182,7 +182,7 @@ spec:
                   dedicated for the cell.
                 properties:
                   containerImage:
-                    default: quay.io/tripleowallabycentos9/openstack-nova-metadata:current-tripleo
+                    default: quay.io/tripleozedcentos9/openstack-nova-metadata:current-tripleo
                     description: The service specific Container Image URL
                     type: string
                   customServiceConfig:
@@ -247,7 +247,7 @@ spec:
                   dedicated for the cell.
                 properties:
                   containerImage:
-                    default: quay.io/tripleowallabycentos9/openstack-nova-novncproxy:current-tripleo
+                    default: quay.io/tripleozedcentos9/openstack-nova-novncproxy:current-tripleo
                     description: The service specific Container Image URL
                     type: string
                   customServiceConfig:

--- a/config/samples/nova_v1beta1_nova-multi-cell.yaml
+++ b/config/samples/nova_v1beta1_nova-multi-cell.yaml
@@ -39,7 +39,7 @@ spec:
     defaultConfigOverwrite:
       logging.conf: |
         # my custom logging configuration
-    containerImage: quay.io/tripleowallabycentos9/openstack-nova-api:current-tripleo
+    containerImage: quay.io/tripleozedcentos9/openstack-nova-api:current-tripleo
     replicate: 3
     nodeSelector: {}
     resources:
@@ -56,7 +56,7 @@ spec:
     defaultConfigOverwrite:
       policy.yaml: |
         # my custom policy
-    containerImage: quay.io/tripleowallabycentos9/openstack-nova-scheduler:current-tripleo
+    containerImage: quay.io/tripleozedcentos9/openstack-nova-scheduler:current-tripleo
     replicate: 3
     nodeSelector: {}
     resources:
@@ -79,7 +79,7 @@ spec:
       logging.conf: |
         # my custom logging configuration
     # TODO: what is the name of the container for metadata?
-    containerImage: quay.io/tripleowallabycentos9/openstack-nova-metadata-api:current-tripleo
+    containerImage: quay.io/tripleozedcentos9/openstack-nova-metadata-api:current-tripleo
     replicate: 3
     nodeSelector: {}
     resources:
@@ -106,7 +106,7 @@ spec:
         defaultConfigOverwrite:
           logging.conf: |
           # my custom logging configuration
-        containerImage: quay.io/tripleowallabycentos9/openstack-nova-conductor:current-tripleo
+        containerImage: quay.io/tripleozedcentos9/openstack-nova-conductor:current-tripleo
         replicate: 3
         nodeSelector: {}
         resources:
@@ -135,7 +135,7 @@ spec:
         defaultConfigOverwrite:
           logging.conf: |
           # my custom logging configuration
-        containerImage: quay.io/tripleowallabycentos9/openstack-nova-conductor:current-tripleo
+        containerImage: quay.io/tripleozedcentos9/openstack-nova-conductor:current-tripleo
         replicate: 3
         nodeSelector: {}
         resources:
@@ -156,7 +156,7 @@ spec:
         defaultConfigOverwrite:
           logging.conf: |
           # my custom logging configuration
-        containerImage: quay.io/tripleowallabycentos9/openstack-nova-novncproxy:current-tripleo
+        containerImage: quay.io/tripleozedcentos9/openstack-nova-novncproxy:current-tripleo
         replicate: 3
         nodeSelector: {}
         resources:
@@ -180,7 +180,7 @@ spec:
         defaultConfigOverwrite:
           logging.conf: |
           # my custom logging configuration
-        containerImage: quay.io/tripleowallabycentos9/openstack-nova-conductor:current-tripleo
+        containerImage: quay.io/tripleozedcentos9/openstack-nova-conductor:current-tripleo
         replicate: 3
         nodeSelector: {}
         resources:
@@ -203,7 +203,7 @@ spec:
           logging.conf: |
             # my custom logging configuration
         # TODO: what is the name of the container for metadata?
-        containerImage: quay.io/tripleowallabycentos9/openstack-nova-metadata-api:current-tripleo
+        containerImage: quay.io/tripleozedcentos9/openstack-nova-metadata-api:current-tripleo
         replicate: 3
         nodeSelector: {}
         resources:
@@ -221,7 +221,7 @@ spec:
         defaultConfigOverwrite:
           logging.conf: |
           # my custom logging configuration
-        containerImage: quay.io/tripleowallabycentos9/openstack-nova-novncproxy:current-tripleo
+        containerImage: quay.io/tripleozedcentos9/openstack-nova-novncproxy:current-tripleo
         replicate: 3
         nodeSelector: {}
         resources:

--- a/config/samples/nova_v1beta1_novaapi.yaml
+++ b/config/samples/nova_v1beta1_novaapi.yaml
@@ -25,7 +25,7 @@ spec:
   defaultConfigOverwrite:
     policy.yaml: |
       # my custom policy
-  containerImage: quay.io/tripleowallabycentos9/openstack-nova-api:current-tripleo
+  containerImage: quay.io/tripleozedcentos9/openstack-nova-api:current-tripleo
   replicas: 1
   nodeSelector: {}
   resources:

--- a/config/samples/nova_v1beta1_novacell0.yaml
+++ b/config/samples/nova_v1beta1_novacell0.yaml
@@ -34,7 +34,7 @@ spec:
     defaultConfigOverwrite:
       logging.conf: >
       # my custom logging configuration
-    containerImage: quay.io/tripleowallabycentos9/openstack-nova-conductor:current-tripleo
+    containerImage: quay.io/tripleozedcentos9/openstack-nova-conductor:current-tripleo
     replicate: 3
     nodeSelector: {}
     resources:

--- a/config/samples/nova_v1beta1_novacell1-upcall.yaml
+++ b/config/samples/nova_v1beta1_novacell1-upcall.yaml
@@ -34,7 +34,7 @@ spec:
     defaultConfigOverwrite:
       logging.conf: >
       # my custom logging configuration
-    containerImage: quay.io/tripleowallabycentos9/openstack-nova-conductor:current-tripleo
+    containerImage: quay.io/tripleozedcentos9/openstack-nova-conductor:current-tripleo
     replicate: 3
     nodeSelector: {}
     resources:
@@ -54,7 +54,7 @@ spec:
     defaultConfigOverwrite:
       logging.conf: >
       # my custom logging configuration
-    containerImage: quay.io/tripleowallabycentos9/openstack-nova-novncproxy:current-tripleo
+    containerImage: quay.io/tripleozedcentos9/openstack-nova-novncproxy:current-tripleo
     replicate: 3
     nodeSelector: {}
     resources:

--- a/config/samples/nova_v1beta1_novacell2-without-upcall.yaml
+++ b/config/samples/nova_v1beta1_novacell2-without-upcall.yaml
@@ -32,7 +32,7 @@ spec:
     defaultConfigOverwrite:
       logging.conf: >
       # my custom logging configuration
-    containerImage: quay.io/tripleowallabycentos9/openstack-nova-conductor:current-tripleo
+    containerImage: quay.io/tripleozedcentos9/openstack-nova-conductor:current-tripleo
     replicate: 3
     nodeSelector: {}
     resources:
@@ -56,7 +56,7 @@ spec:
       logging.conf: >
         # my custom logging configuration
     # TODO: what is the name of the container for metadata?
-    containerImage: quay.io/tripleowallabycentos9/openstack-nova-metadata-api:current-tripleo
+    containerImage: quay.io/tripleozedcentos9/openstack-nova-metadata-api:current-tripleo
     replicate: 3
     nodeSelector: {}
     resources:
@@ -74,7 +74,7 @@ spec:
     defaultConfigOverwrite:
       logging.conf: >
       # my custom logging configuration
-    containerImage: quay.io/tripleowallabycentos9/openstack-nova-novncproxy:current-tripleo
+    containerImage: quay.io/tripleozedcentos9/openstack-nova-novncproxy:current-tripleo
     replicate: 3
     nodeSelector: {}
     resources:

--- a/go.work.sum
+++ b/go.work.sum
@@ -168,6 +168,7 @@ github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9k
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/ginkgo/v2 v2.1.4/go.mod h1:um6tUpWM/cxCK3/FK8BXqEiUMUwRgSM4JXG47RKZmLU=
 github.com/onsi/ginkgo/v2 v2.1.6/go.mod h1:MEH45j8TBi6u9BMogfbp0stKC5cdGjumZj5Y7AG4VIk=
+github.com/onsi/ginkgo/v2 v2.5.0/go.mod h1:Luc4sArBICYCS8THh8v3i3i5CuSZO+RaQRaJoeNwomw=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
@@ -248,10 +249,12 @@ go.opentelemetry.io/otel/sdk/export/metric v0.20.0/go.mod h1:h7RBNMsDJ5pmI1zExLi
 go.opentelemetry.io/otel/sdk/metric v0.20.0/go.mod h1:knxiS8Xd4E/N+ZqKmUPf3gTTZ4/0TjTXukfxjzSTpHE=
 go.opentelemetry.io/otel/trace v0.20.0/go.mod h1:6GjCW8zgDjwGHGa6GkyeB8+/5vjT16gUEi0Nf1iBdgw=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
+go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/goleak v1.1.12/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.17.0/go.mod h1:MXVU+bhUf/A7Xi2HNOnopQOrmycQ5Ih87HtOu4q5SSo=
+go.uber.org/zap v1.21.0/go.mod h1:wjWOCqI0f2ZZrJF/UufIOkiC8ii6tm1iqIsLo76RfJw=
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=


### PR DESCRIPTION
this change updates the default images in the crds
api types and samples to use centos 9 zed images.
