### PR TITLE
[NovaAPI]Fix config template

### DIFF
--- a/templates/nova.conf
+++ b/templates/nova.conf
@@ -36,10 +36,10 @@ force_config_drive=True
 {{if eq .service_name "nova-api"}}
 # scaling should be done by running more pods
 osapi_compute_workers=1
-metadata_workers=0
+metadata_workers=1
 {{else if eq .service_name "nova-metadata"}}
 # scaling should be done by running more pods
-osapi_compute_workers=0
+osapi_compute_workers=1
 metadata_workers=1
 {{end}}
 
@@ -60,7 +60,7 @@ heartbeat_in_pthread=false
 
 {{ if eq .service_name "nova-api"}}
 [oslo_policy]
-enforce_new_defaults=true
+enforce_new_defaults=false
 {{end}}
 
 {{ if eq .service_name "nova-conductor"}}


### PR DESCRIPTION
The metadata and osapi worker config is changed to 1 as that is the minimum by the oslo config definition.

The enforce_new_defaults policy is set to False to keep allowing the global admin to list services. This is done to ease testing.