### PR TITLE
Cleanup CI make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,10 +180,6 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 	test -s $(LOCALBIN)/controller-gen || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
 
 .PHONY: envtest
-# This will be moved to the job definition after the job passes
-# in CI the GOFLAGS is set to -mod=vendor but envtest fails to install
-# dependencies with that
-envtest: export GOFLAGS=-mod=mod
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
 	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
@@ -269,10 +265,6 @@ govet: get-ci-tools
 	GOWORK=off $(CI_TOOLS_REPO_DIR)/test-runner/govet.sh ./api
 
 # Run go test against code
-# this will be moved to the job definition after the job passes
-# in CI GOFLAGS is set to -mod=vendor but envtest fails to install
-# dependencies with that
-gotest: export GOFLAGS=-mod=mod
 gotest: get-ci-tools envtest
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) -v debug --bin-dir $(LOCALBIN) use $(ENVTEST_K8S_VERSION) -p path)" $(CI_TOOLS_REPO_DIR)/test-runner/gotest.sh
 


### PR DESCRIPTION
The GOFLAGS env tuning is merged to the CI job definition so we can remove the temporary fix from our Makefile.

Depends-On: https://github.com/openshift/release/pull/34614 (already merged)