### PR TITLE
Imporve linting

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -43,3 +43,16 @@ jobs:
         with:
           version: latest
           args: --timeout 5m
+
+  operator-lint:
+    name: operator-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.18.x
+      - name: Checkout project code
+        uses: actions/checkout@v2
+      - name: Run operator-lint
+        run: make operator-lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,16 +16,19 @@ repos:
       language: system
       entry: make
       args: ['manifests']
+      pass_filenames: false
     - id: make-generate
       name: make-generate
       language: system
       entry: make
       args: ['generate']
+      pass_filenames: false
     - id: make-operator-lint
       name: make-operator-lint
       language: system
       entry: make
       args: ['operator-lint']
+      pass_filenames: false
 
 - repo: https://github.com/dnephin/pre-commit-golang
   rev: v0.5.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,7 @@ ci:
    - 'go-vet'
    - 'golangci-lint'
    - 'go-lint'
+   - 'make-operator-lint'
 
 repos:
 - repo: local
@@ -20,6 +21,11 @@ repos:
       language: system
       entry: make
       args: ['generate']
+    - id: make-operator-lint
+      name: make-operator-lint
+      language: system
+      entry: make
+      args: ['operator-lint']
 
 - repo: https://github.com/dnephin/pre-commit-golang
   rev: v0.5.1

--- a/Makefile
+++ b/Makefile
@@ -282,3 +282,8 @@ golint: get-ci-tools
 .PHONY: test_crc
 test_crc: manifests generate fmt vet envtest ## Run tests against a deployed CRC cluster
 	USE_EXISTING_CLUSTER=true go test ./... -coverpkg=./controllers -coverprofile cover.out
+
+.PHONY: operator-lint
+operator-lint: ## Runs operator-lint
+	GOBIN=$(LOCALBIN) go install github.com/gibizer/operator-lint@latest
+	go vet -vettool=$(LOCALBIN)/operator-lint ./... ./api/...

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,7 @@ fmt: ## Run go fmt against code.
 .PHONY: vet
 vet: ## Run go vet against code.
 	go vet ./...
+	go vet ./api/...
 
 PROCS?=$(shell expr $(shell nproc --ignore 2) / 2)
 PROC_CMD = --procs ${PROCS}
@@ -256,22 +257,27 @@ get-ci-tools:
 # Run go fmt against code
 gofmt: get-ci-tools
 	$(CI_TOOLS_REPO_DIR)/test-runner/gofmt.sh
+	$(CI_TOOLS_REPO_DIR)/test-runner/gofmt.sh ./api
 
 # Run go vet against code
 govet: get-ci-tools
 	GOWORK=off $(CI_TOOLS_REPO_DIR)/test-runner/govet.sh
+	GOWORK=off $(CI_TOOLS_REPO_DIR)/test-runner/govet.sh ./api
 
 # Run go test against code
 gotest: get-ci-tools
 	GOWORK=off $(CI_TOOLS_REPO_DIR)/test-runner/gotest.sh
+	GOWORK=off $(CI_TOOLS_REPO_DIR)/test-runner/gotest.sh ./api
 
 # Run golangci-lint test against code
 golangci: get-ci-tools
 	GOWORK=off $(CI_TOOLS_REPO_DIR)/test-runner/golangci.sh
+	GOWORK=off $(CI_TOOLS_REPO_DIR)/test-runner/golangci.sh ./api
 
 # Run go lint against code
 golint: get-ci-tools
 	export GOWORK=off && PATH=$(GOBIN):$(PATH); $(CI_TOOLS_REPO_DIR)/test-runner/golint.sh
+	export GOWORK=off && PATH=$(GOBIN):$(PATH); $(CI_TOOLS_REPO_DIR)/test-runner/golint.sh ./api
 
 .PHONY: test_crc
 test_crc: manifests generate fmt vet envtest ## Run tests against a deployed CRC cluster

