### PR TITLE
Default Nova.cellTemplates to create cell0

### DIFF
--- a/api/v1beta1/nova_types.go
+++ b/api/v1beta1/nova_types.go
@@ -29,12 +29,14 @@ type NovaSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=keystone
 	// KeystoneInstance to name of the KeystoneAPI CR to select the Service
 	// instance used by the Nova services to authenticate.
 	KeystoneInstance string `json:"keystoneInstance"`
 
-	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=openstack
 	// APIDatabaseInstance is the name of the MariaDB CR to select the DB
 	// Service instance used for the Nova API DB.
 	APIDatabaseInstance string `json:"apiDatabaseInstance"`
@@ -45,7 +47,8 @@ type NovaSpec struct {
 	// communicate.
 	APIMessageBusInstance string `json:"apiMessageBusInstance"`
 
-	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default={cell0: {cellDatabaseInstance: openstack, cellDatabaseUser: nova_cell0, cellMessageBusInstance: unused, hasAPIAccess: true, conductorServiceTemplate: {containerImage: "quay.io/tripleowallabycentos9/openstack-nova-conductor:current-tripleo"}}}
 	// Cells is a mapping of cell names to NovaCellTemplate objects defining
 	// the cells in the deployment. The "cell0" cell is a mandatory cell in
 	// every deployment. Moreover any real deployment needs at least one
@@ -58,7 +61,7 @@ type NovaSpec struct {
 	ServiceUser string `json:"serviceUser,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="nova"
+	// +kubebuilder:default="nova_api"
 	// APIDatabaseUser - username to use when accessing the API DB
 	APIDatabaseUser string `json:"apiDatabaseUser,omitempty"`
 

--- a/api/v1beta1/nova_types.go
+++ b/api/v1beta1/nova_types.go
@@ -41,7 +41,8 @@ type NovaSpec struct {
 	// Service instance used for the Nova API DB.
 	APIDatabaseInstance string `json:"apiDatabaseInstance"`
 
-	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=unused
 	// APIMessageBusInstance is the name of the RabbitMqCluster CR to select
 	// the Message Bus Service instance used by the Nova top level services to
 	// communicate.
@@ -76,6 +77,7 @@ type NovaSpec struct {
 	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default={service: NovaPassword, apiDatabase: NovaAPIDatabasePassword}
 	// PasswordSelectors - Selectors to identify the DB and ServiceUser
 	// passwords from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
@@ -87,18 +89,18 @@ type NovaSpec struct {
 	Debug Debug `json:"debug,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:type=NovaAPITemplate
+	// +kubebuilder:default={containerImage: "quay.io/tripleowallabycentos9/openstack-nova-api:current-tripleo"}
 	// APIServiceTemplate - define the nova-api service
-	APIServiceTemplate NovaAPITemplate `json:"apiServiceTemplate,omitempty"`
+	APIServiceTemplate NovaAPITemplate `json:"apiServiceTemplate"`
 
 	// +kubebuilder:validation:Optional
 	// SchedulerServiceTemplate- define the nova-scheduler service
-	SchedulerServiceTemplate NovaSchedulerSpec `json:"schedulerServiceTemplate,omitempty"`
+	SchedulerServiceTemplate NovaSchedulerTemplate `json:"schedulerServiceTemplate"`
 
 	// +kubebuilder:validation:Optional
 	// MetadataServiceTemplate - defines the metadata service that is global for the
 	// deployment serving all the cells.
-	MetadataServiceTemplate NovaMetadataSpec `json:"metadataServiceTemplate,omitempty"`
+	MetadataServiceTemplate NovaMetadataTemplate `json:"metadataServiceTemplate"`
 }
 
 // NovaStatus defines the observed state of Nova

--- a/api/v1beta1/novacell_types.go
+++ b/api/v1beta1/novacell_types.go
@@ -28,7 +28,8 @@ import (
 // NovaCellTemplate defines the input parameters specified by the user to
 // create a NovaCell via higher level CRDs.
 type NovaCellTemplate struct {
-	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=openstack
 	// CellDatabaseInstance is the name of the MariaDB CR to select the DB
 	// Service instance used as the DB of this cell.
 	CellDatabaseInstance string `json:"cellDatabaseInstance"`
@@ -37,7 +38,8 @@ type NovaCellTemplate struct {
 	// CellDatabaseUser - username to use when accessing the give cell DB
 	CellDatabaseUser string `json:"cellDatabaseUser"`
 
-	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=unused
 	// CellMessageBusInstance is the name of the RabbitMqCluster CR to select
 	// the Message Bus Service instance used by the nova services to
 	// communicate in this cell.
@@ -49,16 +51,15 @@ type NovaCellTemplate struct {
 	HasAPIAccess bool `json:"hasAPIAccess"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default={containerImage: "quay.io/tripleowallabycentos9/openstack-nova-conductor:current-tripleo"}
 	// ConductorServiceTemplate - defines the cell conductor deployment for the cell.
 	ConductorServiceTemplate NovaConductorTemplate `json:"conductorServiceTemplate"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={}
 	// MetadataServiceTemplate - defines the metadata serive dedicated for the cell.
 	MetadataServiceTemplate NovaMetadataTemplate `json:"metadataServiceTemplate"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={}
 	// NoVNCProxyServiceTemplate - defines the novvncproxy serive dedicated for
 	// the cell.
 	NoVNCProxyServiceTemplate NovaNoVNCProxyTemplate `json:"noVNCProxyServiceTemplate"`

--- a/api/v1beta1/novacell_types.go
+++ b/api/v1beta1/novacell_types.go
@@ -33,10 +33,9 @@ type NovaCellTemplate struct {
 	// Service instance used as the DB of this cell.
 	CellDatabaseInstance string `json:"cellDatabaseInstance"`
 
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="nova"
+	// +kubebuilder:validation:Required
 	// CellDatabaseUser - username to use when accessing the give cell DB
-	CellDatabaseUser string `json:"cellDatabaseUser,omitempty"`
+	CellDatabaseUser string `json:"cellDatabaseUser"`
 
 	// +kubebuilder:validation:Required
 	// CellMessageBusInstance is the name of the RabbitMqCluster CR to select
@@ -50,7 +49,6 @@ type NovaCellTemplate struct {
 	HasAPIAccess bool `json:"hasAPIAccess"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={}
 	// ConductorServiceTemplate - defines the cell conductor deployment for the cell.
 	ConductorServiceTemplate NovaConductorTemplate `json:"conductorServiceTemplate"`
 

--- a/config/crd/bases/nova.openstack.org_nova.yaml
+++ b/config/crd/bases/nova.openstack.org_nova.yaml
@@ -36,11 +36,12 @@ spec:
             description: NovaSpec defines the desired state of Nova
             properties:
               apiDatabaseInstance:
+                default: openstack
                 description: APIDatabaseInstance is the name of the MariaDB CR to
                   select the DB Service instance used for the Nova API DB.
                 type: string
               apiDatabaseUser:
-                default: nova
+                default: nova_api
                 description: APIDatabaseUser - username to use when accessing the
                   API DB
                 type: string
@@ -130,7 +131,6 @@ spec:
                         cell.
                       type: string
                     cellDatabaseUser:
-                      default: nova
                       description: CellDatabaseUser - username to use when accessing
                         the give cell DB
                       type: string
@@ -343,9 +343,18 @@ spec:
                       type: object
                   required:
                   - cellDatabaseInstance
+                  - cellDatabaseUser
                   - cellMessageBusInstance
                   - hasAPIAccess
                   type: object
+                default:
+                  cell0:
+                    cellDatabaseInstance: openstack
+                    cellDatabaseUser: nova_cell0
+                    cellMessageBusInstance: unused
+                    conductorServiceTemplate:
+                      containerImage: quay.io/tripleowallabycentos9/openstack-nova-conductor:current-tripleo
+                    hasAPIAccess: true
                 description: Cells is a mapping of cell names to NovaCellTemplate
                   objects defining the cells in the deployment. The "cell0" cell is
                   a mandatory cell in every deployment. Moreover any real deployment
@@ -380,6 +389,7 @@ spec:
                     type: boolean
                 type: object
               keystoneInstance:
+                default: keystone
                 description: KeystoneInstance to name of the KeystoneAPI CR to select
                   the Service instance used by the Nova services to authenticate.
                 type: string
@@ -753,10 +763,7 @@ spec:
                   to register in keystone
                 type: string
             required:
-            - apiDatabaseInstance
             - apiMessageBusInstance
-            - cellTemplates
-            - keystoneInstance
             - secret
             type: object
           status:

--- a/config/crd/bases/nova.openstack.org_nova.yaml
+++ b/config/crd/bases/nova.openstack.org_nova.yaml
@@ -46,6 +46,7 @@ spec:
                   API DB
                 type: string
               apiMessageBusInstance:
+                default: unused
                 description: APIMessageBusInstance is the name of the RabbitMqCluster
                   CR to select the Message Bus Service instance used by the Nova top
                   level services to communicate.
@@ -56,6 +57,8 @@ spec:
                   API message bus
                 type: string
               apiServiceTemplate:
+                default:
+                  containerImage: quay.io/tripleowallabycentos9/openstack-nova-api:current-tripleo
                 description: APIServiceTemplate - define the nova-api service
                 properties:
                   containerImage:
@@ -126,6 +129,7 @@ spec:
                     by the user to create a NovaCell via higher level CRDs.
                   properties:
                     cellDatabaseInstance:
+                      default: openstack
                       description: CellDatabaseInstance is the name of the MariaDB
                         CR to select the DB Service instance used as the DB of this
                         cell.
@@ -135,11 +139,14 @@ spec:
                         the give cell DB
                       type: string
                     cellMessageBusInstance:
+                      default: unused
                       description: CellMessageBusInstance is the name of the RabbitMqCluster
                         CR to select the Message Bus Service instance used by the
                         nova services to communicate in this cell.
                       type: string
                     conductorServiceTemplate:
+                      default:
+                        containerImage: quay.io/tripleowallabycentos9/openstack-nova-conductor:current-tripleo
                       description: ConductorServiceTemplate - defines the cell conductor
                         deployment for the cell.
                       properties:
@@ -342,9 +349,7 @@ spec:
                           type: object
                       type: object
                   required:
-                  - cellDatabaseInstance
                   - cellDatabaseUser
-                  - cellMessageBusInstance
                   - hasAPIAccess
                   type: object
                 default:
@@ -397,44 +402,8 @@ spec:
                 description: MetadataServiceTemplate - defines the metadata service
                   that is global for the deployment serving all the cells.
                 properties:
-                  apiDatabaseHostname:
-                    description: 'APIDatabaseHostname - hostname to use when accessing
-                      the API DB. This filed is Required if the CellName is not provided
-                      TODO(gibi): Add a webhook to validate the CellName constraint'
-                    type: string
-                  apiDatabaseUser:
-                    default: nova
-                    description: APIDatabaseUser - username to use when accessing
-                      the API DB
-                    type: string
-                  cellDatabaseHostname:
-                    description: 'CellDatabaseHostname - hostname to use when accessing
-                      the cell DB This is unused if CellName is not provided. But
-                      if it is provided then CellDatabaseHostName is also Required.
-                      TODO(gibi): add webhook to validate this CellName constraint'
-                    type: string
-                  cellDatabaseUser:
-                    default: nova
-                    description: CellDatabaseUser - username to use when accessing
-                      the cell DB
-                    type: string
-                  cellMessageBusHostname:
-                    description: 'CellMessageBusHostname - hostname to use when accessing
-                      the cell message bus. This is unused if CellName is not provided.
-                      But if it is provided then CellMessageBusHostname is required.
-                      TODO(gibi): add webhook to validate this CellName constraint'
-                    type: string
-                  cellMessageBusUser:
-                    default: nova
-                    description: CellMessageBusUser - username to use when accessing
-                      the cell message bus
-                    type: string
-                  cellName:
-                    description: CellName is the name of the Nova Cell this metadata
-                      service belongs to. If not provided then the metadata serving
-                      every cells in the deployment
-                    type: string
                   containerImage:
+                    default: quay.io/tripleowallabycentos9/openstack-nova-metadata:current-tripleo
                     description: The service specific Container Image URL
                     type: string
                   customServiceConfig:
@@ -445,79 +414,19 @@ spec:
                       content gets added to to /etc/<service>/<service>.conf.d directory
                       as custom.conf file.
                     type: string
-                  debug:
-                    description: Debug - enable debug for different deploy stages.
-                      If an init container is used, it runs and the actual action
-                      pod gets started with sleep infinity
-                    properties:
-                      preserveJobs:
-                        default: false
-                        description: PreserveJobs - do not delete jobs after they
-                          finished e.g. to check logs
-                        type: boolean
-                      stopDBSync:
-                        default: false
-                        description: 'StopDBSync allows stopping the init container
-                          before running db sync to apply the DB schema QUESTION(gibi):
-                          Not all CR will run dbsync, should we have per CR Debug
-                          struct or keep this generic one and ignore fields in the
-                          controller that are not applicable'
-                        type: boolean
-                      stopService:
-                        default: false
-                        description: 'StopService allows stopping the service container
-                          before staring the openstack service binary QUESTION(gibi):
-                          Not all CR will run a service, should we have per CR Debug
-                          struct or keep this generic one and ignore fields in the
-                          controller that are not applicable'
-                        type: boolean
-                    type: object
                   defaultConfigOverwrite:
                     additionalProperties:
                       type: string
                     description: ConfigOverwrite - interface to overwrite default
-                      config files like e.g. logging.conf or policy.json. But can
-                      also be used to add additional files. Those get added to the
-                      service config dir in /etc/<service> .
+                      config files like e.g. logging.conf But can also be used to
+                      add additional files. Those get added to the service config
+                      dir in /etc/<service> .
                     type: object
-                  keystoneAuthURL:
-                    description: KeystoneAuthURL - the URL that the nova-metadata
-                      service can use to talk to keystone
-                    type: string
                   nodeSelector:
                     additionalProperties:
                       type: string
                     description: NodeSelector to target subset of worker nodes running
                       this service
-                    type: object
-                  passwordSelectors:
-                    description: PasswordSelectors - Field names to identify the passwords
-                      from the Secret
-                    properties:
-                      apiDatabase:
-                        default: NovaAPIDatabasePassword
-                        description: APIDatabase - the name of the field to get the
-                          API DB password from the Secret
-                        type: string
-                      apiMessageBus:
-                        default: NovaAPIMessageBusPassword
-                        description: APIMessageBus - the name of the field to get
-                          the API message bus password from the Secret
-                        type: string
-                      cellDatabase:
-                        default: NovaCell0DatabasePassword
-                        description: CellDatabase - the name of the field to get the
-                          Cell DB password from the Secret
-                        type: string
-                      cellMessageBus:
-                        description: CellMessageBus - the name of the field to get
-                          the API message bus password from the Secret
-                        type: string
-                      service:
-                        default: NovaPassword
-                        description: Service - Selector to get the keystone service
-                          user password from the Secret
-                        type: string
                     type: object
                   replicas:
                     default: 1
@@ -553,21 +462,11 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
-                  secret:
-                    description: Secret is the name of the Secret instance containing
-                      password information for the nova-conductor service.
-                    type: string
-                  serviceUser:
-                    default: nova
-                    description: ServiceUser - optional username used for this service
-                      to register in keystone
-                    type: string
-                required:
-                - containerImage
-                - keystoneAuthURL
-                - secret
                 type: object
               passwordSelectors:
+                default:
+                  apiDatabase: NovaAPIDatabasePassword
+                  service: NovaPassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser passwords from the Secret
                 properties:
@@ -599,25 +498,8 @@ spec:
               schedulerServiceTemplate:
                 description: SchedulerServiceTemplate- define the nova-scheduler service
                 properties:
-                  apiDatabaseHostname:
-                    description: APIDatabaseHostname - hostname to use when accessing
-                      the API DB
-                    type: string
-                  apiDatabaseUser:
-                    default: nova
-                    description: APIDatabaseUser - username to use when accessing
-                      the API DB
-                    type: string
-                  apiMessageBusHostname:
-                    description: APIMessageBusHostname - hostname to use when accessing
-                      the API message bus
-                    type: string
-                  apiMessageBusUser:
-                    default: nova
-                    description: APIMessageBusUser - username to use when accessing
-                      the API message bus
-                    type: string
                   containerImage:
+                    default: quay.io/tripleowallabycentos9/openstack-nova-scheduler:current-tripleo
                     description: The service specific Container Image URL
                     type: string
                   customServiceConfig:
@@ -628,79 +510,19 @@ spec:
                       content gets added to to /etc/<service>/<service>.conf.d directory
                       as custom.conf file.
                     type: string
-                  debug:
-                    description: Debug - enable debug for different deploy stages.
-                      If an init container is used, it runs and the actual action
-                      pod gets started with sleep infinity
-                    properties:
-                      preserveJobs:
-                        default: false
-                        description: PreserveJobs - do not delete jobs after they
-                          finished e.g. to check logs
-                        type: boolean
-                      stopDBSync:
-                        default: false
-                        description: 'StopDBSync allows stopping the init container
-                          before running db sync to apply the DB schema QUESTION(gibi):
-                          Not all CR will run dbsync, should we have per CR Debug
-                          struct or keep this generic one and ignore fields in the
-                          controller that are not applicable'
-                        type: boolean
-                      stopService:
-                        default: false
-                        description: 'StopService allows stopping the service container
-                          before staring the openstack service binary QUESTION(gibi):
-                          Not all CR will run a service, should we have per CR Debug
-                          struct or keep this generic one and ignore fields in the
-                          controller that are not applicable'
-                        type: boolean
-                    type: object
                   defaultConfigOverwrite:
                     additionalProperties:
                       type: string
                     description: ConfigOverwrite - interface to overwrite default
-                      config files like e.g. logging.conf or policy.json. But can
-                      also be used to add additional files. Those get added to the
-                      service config dir in /etc/<service> .
+                      config files like e.g. logging.conf But can also be used to
+                      add additional files. Those get added to the service config
+                      dir in /etc/<service> .
                     type: object
-                  keystoneAuthURL:
-                    description: KeystoneAuthURL - the URL that the nova-scheduler
-                      service can use to talk to keystone
-                    type: string
                   nodeSelector:
                     additionalProperties:
                       type: string
                     description: NodeSelector to target subset of worker nodes running
                       this service
-                    type: object
-                  passwordSelectors:
-                    description: PasswordSelectors - Field names to identify the passwords
-                      from the Secret
-                    properties:
-                      apiDatabase:
-                        default: NovaAPIDatabasePassword
-                        description: APIDatabase - the name of the field to get the
-                          API DB password from the Secret
-                        type: string
-                      apiMessageBus:
-                        default: NovaAPIMessageBusPassword
-                        description: APIMessageBus - the name of the field to get
-                          the API message bus password from the Secret
-                        type: string
-                      cellDatabase:
-                        default: NovaCell0DatabasePassword
-                        description: CellDatabase - the name of the field to get the
-                          Cell DB password from the Secret
-                        type: string
-                      cellMessageBus:
-                        description: CellMessageBus - the name of the field to get
-                          the API message bus password from the Secret
-                        type: string
-                      service:
-                        default: NovaPassword
-                        description: Service - Selector to get the keystone service
-                          user password from the Secret
-                        type: string
                     type: object
                   replicas:
                     default: 1
@@ -736,21 +558,6 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
-                  secret:
-                    description: Secret is the name of the Secret instance containing
-                      password information for the nova-scheduler sevice.
-                    type: string
-                  serviceUser:
-                    default: nova
-                    description: ServiceUser - optional username used for this service
-                      to register in keystone
-                    type: string
-                required:
-                - apiDatabaseHostname
-                - apiMessageBusHostname
-                - containerImage
-                - keystoneAuthURL
-                - secret
                 type: object
               secret:
                 description: Secret is the name of the Secret instance containing
@@ -763,7 +570,6 @@ spec:
                   to register in keystone
                 type: string
             required:
-            - apiMessageBusInstance
             - secret
             type: object
           status:

--- a/config/samples/nova_v1beta1_nova.yaml
+++ b/config/samples/nova_v1beta1_nova.yaml
@@ -3,10 +3,7 @@ kind: Nova
 metadata:
   name: nova
 spec:
-  apiDatabaseInstance: openstack
-  apiDatabaseUser: nova_api
   apiMessageBusInstance: not-implemented-yet
-  keystoneInstance: keystone
   secret: osp-secret
   # NOTE(gibi): defaulting structs only work if we provide {} value. If the
   # field is left out then it will not be defaulted.

--- a/config/samples/nova_v1beta1_nova.yaml
+++ b/config/samples/nova_v1beta1_nova.yaml
@@ -3,47 +3,12 @@ kind: Nova
 metadata:
   name: nova
 spec:
-  apiMessageBusInstance: not-implemented-yet
   secret: osp-secret
-  # NOTE(gibi): defaulting structs only work if we provide {} value. If the
-  # field is left out then it will not be defaulted.
-  passwordSelectors: {}
-  # NOTE(gibi): if apiServiceTemplate and schedlerServiceTemplate is not
-  # specified still a CRs for those services are created with default
-  # configuration.
-  # NOTE(gibi): I don't see a way to define the apiServiceTemplate field with
-  # kubebuilder to get a properly defaulted ApiServiceTemplate struct if the
-  # apiServiceTemplate is not provided here.
-  apiServiceTemplate: {}
-  # NOTE(gibi): We are not passing a Secret to the NovaAPI here any more. Nova
-  # controller will push a Secret to NovaAPI CR automatically and NovaAPI will
-  # hardcode which fields it will look at in that Secret.
-  # TODO(gibi): Refactor secret handling that i) allows using Secret + field
-  # selectors on the Nova CR level, but the NovaAPI CR should only take a
-  # single Secret and no field selectors (i.e. field selectors will be
-  # hardcoded). ii) The Nova CR should generate a separate Secret object to
-  # NovaAPI. iii) Add usernames to the generated Secret.
-  # NOTE(gibi): The ContainerImage, Replicas, NodeSelector,
-  # CustomServiceConfig, DefaultConfigOverwrite, Resources are customizable
-  # here but nothing else. Also all these fields has a meaningful default
-  # value.
   cellTemplates:
     cell0:
-      cellDatabaseInstance: openstack
       cellDatabaseUser: nova_cell0
-      cellMessageBusInstance: not-implemented-yet
       # cell0 always needs API access as it hosts the super conductor
       hasAPIAccess: true
-      conductorServiceTemplate: {}
-      # we never need a metadata service in cell0 as there are no computes there
-      # and we need to
-      metadataServiceTemplate: null
-      # we never need novncproxy service in cell0
-      noVNCProxyServiceTemplate: null
-    # this is currently not deployed
     cell1:
-      cellDatabaseInstance: openstack
       cellDatabaseUser: nova_cell1
-      cellMessageBusInstance: not-implemented-yet
       hasAPIAccess: true
-      conductorServiceTemplate: {}

--- a/config/samples/nova_v1beta1_nova_only_cell0.yaml
+++ b/config/samples/nova_v1beta1_nova_only_cell0.yaml
@@ -3,11 +3,7 @@ kind: Nova
 metadata:
   name: nova
 spec:
-  apiDatabaseInstance: openstack
-  # This is a MariaDB limitation that the DB user is always the name of the DB
-  apiDatabaseUser: nova_api
   apiMessageBusInstance: default-security-context
-  keystoneInstance: keystone
   secret: osp-secret
   # NOTE(gibi): defaulting structs only work if we provide {} value. If the
   # field is left out then it will not be defaulted.
@@ -27,18 +23,3 @@ spec:
   # single Secret and no field selectors (i.e. field selectors will be
   # hardcoded). ii) The Nova CR should generate a separate Secret object to
   # NovaAPI. iii) Add usernames to the generated Secret.
-  # NOTE(gibi): The ContainerImage, Replicas, NodeSelector,
-  # CustomServiceConfig, DefaultConfigOverwrite, Resources are customizable
-  # here but nothing else. Also all these fields has a meaningful default
-  # value.
-  cellTemplates:
-    cell0:
-      cellDatabaseInstance: openstack
-      # This is a MariaDB limitation that the DB user is always the name of the DB
-      cellDatabaseUser: nova_cell0
-      # NOTE(gibi): cell0 has no message bus but all the other cells requires
-      # message bus so it is a required field today.
-      cellMessageBusInstance: unused
-      # NOTE(gibi): it is unused today, we might not need it later either
-      hasAPIAccess: true
-      conductorServiceTemplate: {}

--- a/config/samples/nova_v1beta1_nova_only_cell0.yaml
+++ b/config/samples/nova_v1beta1_nova_only_cell0.yaml
@@ -3,23 +3,4 @@ kind: Nova
 metadata:
   name: nova
 spec:
-  apiMessageBusInstance: default-security-context
   secret: osp-secret
-  # NOTE(gibi): defaulting structs only work if we provide {} value. If the
-  # field is left out then it will not be defaulted.
-  passwordSelectors: {}
-  # NOTE(gibi): if apiServiceTemplate and schedlerServiceTemplate is not
-  # specified still a CRs for those services are created with default
-  # configuration.
-  # NOTE(gibi): I don't see a way to define the apiServiceTemplate field with
-  # kubebuilder to get a properly defaulted ApiServiceTemplate struct if the
-  # apiServiceTemplate is not provided here.
-  apiServiceTemplate: {}
-  # NOTE(gibi): We are not passing a Secret to the NovaAPI here any more. Nova
-  # controller will push a Secret to NovaAPI CR automatically and NovaAPI will
-  # hardcode which fields it will look at in that Secret.
-  # TODO(gibi): Refactor secret handling that i) allows using Secret + field
-  # selectors on the Nova CR level, but the NovaAPI CR should only take a
-  # single Secret and no field selectors (i.e. field selectors will be
-  # hardcoded). ii) The Nova CR should generate a separate Secret object to
-  # NovaAPI. iii) Add usernames to the generated Secret.

--- a/test/functional/nova_controller_test.go
+++ b/test/functional/nova_controller_test.go
@@ -415,7 +415,7 @@ var _ = Describe("Nova controller", func() {
 				ContainSubstring("[database]\nconnection = mysql+pymysql://nova:12345678@hostname-for-db-for-cell0/nova"),
 			)
 			Expect(configDataMap.Data["01-nova.conf"]).To(
-				ContainSubstring("[api_database]\nconnection = mysql+pymysql://nova:12345678@hostname-for-db-for-api/nova"),
+				ContainSubstring("[api_database]\nconnection = mysql+pymysql://nova_api:12345678@hostname-for-db-for-api/nova_api"),
 			)
 
 			SimulateStatefulSetReplicaReady(novaAPIdeploymentName)

--- a/test/functional/nova_multicell_test.go
+++ b/test/functional/nova_multicell_test.go
@@ -232,7 +232,7 @@ var _ = Describe("Nova controller", func() {
 				ContainSubstring("[database]\nconnection = mysql+pymysql://nova:12345678@hostname-for-db-for-api/nova"),
 			)
 			Expect(configDataMap.Data["01-nova.conf"]).To(
-				ContainSubstring("[api_database]\nconnection = mysql+pymysql://nova:12345678@hostname-for-db-for-api/nova"),
+				ContainSubstring("[api_database]\nconnection = mysql+pymysql://nova_api:12345678@hostname-for-db-for-api/nova_api"),
 			)
 
 			SimulateStatefulSetReplicaReady(novaAPIdeploymentName)


### PR DESCRIPTION
1. Default cellTemplates to have cell0 deployed if nothing is defined.
2. Made extra defaulting to further reduce minimum sample needed to define Nova with cell0 or even with multiple cells. 

As a result:
- Minimal config that results in a Nova deployment with cell0: [config/samples/nova_v1beta1_nova_only_cell0.yaml](https://github.com/gibizer/nova-operator/blob/2c5f332a0547460b79710ae1e327e0ba7be5bd72/config/samples/nova_v1beta1_nova_only_cell0.yaml)
- Minimal config that results in a Nova deployment with both cell0 and cell1: [config/samples/nova_v1beta1_nova.yaml](https://github.com/gibizer/nova-operator/blob/2c5f332a0547460b79710ae1e327e0ba7be5bd72/config/samples/nova_v1beta1_nova.yaml)

Partially fixes: #134
