### PR TITLE
[EnvTest]Do not run against real cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -279,10 +279,6 @@ golint: get-ci-tools
 	export GOWORK=off && PATH=$(GOBIN):$(PATH); $(CI_TOOLS_REPO_DIR)/test-runner/golint.sh
 	export GOWORK=off && PATH=$(GOBIN):$(PATH); $(CI_TOOLS_REPO_DIR)/test-runner/golint.sh ./api
 
-.PHONY: test_crc
-test_crc: manifests generate fmt vet envtest ## Run tests against a deployed CRC cluster
-	USE_EXISTING_CLUSTER=true go test ./... -coverpkg=./controllers -coverprofile cover.out
-
 .PHONY: operator-lint
 operator-lint: ## Runs operator-lint
 	GOBIN=$(LOCALBIN) go install github.com/gibizer/operator-lint@latest

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -222,10 +222,6 @@ func ListJobs(namespace string) *batchv1.JobList {
 func SimulateJobFailure(name types.NamespacedName) {
 	Eventually(func(g Gomega) {
 		job := GetJob(name)
-
-		// NOTE(gibi) when run against a real env we need to find a
-		// better way to make the job fail. This works but it is unreal.
-
 		// Simulate that the job is failed
 		job.Status.Failed = 1
 		job.Status.Active = 0
@@ -239,12 +235,6 @@ func SimulateJobSuccess(name types.NamespacedName) {
 	Eventually(func(g Gomega) {
 
 		job := GetJob(name)
-		// NOTE(gibi): We don't need to do this when run against a real
-		// env as there the job could run successfully automatically if the
-		// database user is registered manually in the DB service. But for that
-		// we would need another set of test setup, i.e. deploying the
-		// mariadb-operator.
-
 		// Simulate that the job is succeeded
 		job.Status.Succeeded = 1
 		job.Status.Active = 0
@@ -272,11 +262,6 @@ func ListDeployments(namespace string) *appsv1.DeploymentList {
 func SimulateDeploymentReplicaReady(name types.NamespacedName) {
 	Eventually(func(g Gomega) {
 		deployment := GetDeployment(name)
-		// NOTE(gibi): We don't need to do this when run against a real
-		// env as there the deployment could reach the ready state automatically.
-		// But for that  we would need another set of test setup, i.e. deploying
-		// the mariadb-operator.
-
 		deployment.Status.Replicas = 1
 		deployment.Status.ReadyReplicas = 1
 		g.Expect(k8sClient.Status().Update(ctx, deployment)).To(Succeed())

--- a/test/functional/novaapi_controller_test.go
+++ b/test/functional/novaapi_controller_test.go
@@ -316,10 +316,6 @@ var _ = Describe("NovaAPI controller", func() {
 
 		When("the StatefulSet has at least one Replica ready", func() {
 			BeforeEach(func() {
-				th.SkipInExistingCluster(
-					"Deployment never finishes in a real env as dependencies like" +
-						"ServiceAccount is missing",
-				)
 				ExpectConditionWithDetails(
 					novaAPIName,
 					conditionGetterFunc(NovaAPIConditionGetter),


### PR DESCRIPTION
We agreed to use the EnvTests to run against kube-apiserver instead of a full cluster. So this patch removes the (broken) possibility to run against real cluster.

Testing against a real cluster will be done with a kuttl based test env.

Closes: #78