--- a/api/v1beta1/novaconductor_types.go
+++ b/api/v1beta1/novaconductor_types.go
@@ -69,12 +69,12 @@ type NovaConductorSpec struct {
 
 	// +kubebuilder:validation:Required
 	// CellName is the name of the Nova Cell this conductor belongs to.
-	CellName string `json:"cellName,omitempty"`
+	CellName string `json:"cellName"`
 
 	// +kubebuilder:validation:Required
 	// Secret is the name of the Secret instance containing password
 	// information for the nova-conductor service.
-	Secret string `json:"secret,omitempty"`
+	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
 	// PasswordSelectors - Field names to identify the passwords from the

--- a/api/v1beta1/novametadata_types.go
+++ b/api/v1beta1/novametadata_types.go
@@ -75,7 +75,7 @@ type NovaMetadataSpec struct {
 	// +kubebuilder:validation:Required
 	// Secret is the name of the Secret instance containing password
 	// information for the nova-conductor service.
-	Secret string `json:"secret,omitempty"`
+	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
 	// PasswordSelectors - Field names to identify the passwords from the

--- a/api/v1beta1/novanovncproxy_types.go
+++ b/api/v1beta1/novanovncproxy_types.go
@@ -69,12 +69,12 @@ type NovaNoVNCProxySpec struct {
 
 	// +kubebuilder:validation:Required
 	// CellName is the name of the Nova Cell this novncproxy belongs to.
-	CellName string `json:"cellName,omitempty"`
+	CellName string `json:"cellName"`
 
 	// +kubebuilder:validation:Required
 	// Secret is the name of the Secret instance containing password
 	// information for the nova-conductor service.
-	Secret string `json:"secret,omitempty"`
+	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
 	// PasswordSelectors - Field names to identify the passwords from the

--- a/api/v1beta1/novascheduler_types.go
+++ b/api/v1beta1/novascheduler_types.go
@@ -70,7 +70,7 @@ type NovaSchedulerSpec struct {
 	// +kubebuilder:validation:Required
 	// Secret is the name of the Secret instance containing password
 	// information for the nova-scheduler sevice.
-	Secret string `json:"secret,omitempty"`
+	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
 	// PasswordSelectors - Field names to identify the passwords from the

--- a/config/crd/bases/nova.openstack.org_nova.yaml
+++ b/config/crd/bases/nova.openstack.org_nova.yaml
@@ -554,6 +554,7 @@ spec:
                 required:
                 - containerImage
                 - keystoneAuthURL
+                - secret
                 type: object
               passwordSelectors:
                 description: PasswordSelectors - Selectors to identify the DB and
@@ -736,6 +737,7 @@ spec:
                 - apiMessageBusHostname
                 - containerImage
                 - keystoneAuthURL
+                - secret
                 type: object
               secret:
                 description: Secret is the name of the Secret instance containing

--- a/config/crd/bases/nova.openstack.org_novaconductors.yaml
+++ b/config/crd/bases/nova.openstack.org_novaconductors.yaml
@@ -217,7 +217,9 @@ spec:
                   to register in keystone
                 type: string
             required:
+            - cellName
             - containerImage
+            - secret
             type: object
           status:
             description: NovaConductorStatus defines the observed state of NovaConductor

--- a/config/crd/bases/nova.openstack.org_novametadata.yaml
+++ b/config/crd/bases/nova.openstack.org_novametadata.yaml
@@ -202,6 +202,7 @@ spec:
             required:
             - containerImage
             - keystoneAuthURL
+            - secret
             type: object
           status:
             description: NovaMetadataStatus defines the observed state of NovaMetadata

--- a/config/crd/bases/nova.openstack.org_novanovncproxies.yaml
+++ b/config/crd/bases/nova.openstack.org_novanovncproxies.yaml
@@ -177,8 +177,10 @@ spec:
                 type: string
             required:
             - cellDatabaseHostname
+            - cellName
             - containerImage
             - keystoneAuthURL
+            - secret
             type: object
           status:
             description: NovaNoVNCProxyStatus defines the observed state of NovaNoVNCProxy

--- a/config/crd/bases/nova.openstack.org_novaschedulers.yaml
+++ b/config/crd/bases/nova.openstack.org_novaschedulers.yaml
@@ -185,6 +185,7 @@ spec:
             - apiMessageBusHostname
             - containerImage
             - keystoneAuthURL
+            - secret
             type: object
           status:
             description: NovaSchedulerStatus defines the observed state of NovaScheduler


### PR DESCRIPTION
1. ensuring normal linting runs on the `api` module as well
2. introduce `operator-lint` [1] target and local pre-commit hook to check for operator development specific rule violations.
3. run operator-lint in github workflow
4. fix rule violations.

[1] https://github.com/gibizer/operator-lint