### PR TITLE
Remove omitempty

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -281,5 +281,6 @@ golint: get-ci-tools
 
 .PHONY: operator-lint
 operator-lint: ## Runs operator-lint
-	GOBIN=$(LOCALBIN) go install github.com/gibizer/operator-lint@latest
+	#TODO(gibi): bump this to v0.2.2 as soon as that version is tagged
+	GOBIN=$(LOCALBIN) go install github.com/gibizer/operator-lint@2ffa25b7f1c13fb2bdae5444a3dd1b5bbad529b1
 	go vet -vettool=$(LOCALBIN)/operator-lint ./... ./api/...

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -31,7 +31,7 @@ type NovaServiceBase struct {
 	// +kubebuilder:validation:Maximum=32
 	// +kubebuilder:validation:Minimum=0
 	// Replicas of the service to run
-	Replicas int32 `json:"replicas,omitempty"`
+	Replicas int32 `json:"replicas"`
 
 	// +kubebuilder:validation:Optional
 	// NodeSelector to target subset of worker nodes running this service

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -63,7 +63,7 @@ type Debug struct {
 	// QUESTION(gibi): Not all CR will run dbsync, should we have per CR
 	// Debug struct or keep this generic one and ignore fields in the
 	// controller that are not applicable
-	StopDBSync bool `json:"stopDBSync,omitempty"`
+	StopDBSync bool `json:"stopDBSync"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
 	// StopService allows stopping the service container before staring
@@ -71,11 +71,11 @@ type Debug struct {
 	// QUESTION(gibi): Not all CR will run a service, should we have per CR
 	// Debug struct or keep this generic one and ignore fields in the
 	// controller that are not applicable
-	StopService bool `json:"stopService,omitempty"`
+	StopService bool `json:"stopService"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
 	// PreserveJobs - do not delete jobs after they finished e.g. to check logs
-	PreserveJobs bool `json:"preserveJobs,omitempty"`
+	PreserveJobs bool `json:"preserveJobs"`
 }
 
 // PasswordSelector to identify the DB and AdminUser password from the Secret

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -38,11 +38,10 @@ type NovaServiceBase struct {
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="# add your customization here"
 	// CustomServiceConfig - customize the service config using this parameter to change service defaults,
 	// or overwrite rendered information using raw OpenStack config format. The content gets added to
 	// to /etc/<service>/<service>.conf.d directory as custom.conf file.
-	CustomServiceConfig string `json:"customServiceConfig,omitempty"`
+	CustomServiceConfig string `json:"customServiceConfig"`
 
 	// +kubebuilder:validation:Optional
 	// ConfigOverwrite - interface to overwrite default config files like e.g. logging.conf or policy.json.

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -84,15 +84,15 @@ type PasswordSelector struct {
 	// +kubebuilder:default="NovaPassword"
 	// Service - Selector to get the keystone service user password from the
 	// Secret
-	Service string `json:"service,omitempty"`
+	Service string `json:"service"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="NovaAPIDatabasePassword"
 	// APIDatabase - the name of the field to get the API DB password from the
 	// Secret
-	APIDatabase string `json:"apiDatabase,omitempty"`
+	APIDatabase string `json:"apiDatabase"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="NovaCell0DatabasePassword"
 	// CellDatabase - the name of the field to get the Cell DB password from
 	// the Secret
-	CellDatabase string `json:"cellDatabase,omitempty"`
+	CellDatabase string `json:"cellDatabase"`
 }

--- a/api/v1beta1/nova_types.go
+++ b/api/v1beta1/nova_types.go
@@ -60,17 +60,12 @@ type NovaSpec struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="nova"
 	// ServiceUser - optional username used for this service to register in keystone
-	ServiceUser string `json:"serviceUser,omitempty"`
+	ServiceUser string `json:"serviceUser"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="nova_api"
 	// APIDatabaseUser - username to use when accessing the API DB
-	APIDatabaseUser string `json:"apiDatabaseUser,omitempty"`
-
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="nova"
-	// APIMessageBusUser - username to use when accessing the API message bus
-	APIMessageBusUser string `json:"apiMessageBusUser,omitempty"`
+	APIDatabaseUser string `json:"apiDatabaseUser"`
 
 	// +kubebuilder:validation:Required
 	// Secret is the name of the Secret instance containing password

--- a/api/v1beta1/nova_types.go
+++ b/api/v1beta1/nova_types.go
@@ -73,10 +73,10 @@ type NovaSpec struct {
 	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={service: NovaPassword, apiDatabase: NovaAPIDatabasePassword}
+	// +kubebuilder:default={service: NovaPassword}
 	// PasswordSelectors - Selectors to identify the DB and ServiceUser
 	// passwords from the Secret
-	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
+	PasswordSelectors PasswordSelector `json:"passwordSelectors"`
 
 	// +kubebuilder:validation:Optional
 	// Debug - enable debug for different deploy stages. If an init container

--- a/api/v1beta1/novaapi_types.go
+++ b/api/v1beta1/novaapi_types.go
@@ -42,7 +42,7 @@ type NovaAPITemplate struct {
 	// +kubebuilder:validation:Maximum=32
 	// +kubebuilder:validation:Minimum=0
 	// Replicas of the service to run
-	Replicas int32 `json:"replicas,omitempty"`
+	Replicas int32 `json:"replicas"`
 
 	// +kubebuilder:validation:Optional
 	// NodeSelector to target subset of worker nodes running this service

--- a/api/v1beta1/novaapi_types.go
+++ b/api/v1beta1/novaapi_types.go
@@ -35,7 +35,7 @@ type NovaAPITemplate struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="quay.io/tripleozedcentos9/openstack-nova-api:current-tripleo"
 	// ContainerImage - The service specific Container Image URL
-	ContainerImage string `json:"containerImage,omitempty"`
+	ContainerImage string `json:"containerImage"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=1

--- a/api/v1beta1/novaapi_types.go
+++ b/api/v1beta1/novaapi_types.go
@@ -85,15 +85,15 @@ type NovaAPISpec struct {
 	// +kubebuilder:default="nova"
 	// ServiceUser - optional username used for this service to register in
 	// keystone
-	ServiceUser string `json:"serviceUser,omitempty"`
+	ServiceUser string `json:"serviceUser"`
 
 	// +kubebuilder:validation:Required
 	KeystoneAuthURL string `json:"keystoneAuthURL"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="nova"
+	// +kubebuilder:default="nova_api"
 	// APIDatabaseUser - username to use when accessing the API DB
-	APIDatabaseUser string `json:"apiDatabaseUser,omitempty"`
+	APIDatabaseUser string `json:"apiDatabaseUser"`
 
 	// +kubebuilder:validation:Required
 	// APIDatabaseHostname - hostname to use when accessing the API DB
@@ -106,9 +106,9 @@ type NovaAPISpec struct {
 	APIMessageBusSecretName string `json:"apiMessageBusSecretName"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="nova"
+	// +kubebuilder:default="nova_cell0"
 	// APIDatabaseUser - username to use when accessing the cell0 DB
-	Cell0DatabaseUser string `json:"cell0DatabaseUser,omitempty"`
+	Cell0DatabaseUser string `json:"cell0DatabaseUser"`
 
 	// +kubebuilder:validation:Required
 	// APIDatabaseHostname - hostname to use when accessing the cell0 DB

--- a/api/v1beta1/novaapi_types.go
+++ b/api/v1beta1/novaapi_types.go
@@ -49,11 +49,10 @@ type NovaAPITemplate struct {
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="# add your customization here"
 	// CustomServiceConfig - customize the service config using this parameter to change service defaults,
 	// or overwrite rendered information using raw OpenStack config format. The content gets added to
 	// to /etc/<service>/<service>.conf.d directory as custom.conf file.
-	CustomServiceConfig string `json:"customServiceConfig,omitempty"`
+	CustomServiceConfig string `json:"customServiceConfig"`
 
 	// +kubebuilder:validation:Optional
 	// ConfigOverwrite - interface to overwrite default config files like e.g. logging.conf

--- a/api/v1beta1/novaapi_types.go
+++ b/api/v1beta1/novaapi_types.go
@@ -77,9 +77,10 @@ type NovaAPISpec struct {
 	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default={service: NovaPassword}
 	// PasswordSelectors - Field names to identify the passwords from the
 	// Secret
-	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
+	PasswordSelectors PasswordSelector `json:"passwordSelectors"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="nova"

--- a/api/v1beta1/novacell_types.go
+++ b/api/v1beta1/novacell_types.go
@@ -83,9 +83,10 @@ type NovaCellSpec struct {
 	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default={service: NovaPassword}
 	// PasswordSelectors - Field names to identify the passwords from the
 	// Secret
-	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
+	PasswordSelectors PasswordSelector `json:"passwordSelectors"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=nova

--- a/api/v1beta1/novaconductor_types.go
+++ b/api/v1beta1/novaconductor_types.go
@@ -79,7 +79,7 @@ type NovaConductorSpec struct {
 	// +kubebuilder:default={service: NovaPassword}
 	// PasswordSelectors - Field names to identify the passwords from the
 	// Secret
-	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
+	PasswordSelectors PasswordSelector `json:"passwordSelectors"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=nova
@@ -192,6 +192,7 @@ func NewNovaConductorSpec(
 		NovaServiceBase:          NovaServiceBase(novaCell.ConductorServiceTemplate),
 		KeystoneAuthURL:          novaCell.KeystoneAuthURL,
 		ServiceUser:              novaCell.ServiceUser,
+		PasswordSelectors:        novaCell.PasswordSelectors,
 	}
 	return conductorSpec
 }

--- a/api/v1beta1/novaconductor_types.go
+++ b/api/v1beta1/novaconductor_types.go
@@ -45,11 +45,10 @@ type NovaConductorTemplate struct {
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="# add your customization here"
 	// CustomServiceConfig - customize the service config using this parameter to change service defaults,
 	// or overwrite rendered information using raw OpenStack config format. The content gets added to
 	// to /etc/<service>/<service>.conf.d directory as custom.conf file.
-	CustomServiceConfig string `json:"customServiceConfig,omitempty"`
+	CustomServiceConfig string `json:"customServiceConfig"`
 
 	// +kubebuilder:validation:Optional
 	// ConfigOverwrite - interface to overwrite default config files like e.g. logging.conf

--- a/api/v1beta1/novaconductor_types.go
+++ b/api/v1beta1/novaconductor_types.go
@@ -77,6 +77,7 @@ type NovaConductorSpec struct {
 	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default={service: NovaPassword}
 	// PasswordSelectors - Field names to identify the passwords from the
 	// Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`

--- a/api/v1beta1/novametadata_types.go
+++ b/api/v1beta1/novametadata_types.go
@@ -77,9 +77,10 @@ type NovaMetadataSpec struct {
 	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default={service: NovaPassword}
 	// PasswordSelectors - Field names to identify the passwords from the
 	// Secret
-	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
+	PasswordSelectors PasswordSelector `json:"passwordSelectors"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=nova

--- a/api/v1beta1/novametadata_types.go
+++ b/api/v1beta1/novametadata_types.go
@@ -45,11 +45,10 @@ type NovaMetadataTemplate struct {
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="# add your customization here"
 	// CustomServiceConfig - customize the service config using this parameter to change service defaults,
 	// or overwrite rendered information using raw OpenStack config format. The content gets added to
 	// to /etc/<service>/<service>.conf.d directory as custom.conf file.
-	CustomServiceConfig string `json:"customServiceConfig,omitempty"`
+	CustomServiceConfig string `json:"customServiceConfig"`
 
 	// +kubebuilder:validation:Optional
 	// ConfigOverwrite - interface to overwrite default config files like e.g. logging.conf

--- a/api/v1beta1/novanovncproxy_types.go
+++ b/api/v1beta1/novanovncproxy_types.go
@@ -76,9 +76,10 @@ type NovaNoVNCProxySpec struct {
 	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default={service: NovaPassword}
 	// PasswordSelectors - Field names to identify the passwords from the
 	// Secret
-	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
+	PasswordSelectors PasswordSelector `json:"passwordSelectors"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=nova

--- a/api/v1beta1/novanovncproxy_types.go
+++ b/api/v1beta1/novanovncproxy_types.go
@@ -45,11 +45,10 @@ type NovaNoVNCProxyTemplate struct {
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="# add your customization here"
 	// CustomServiceConfig - customize the service config using this parameter to change service defaults,
 	// or overwrite rendered information using raw OpenStack config format. The content gets added to
 	// to /etc/<service>/<service>.conf.d directory as custom.conf file.
-	CustomServiceConfig string `json:"customServiceConfig,omitempty"`
+	CustomServiceConfig string `json:"customServiceConfig"`
 
 	// +kubebuilder:validation:Optional
 	// ConfigOverwrite - interface to overwrite default config files like e.g. logging.conf

--- a/api/v1beta1/novascheduler_types.go
+++ b/api/v1beta1/novascheduler_types.go
@@ -72,9 +72,10 @@ type NovaSchedulerSpec struct {
 	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default={service: NovaPassword}
 	// PasswordSelectors - Field names to identify the passwords from the
 	// Secret
-	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
+	PasswordSelectors PasswordSelector `json:"passwordSelectors"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=nova

--- a/api/v1beta1/novascheduler_types.go
+++ b/api/v1beta1/novascheduler_types.go
@@ -45,11 +45,10 @@ type NovaSchedulerTemplate struct {
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="# add your customization here"
 	// CustomServiceConfig - customize the service config using this parameter to change service defaults,
 	// or overwrite rendered information using raw OpenStack config format. The content gets added to
 	// to /etc/<service>/<service>.conf.d directory as custom.conf file.
-	CustomServiceConfig string `json:"customServiceConfig,omitempty"`
+	CustomServiceConfig string `json:"customServiceConfig"`
 
 	// +kubebuilder:validation:Optional
 	// ConfigOverwrite - interface to overwrite default config files like e.g. logging.conf

--- a/api/v1beta1/novascheduler_types.go
+++ b/api/v1beta1/novascheduler_types.go
@@ -96,11 +96,6 @@ type NovaSchedulerSpec struct {
 	// APIDatabaseHostname - hostname to use when accessing the API DB
 	APIDatabaseHostname string `json:"apiDatabaseHostname"`
 
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=nova
-	// APIMessageBusUser - username to use when accessing the API message bus
-	APIMessageBusUser string `json:"apiMessageBusUser"`
-
 	// +kubebuilder:validation:Required
 	// APIMessageBusHostname - hostname to use when accessing the API message
 	// bus

--- a/config/crd/bases/nova.openstack.org_nova.yaml
+++ b/config/crd/bases/nova.openstack.org_nova.yaml
@@ -456,7 +456,6 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  apiDatabase: NovaAPIDatabasePassword
                   service: NovaPassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser passwords from the Secret

--- a/config/crd/bases/nova.openstack.org_nova.yaml
+++ b/config/crd/bases/nova.openstack.org_nova.yaml
@@ -51,11 +51,6 @@ spec:
                   CR to select the Message Bus Service instance used by the Nova top
                   level services to communicate.
                 type: string
-              apiMessageBusUser:
-                default: nova
-                description: APIMessageBusUser - username to use when accessing the
-                  API message bus
-                type: string
               apiServiceTemplate:
                 default:
                   containerImage: quay.io/tripleozedcentos9/openstack-nova-api:current-tripleo

--- a/config/crd/bases/nova.openstack.org_nova.yaml
+++ b/config/crd/bases/nova.openstack.org_nova.yaml
@@ -67,7 +67,6 @@ spec:
                       URL
                     type: string
                   customServiceConfig:
-                    default: '# add your customization here'
                     description: CustomServiceConfig - customize the service config
                       using this parameter to change service defaults, or overwrite
                       rendered information using raw OpenStack config format. The
@@ -156,7 +155,6 @@ spec:
                           description: The service specific Container Image URL
                           type: string
                         customServiceConfig:
-                          default: '# add your customization here'
                           description: CustomServiceConfig - customize the service
                             config using this parameter to change service defaults,
                             or overwrite rendered information using raw OpenStack
@@ -226,7 +224,6 @@ spec:
                           description: The service specific Container Image URL
                           type: string
                         customServiceConfig:
-                          default: '# add your customization here'
                           description: CustomServiceConfig - customize the service
                             config using this parameter to change service defaults,
                             or overwrite rendered information using raw OpenStack
@@ -292,7 +289,6 @@ spec:
                           description: The service specific Container Image URL
                           type: string
                         customServiceConfig:
-                          default: '# add your customization here'
                           description: CustomServiceConfig - customize the service
                             config using this parameter to change service defaults,
                             or overwrite rendered information using raw OpenStack
@@ -408,7 +404,6 @@ spec:
                     description: The service specific Container Image URL
                     type: string
                   customServiceConfig:
-                    default: '# add your customization here'
                     description: CustomServiceConfig - customize the service config
                       using this parameter to change service defaults, or overwrite
                       rendered information using raw OpenStack config format. The
@@ -495,7 +490,6 @@ spec:
                     description: The service specific Container Image URL
                     type: string
                   customServiceConfig:
-                    default: '# add your customization here'
                     description: CustomServiceConfig - customize the service config
                       using this parameter to change service defaults, or overwrite
                       rendered information using raw OpenStack config format. The

--- a/config/crd/bases/nova.openstack.org_novaapis.yaml
+++ b/config/crd/bases/nova.openstack.org_novaapis.yaml
@@ -40,7 +40,7 @@ spec:
                   the API DB
                 type: string
               apiDatabaseUser:
-                default: nova
+                default: nova_api
                 description: APIDatabaseUser - username to use when accessing the
                   API DB
                 type: string
@@ -54,7 +54,7 @@ spec:
                   the cell0 DB
                 type: string
               cell0DatabaseUser:
-                default: nova
+                default: nova_cell0
                 description: APIDatabaseUser - username to use when accessing the
                   cell0 DB
                 type: string

--- a/config/crd/bases/nova.openstack.org_novaapis.yaml
+++ b/config/crd/bases/nova.openstack.org_novaapis.yaml
@@ -113,6 +113,8 @@ spec:
                   this service
                 type: object
               passwordSelectors:
+                default:
+                  service: NovaPassword
                 description: PasswordSelectors - Field names to identify the passwords
                   from the Secret
                 properties:

--- a/config/crd/bases/nova.openstack.org_novaapis.yaml
+++ b/config/crd/bases/nova.openstack.org_novaapis.yaml
@@ -62,7 +62,6 @@ spec:
                 description: The service specific Container Image URL
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets

--- a/config/crd/bases/nova.openstack.org_novacells.yaml
+++ b/config/crd/bases/nova.openstack.org_novacells.yaml
@@ -75,7 +75,6 @@ spec:
                     description: The service specific Container Image URL
                     type: string
                   customServiceConfig:
-                    default: '# add your customization here'
                     description: CustomServiceConfig - customize the service config
                       using this parameter to change service defaults, or overwrite
                       rendered information using raw OpenStack config format. The
@@ -171,7 +170,6 @@ spec:
                     description: The service specific Container Image URL
                     type: string
                   customServiceConfig:
-                    default: '# add your customization here'
                     description: CustomServiceConfig - customize the service config
                       using this parameter to change service defaults, or overwrite
                       rendered information using raw OpenStack config format. The
@@ -236,7 +234,6 @@ spec:
                     description: The service specific Container Image URL
                     type: string
                   customServiceConfig:
-                    default: '# add your customization here'
                     description: CustomServiceConfig - customize the service config
                       using this parameter to change service defaults, or overwrite
                       rendered information using raw OpenStack config format. The

--- a/config/crd/bases/nova.openstack.org_novacells.yaml
+++ b/config/crd/bases/nova.openstack.org_novacells.yaml
@@ -290,6 +290,8 @@ spec:
                     type: object
                 type: object
               passwordSelectors:
+                default:
+                  service: NovaPassword
                 description: PasswordSelectors - Field names to identify the passwords
                   from the Secret
                 properties:

--- a/config/crd/bases/nova.openstack.org_novaconductors.yaml
+++ b/config/crd/bases/nova.openstack.org_novaconductors.yaml
@@ -68,7 +68,6 @@ spec:
                 description: The service specific Container Image URL
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets

--- a/config/crd/bases/nova.openstack.org_novaconductors.yaml
+++ b/config/crd/bases/nova.openstack.org_novaconductors.yaml
@@ -121,6 +121,8 @@ spec:
                   this service
                 type: object
               passwordSelectors:
+                default:
+                  service: NovaPassword
                 description: PasswordSelectors - Field names to identify the passwords
                   from the Secret
                 properties:

--- a/config/crd/bases/nova.openstack.org_novametadata.yaml
+++ b/config/crd/bases/nova.openstack.org_novametadata.yaml
@@ -76,7 +76,6 @@ spec:
                 description: The service specific Container Image URL
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets

--- a/config/crd/bases/nova.openstack.org_novametadata.yaml
+++ b/config/crd/bases/nova.openstack.org_novametadata.yaml
@@ -128,6 +128,8 @@ spec:
                   this service
                 type: object
               passwordSelectors:
+                default:
+                  service: NovaPassword
                 description: PasswordSelectors - Field names to identify the passwords
                   from the Secret
                 properties:

--- a/config/crd/bases/nova.openstack.org_novanovncproxies.yaml
+++ b/config/crd/bases/nova.openstack.org_novanovncproxies.yaml
@@ -104,6 +104,8 @@ spec:
                   this service
                 type: object
               passwordSelectors:
+                default:
+                  service: NovaPassword
                 description: PasswordSelectors - Field names to identify the passwords
                   from the Secret
                 properties:

--- a/config/crd/bases/nova.openstack.org_novanovncproxies.yaml
+++ b/config/crd/bases/nova.openstack.org_novanovncproxies.yaml
@@ -52,7 +52,6 @@ spec:
                 description: The service specific Container Image URL
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets

--- a/config/crd/bases/nova.openstack.org_novaschedulers.yaml
+++ b/config/crd/bases/nova.openstack.org_novaschedulers.yaml
@@ -104,6 +104,8 @@ spec:
                   this service
                 type: object
               passwordSelectors:
+                default:
+                  service: NovaPassword
                 description: PasswordSelectors - Field names to identify the passwords
                   from the Secret
                 properties:

--- a/config/crd/bases/nova.openstack.org_novaschedulers.yaml
+++ b/config/crd/bases/nova.openstack.org_novaschedulers.yaml
@@ -48,11 +48,6 @@ spec:
                 description: APIMessageBusHostname - hostname to use when accessing
                   the API message bus
                 type: string
-              apiMessageBusUser:
-                default: nova
-                description: APIMessageBusUser - username to use when accessing the
-                  API message bus
-                type: string
               containerImage:
                 description: The service specific Container Image URL
                 type: string

--- a/config/crd/bases/nova.openstack.org_novaschedulers.yaml
+++ b/config/crd/bases/nova.openstack.org_novaschedulers.yaml
@@ -57,7 +57,6 @@ spec:
                 description: The service specific Container Image URL
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets

--- a/config/manifests/bases/nova-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/nova-operator.clusterserviceversion.yaml
@@ -16,6 +16,36 @@ spec:
       kind: NovaAPI
       name: novaapis.nova.openstack.org
       version: v1beta1
+    - description: NovaCell is the Schema for the novacells API
+      displayName: Nova Cell
+      kind: NovaCell
+      name: novacells.nova.openstack.org
+      version: v1beta1
+    - description: NovaConductor is the Schema for the novaconductors API
+      displayName: Nova Conductor
+      kind: NovaConductor
+      name: novaconductors.nova.openstack.org
+      version: v1beta1
+    - description: NovaMetadata is the Schema for the novametadata API
+      displayName: Nova Metadata
+      kind: NovaMetadata
+      name: novametadata.nova.openstack.org
+      version: v1beta1
+    - description: NovaNoVNCProxy is the Schema for the novanovncproxies API
+      displayName: Nova No VNCProxy
+      kind: NovaNoVNCProxy
+      name: novanovncproxies.nova.openstack.org
+      version: v1beta1
+    - description: Nova is the Schema for the nova API
+      displayName: Nova
+      kind: Nova
+      name: novas.nova.openstack.org
+      version: v1beta1
+    - description: NovaScheduler is the Schema for the novaschedulers API
+      displayName: Nova Scheduler
+      kind: NovaScheduler
+      name: novaschedulers.nova.openstack.org
+      version: v1beta1
   description: Nova Operator
   displayName: Nova Operator
   icon:

--- a/config/samples/nova_v1beta1_nova-multi-cell.yaml
+++ b/config/samples/nova_v1beta1_nova-multi-cell.yaml
@@ -26,7 +26,6 @@ spec:
     apiDatabase: NovaAPIDatabasePassword
     apiMessageBus: NovaAPIMessageBusPassword
   serviceUser: nova
-  apiMessageBusUser: nova
   debug:
     stopDBSync: False
     stopService: False

--- a/config/samples/nova_v1beta1_novaapi.yaml
+++ b/config/samples/nova_v1beta1_novaapi.yaml
@@ -15,7 +15,6 @@ spec:
   apiDatabaseUser: nova
   # This is the hostname of the default DB today
   apiDatabaseHostname: openstack
-  apiMessageBusUser: nova
   # Q: do we need db an rabbit port? it seems today we use the default port
   # This is the hostname of the default Rabbit today
   apiMessageBusHostname: default-security-context

--- a/config/samples/nova_v1beta1_novacell0.yaml
+++ b/config/samples/nova_v1beta1_novacell0.yaml
@@ -18,7 +18,6 @@ spec:
   apiDatabaseUser: nova
   # This is the hostname of the default DB today
   apiDatabaseHostname: openstack
-  apiMessageBusUser: nova
   # Q: do we need db an rabbit port? it seems today we use the default port
   # This is the hostname of the default Rabbit today
   apiMessageBusHostname: default-security-context

--- a/config/samples/nova_v1beta1_novacell1-upcall.yaml
+++ b/config/samples/nova_v1beta1_novacell1-upcall.yaml
@@ -18,7 +18,6 @@ spec:
   apiDatabaseUser: nova
   # This is the hostname of the default DB today
   apiDatabaseHostname: openstack
-  apiMessageBusUser: nova
   # Q: do we need db an rabbit port? it seems today we use the default port
   # This is the hostname of the default Rabbit today
   apiMessageBusHostname: default-security-context

--- a/config/samples/nova_v1beta1_novacell2-without-upcall.yaml
+++ b/config/samples/nova_v1beta1_novacell2-without-upcall.yaml
@@ -17,7 +17,6 @@ spec:
   apiDatabaseUser: null
   # cell2 doesn't have access to the api DB
   apiDatabaseHostname: null
-  apiMessageBusUser: null
   # cell2 doesn't have access to api message bus
   apiMessageBusHostname: null
   cellDatabaseUser: nova

--- a/controllers/nova_controller.go
+++ b/controllers/nova_controller.go
@@ -688,6 +688,7 @@ func (r *NovaReconciler) ensureAPI(
 		// we need to copy fields one by one here.
 		NovaServiceBase: novav1.NovaServiceBase(instance.Spec.APIServiceTemplate),
 		KeystoneAuthURL: keystoneAuthURL,
+		ServiceUser:     instance.Spec.ServiceUser,
 	}
 	api := &novav1.NovaAPI{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/nova_controller.go
+++ b/controllers/nova_controller.go
@@ -623,8 +623,9 @@ func (r *NovaReconciler) ensureCell(
 		NoVNCProxyServiceTemplate: cellTemplate.NoVNCProxyServiceTemplate,
 		Debug:                     instance.Spec.Debug,
 		// TODO(gibi): this should be part of the secret
-		ServiceUser:     instance.Spec.ServiceUser,
-		KeystoneAuthURL: keystoneAuthURL,
+		ServiceUser:       instance.Spec.ServiceUser,
+		KeystoneAuthURL:   keystoneAuthURL,
+		PasswordSelectors: instance.Spec.PasswordSelectors,
 	}
 	if cellTemplate.HasAPIAccess {
 		cellSpec.APIDatabaseHostname = apiDB.GetDatabaseHostname()
@@ -686,9 +687,10 @@ func (r *NovaReconciler) ensureAPI(
 		// has exactly the same fields as the NovaAPITemplate so we can convert
 		// between them directly. As soon as these two structs start to diverge
 		// we need to copy fields one by one here.
-		NovaServiceBase: novav1.NovaServiceBase(instance.Spec.APIServiceTemplate),
-		KeystoneAuthURL: keystoneAuthURL,
-		ServiceUser:     instance.Spec.ServiceUser,
+		NovaServiceBase:   novav1.NovaServiceBase(instance.Spec.APIServiceTemplate),
+		KeystoneAuthURL:   keystoneAuthURL,
+		ServiceUser:       instance.Spec.ServiceUser,
+		PasswordSelectors: instance.Spec.PasswordSelectors,
 	}
 	api := &novav1.NovaAPI{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -431,23 +431,31 @@ func SimulateMariaDBDatabaseCompleted(name types.NamespacedName) {
 	logger.Info("Simulated DB completed", "on", name)
 }
 
-func CreateNovaConductor(namespace string, spec novav1.NovaConductorSpec) types.NamespacedName {
-	novaConductorName := uuid.New().String()
-	novaConductor := &novav1.NovaConductor{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "nova.openstack.org/v1beta1",
-			Kind:       "NovaConductor",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      novaConductorName,
-			Namespace: namespace,
-		},
-		Spec: spec,
+func GetDefaultNovaConductorSpec() map[string]interface{} {
+	return map[string]interface{}{
+		"cellName":                 "cell0",
+		"secret":                   SecretName,
+		"cellMessageBusSecretName": MessageBusSecretName,
+		"containerImage":           ContainerImage,
+		"keystoneAuthURL":          "keystone-auth-url",
 	}
+}
 
-	Expect(k8sClient.Create(ctx, novaConductor)).Should(Succeed())
+func CreateNovaConductor(namespace string, spec map[string]interface{}) types.NamespacedName {
+	novaAPIName := uuid.New().String()
 
-	return types.NamespacedName{Name: novaConductorName, Namespace: namespace}
+	raw := map[string]interface{}{
+		"apiVersion": "nova.openstack.org/v1beta1",
+		"kind":       "NovaConductor",
+		"metadata": map[string]interface{}{
+			"name":      novaAPIName,
+			"namespace": namespace,
+		},
+		"spec": spec,
+	}
+	CreateUnstructured(raw)
+
+	return types.NamespacedName{Name: novaAPIName, Namespace: namespace}
 }
 
 func DeleteNovaConductor(name types.NamespacedName) {

--- a/test/functional/nova_controller_test.go
+++ b/test/functional/nova_controller_test.go
@@ -247,8 +247,11 @@ var _ = Describe("Nova controller", func() {
 			// assert that cell related CRs are created
 			cell := GetNovaCell(cell0Name)
 			Expect(cell.Spec.CellMessageBusSecretName).To(Equal("rabbitmq-secret"))
+			Expect(cell.Spec.ServiceUser).To(Equal("nova"))
+
 			conductor := GetNovaConductor(cell0ConductorName)
 			Expect(conductor.Spec.CellMessageBusSecretName).To(Equal("rabbitmq-secret"))
+			Expect(conductor.Spec.ServiceUser).To(Equal("nova"))
 
 			ExpectCondition(
 				cell0ConductorName,
@@ -289,6 +292,7 @@ var _ = Describe("Nova controller", func() {
 
 			api := GetNovaAPI(novaAPIName)
 			Expect(api.Spec.APIMessageBusSecretName).To(Equal("rabbitmq-secret"))
+			Expect(api.Spec.ServiceUser).To(Equal("nova"))
 
 			SimulateStatefulSetReplicaReady(novaAPIdeploymentName)
 

--- a/test/functional/nova_reconfiguration_test.go
+++ b/test/functional/nova_reconfiguration_test.go
@@ -1,0 +1,214 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package functional_test
+
+import (
+	"os"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
+	novav1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func CreateNovaWith3CellsAndEnsureReady(namespace string) types.NamespacedName {
+	var novaName types.NamespacedName
+	var mariaDBDatabaseNameForAPI types.NamespacedName
+	var cell0 Cell
+	var cell1 Cell
+	var cell2 Cell
+	var novaAPIName types.NamespacedName
+	var novaAPIdeploymentName types.NamespacedName
+	var novaKeystoneServiceName types.NamespacedName
+
+	novaName = types.NamespacedName{
+		Namespace: namespace,
+		Name:      uuid.New().String(),
+	}
+	mariaDBDatabaseNameForAPI = types.NamespacedName{
+		Namespace: namespace,
+		Name:      "nova-api",
+	}
+	novaAPIName = types.NamespacedName{
+		Namespace: namespace,
+		Name:      novaName.Name + "-api",
+	}
+	novaAPIdeploymentName = types.NamespacedName{
+		Namespace: namespace,
+		Name:      novaAPIName.Name,
+	}
+	novaKeystoneServiceName = types.NamespacedName{
+		Namespace: namespace,
+		Name:      "nova",
+	}
+	cell0 = NewCell(novaName, "cell0")
+	cell1 = NewCell(novaName, "cell1")
+	cell2 = NewCell(novaName, "cell2")
+
+	DeferCleanup(k8sClient.Delete, ctx, CreateNovaSecret(namespace, SecretName))
+	DeferCleanup(
+		k8sClient.Delete,
+		ctx,
+		CreateNovaMessageBusSecret(namespace, "mq-for-api-secret"),
+	)
+	DeferCleanup(
+		k8sClient.Delete,
+		ctx,
+		CreateNovaMessageBusSecret(namespace, "mq-for-cell1-secret"),
+	)
+	DeferCleanup(
+		k8sClient.Delete,
+		ctx,
+		CreateNovaMessageBusSecret(namespace, "mq-for-cell2-secret"),
+	)
+
+	serviceSpec := corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 3306}}}
+	DeferCleanup(DeleteDBService, CreateDBService(namespace, "db-for-api", serviceSpec))
+	DeferCleanup(DeleteDBService, CreateDBService(namespace, "db-for-cell1", serviceSpec))
+	DeferCleanup(DeleteDBService, CreateDBService(namespace, "db-for-cell2", serviceSpec))
+
+	spec := GetDefaultNovaSpec()
+	cell0Template := GetDefaultNovaCellTemplate()
+	cell0Template["cellName"] = "cell0"
+	cell0Template["cellDatabaseInstance"] = "db-for-api"
+	cell0Template["cellDatabaseUser"] = "nova_cell0"
+
+	cell1Template := GetDefaultNovaCellTemplate()
+	cell1Template["cellName"] = "cell1"
+	cell1Template["cellDatabaseInstance"] = "db-for-cell1"
+	cell1Template["cellDatabaseUser"] = "nova_cell1"
+	cell1Template["cellMessageBusInstance"] = "mq-for-cell1"
+
+	cell2Template := GetDefaultNovaCellTemplate()
+	cell2Template["cellName"] = "cell2"
+	cell2Template["cellDatabaseInstance"] = "db-for-cell2"
+	cell2Template["cellDatabaseUser"] = "nova_cell2"
+	cell2Template["cellMessageBusInstance"] = "mq-for-cell2"
+	cell2Template["hasAPIAccess"] = false
+
+	spec["cellTemplates"] = map[string]interface{}{
+		"cell0": cell0Template,
+		"cell1": cell1Template,
+		"cell2": cell2Template,
+	}
+	spec["apiDatabaseInstance"] = "db-for-api"
+	spec["apiMessageBusInstance"] = "mq-for-api"
+
+	CreateNova(novaName, spec)
+	DeferCleanup(DeleteNova, novaName)
+	DeferCleanup(DeleteKeystoneAPI, CreateKeystoneAPI(namespace))
+
+	SimulateKeystoneServiceReady(novaKeystoneServiceName)
+
+	SimulateMariaDBDatabaseCompleted(mariaDBDatabaseNameForAPI)
+	SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
+	SimulateMariaDBDatabaseCompleted(cell1.MariaDBDatabaseName)
+	SimulateMariaDBDatabaseCompleted(cell2.MariaDBDatabaseName)
+
+	SimulateTransportURLReady(cell0.TransportURLName)
+	SimulateTransportURLReady(cell1.TransportURLName)
+	SimulateTransportURLReady(cell2.TransportURLName)
+
+	SimulateJobSuccess(cell0.CellDBSyncJobName)
+	SimulateStatefulSetReplicaReady(cell0.ConductorStatefulSetName)
+
+	SimulateStatefulSetReplicaReady(novaAPIdeploymentName)
+
+	SimulateJobSuccess(cell1.CellDBSyncJobName)
+	SimulateStatefulSetReplicaReady(cell1.ConductorStatefulSetName)
+
+	SimulateJobSuccess(cell2.CellDBSyncJobName)
+	SimulateStatefulSetReplicaReady(cell2.ConductorStatefulSetName)
+
+	ExpectCondition(
+		novaName,
+		conditionGetterFunc(NovaConditionGetter),
+		novav1.NovaAllCellsReadyCondition,
+		corev1.ConditionTrue,
+	)
+	ExpectCondition(
+		novaName,
+		conditionGetterFunc(NovaConditionGetter),
+		condition.ReadyCondition,
+		corev1.ConditionTrue,
+	)
+	return novaName
+}
+
+var _ = Describe("Nova reconfiguration", func() {
+	var namespace string
+	var novaName types.NamespacedName
+
+	BeforeEach(func() {
+		// NOTE(gibi): We need to create a unique namespace for each test run
+		// as namespaces cannot be deleted in a locally running envtest. See
+		// https://book.kubebuilder.io/reference/envtest.html#namespace-usage-limitation
+		namespace = uuid.New().String()
+		CreateNamespace(namespace)
+		// We still request the delete of the Namespace to properly cleanup if
+		// we run the test in an existing cluster.
+		DeferCleanup(DeleteNamespace, namespace)
+		// NOTE(gibi): ConfigMap generation looks up the local templates
+		// directory via ENV, so provide it
+		DeferCleanup(os.Setenv, "OPERATOR_TEMPLATES", os.Getenv("OPERATOR_TEMPLATES"))
+		os.Setenv("OPERATOR_TEMPLATES", "../../templates")
+
+		// Uncomment this if you need the full output in the logs from gomega
+		// matchers
+		// format.MaxLength = 0
+
+		novaName = CreateNovaWith3CellsAndEnsureReady(namespace)
+
+	})
+	When("cell0 conductor replicas is set to 0", func() {
+		It("sets the deployment replicas to 0", func() {
+			cell0DeploymentName := NewCell(novaName, "cell0").ConductorStatefulSetName
+
+			deployment := GetStatefulSet(cell0DeploymentName)
+			one := int32(1)
+			Expect(deployment.Spec.Replicas).To(Equal(&one))
+
+			// We need this big Eventually block because the Update() call might
+			// return a Conflict and then we have to retry by re-reading Nova,
+			// and updating the Replicas again.
+			// NOTE(gibi): we expected fauilure here, hence the ShouldNot
+			// construct, due to a bug in propagating the Replicas 0 to the
+			// NovaConductor
+			Eventually(func(g Gomega) {
+				nova := GetNova(novaName)
+
+				// TODO(gibi): Is there a simpler way to achieve this update
+				// in golang?
+				cell0 := nova.Spec.CellTemplates["cell0"]
+				(&cell0).ConductorServiceTemplate.Replicas = int32(0)
+				nova.Spec.CellTemplates["cell0"] = cell0
+
+				err := k8sClient.Update(ctx, nova)
+				g.Expect(err == nil || k8s_errors.IsConflict(err)).To(BeTrue())
+
+				deployment = &appsv1.StatefulSet{}
+				g.Expect(k8sClient.Get(ctx, cell0DeploymentName, deployment)).Should(Succeed())
+				zero := int32(0)
+				g.Expect(deployment.Spec.Replicas).To(Equal(&zero))
+			}, timeout, interval).ShouldNot(Succeed())
+		})
+	})
+})

--- a/test/functional/nova_reconfiguration_test.go
+++ b/test/functional/nova_reconfiguration_test.go
@@ -189,9 +189,6 @@ var _ = Describe("Nova reconfiguration", func() {
 			// We need this big Eventually block because the Update() call might
 			// return a Conflict and then we have to retry by re-reading Nova,
 			// and updating the Replicas again.
-			// NOTE(gibi): we expected fauilure here, hence the ShouldNot
-			// construct, due to a bug in propagating the Replicas 0 to the
-			// NovaConductor
 			Eventually(func(g Gomega) {
 				nova := GetNova(novaName)
 
@@ -208,7 +205,7 @@ var _ = Describe("Nova reconfiguration", func() {
 				g.Expect(k8sClient.Get(ctx, cell0DeploymentName, deployment)).Should(Succeed())
 				zero := int32(0)
 				g.Expect(deployment.Spec.Replicas).To(Equal(&zero))
-			}, timeout, interval).ShouldNot(Succeed())
+			}, timeout, interval).Should(Succeed())
 		})
 	})
 })

--- a/test/functional/novacell_controller_test.go
+++ b/test/functional/novacell_controller_test.go
@@ -54,7 +54,7 @@ var _ = Describe("NovaCell controller", func() {
 
 	When("A NovaCell CR instance is created without any input", func() {
 		BeforeEach(func() {
-			novaCellName = CreateNovaCell(namespace, novav1.NovaCellSpec{})
+			novaCellName = CreateNovaCell(namespace, GetDefaultNovaCellSpec())
 			DeferCleanup(DeleteNovaCell, novaCellName)
 		})
 
@@ -91,18 +91,7 @@ var _ = Describe("NovaCell controller", func() {
 				CreateNovaMessageBusSecret(namespace, MessageBusSecretName),
 			)
 
-			novaCellName = CreateNovaCell(
-				namespace,
-				novav1.NovaCellSpec{
-					CellName:                 "cell0",
-					Secret:                   SecretName,
-					CellMessageBusSecretName: MessageBusSecretName,
-					ConductorServiceTemplate: novav1.NovaConductorTemplate{
-						ContainerImage: ContainerImage,
-						Replicas:       1,
-					},
-				},
-			)
+			novaCellName = CreateNovaCell(namespace, GetDefaultNovaCellSpec())
 			DeferCleanup(DeleteNovaCell, novaCellName)
 			novaConductorName = types.NamespacedName{
 				Namespace: namespace,

--- a/test/functional/novaconductor_controller_test.go
+++ b/test/functional/novaconductor_controller_test.go
@@ -184,8 +184,7 @@ var _ = Describe("NovaConductor controller", func() {
 						Name:      fmt.Sprintf("%s-config-data", novaConductorName.Name),
 					},
 				)
-				Expect(configDataMap.Data).Should(
-					HaveKeyWithValue("custom.conf", "# add your customization here"))
+				Expect(configDataMap.Data).Should(HaveKeyWithValue("custom.conf", ""))
 
 				scriptMap := th.GetConfigMap(
 					types.NamespacedName{


### PR DESCRIPTION
The `omitempty` tag can cause surprising behavior when used on a field that has default value defined. For example: If we have field

```golnag
// +kubebuilder:default=1
Replicas int32 `json:"replicas,omitempty"`
```

and the client is populating this field via `controllerutil.CreateOrPatch` with a value `0` then the value of the field will be `1` instead of `0` on the server side. The `0` value is the empty value of `int32` and `omitempty` means if the value is empty then the field is not emitted when serialized to json. Therefore the server won't get the field replicas and therefore uses the default value `1` from the kubebuilder default annotation.

This series removes `omitempty` from fields that has default value defined to avoid the above surprise. But this change teased out bugs in the code and shortcomings in our envtest coverage which are fixed here:
* PasswordSelector and ServiceUser fields were not propagated between Nova and lower level CRs.  These are fixed now
* The envtest was not able to create Nova CR with leaving out optional fields from the input because it used novav1 golang structs to create the CRs. So the creation in the test is switched to use unstructured create to allow leaving out fields form the input.

There is a new check in operator-lint C003 to prevent `omitempty` + default value to be re-introduced later. https://github.com/gibizer/operator-lint/blob/dev/linters/crd/C003/README.md 