### PR TITLE
[NovaAPI]Sync Rabbit config

### DIFF
--- a/templates/nova.conf
+++ b/templates/nova.conf
@@ -47,8 +47,8 @@ metadata_workers=1
 lock_path = /var/lib/nova/tmp
 
 [oslo_messaging_rabbit]
-amqp_durable_queues=true
-amqp_auto_delete=true
+amqp_durable_queues=false
+amqp_auto_delete=false
 # we should consider using quorum queues instead
 # rabbit_quorum_queue=true
 {{/*we might just want to make this always false*/}}


### PR DESCRIPTION
This patch makes sure that rabbitmq config of nova-api is compatible the our RabbitMQCluster config created by install_yamls.

I opened #160 to track that we want to re-enable these at some point