### PR TITLE
add_service_db_finalizer_logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/openshift/api v3.9.0+incompatible
 	github.com/openstack-k8s-operators/keystone-operator/api v0.0.0-20221215165910-80274d6445b1
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230110110231-28368fe6a6a9
-	github.com/openstack-k8s-operators/lib-common/modules/database v0.0.0-20230110110231-28368fe6a6a9
+	github.com/openstack-k8s-operators/lib-common/modules/database v0.0.0-20230126174350-3be54a6d3263
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.0.0-20230110110231-28368fe6a6a9
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20221128124656-71e59ad7384d
 	github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20221209164002-f9e6b9363961

--- a/go.sum
+++ b/go.sum
@@ -312,8 +312,8 @@ github.com/openstack-k8s-operators/keystone-operator/api v0.0.0-20221215165910-8
 github.com/openstack-k8s-operators/keystone-operator/api v0.0.0-20221215165910-80274d6445b1/go.mod h1:HfMoeyB6kEPfH6Q5YlLyUwmY5ZIgEsDoIBvArE01Oto=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230110110231-28368fe6a6a9 h1:Z8+r/5O5AfTOzbdrUxSbGxdiSbhluFwDMU/5c9jMkFA=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230110110231-28368fe6a6a9/go.mod h1:qV9OlokZRpqbHI3lmeN5EOmIKynWphw6GPl3zP9KOGM=
-github.com/openstack-k8s-operators/lib-common/modules/database v0.0.0-20230110110231-28368fe6a6a9 h1:ho8NL1fPXgJEN0/xcykA6SDVme53S+vI+3BD6KWyT+o=
-github.com/openstack-k8s-operators/lib-common/modules/database v0.0.0-20230110110231-28368fe6a6a9/go.mod h1:rONM/XgvFs6putDIxRHNv9/CTGh2afAvJM5wRP2OywY=
+github.com/openstack-k8s-operators/lib-common/modules/database v0.0.0-20230126174350-3be54a6d3263 h1:upigetLqHvFWeTf+4Tbs9lCjgtpIxsc+ObAQw7OGOmg=
+github.com/openstack-k8s-operators/lib-common/modules/database v0.0.0-20230126174350-3be54a6d3263/go.mod h1:rONM/XgvFs6putDIxRHNv9/CTGh2afAvJM5wRP2OywY=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.0.0-20220915080953-f73a201a1da6 h1:MVNEHyqD0ZdO9jiyUSKw5M2T9Lc4l4Wx1pdC2/BSJ5Y=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.0.0-20220915080953-f73a201a1da6/go.mod h1:YsqouRH8DoZAjFaxcIErspk59BcwXtVjPxK/yV17Wrc=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.0.0-20230110110231-28368fe6a6a9 h1:kC5Lf5d8U03yyfHfObgR5hBy+gCUjXiH0teU5gDjKoY=

--- a/test/functional/nova_controller_test.go
+++ b/test/functional/nova_controller_test.go
@@ -605,5 +605,21 @@ var _ = Describe("Nova controller", func() {
 			service = GetKeystoneService(novaKeystoneServiceName)
 			Expect(service.Finalizers).NotTo(ContainElement("Nova"))
 		})
+
+		It("removes the finalizers from the nova dbs", func() {
+			SimulateKeystoneServiceReady(novaKeystoneServiceName)
+
+			apiDB := GetMariaDBDatabase(mariaDBDatabaseNameForAPI)
+			Expect(apiDB.Finalizers).To(ContainElement("Nova"))
+			cell0DB := GetMariaDBDatabase(mariaDBDatabaseNameForCell0)
+			Expect(cell0DB.Finalizers).To(ContainElement("Nova"))
+
+			DeleteNova(novaName)
+
+			apiDB = GetMariaDBDatabase(mariaDBDatabaseNameForAPI)
+			Expect(apiDB.Finalizers).NotTo(ContainElement("Nova"))
+			cell0DB = GetMariaDBDatabase(mariaDBDatabaseNameForCell0)
+			Expect(cell0DB.Finalizers).NotTo(ContainElement("Nova"))
+		})
 	})
 })


### PR DESCRIPTION
Ever since  : https://github.com/openstack-k8s-operators/lib-common/pull/87

Podified operators which use service dbs and the db.CreateOrPatchDB method ,
now will get the finalizer set on the db automatically when using the newest lib-common,
but they won't have the code remove it on cleanup i.e reconcileDelete,
which might make the delete operator action hang.

This adds the service Db removal code in the operator delete (reconcileDelete)
function to work with the above.

Also updated lib-common to latest as to not break lib-common's exported functio
