### PR TITLE
Add basic validation to our samples

### DIFF
--- a/config/samples/nova_v1beta1_nova-multi-cell.yaml
+++ b/config/samples/nova_v1beta1_nova-multi-cell.yaml
@@ -10,7 +10,7 @@ spec:
   # This is the name of the single RabbitMqCluster CR we deploy today
   # The Service is labelled with
   # app.kubernetes.io/component=rabbitmq, app.kubernetes.io/name=<RabbitMqCluster.Name>
-  apiMessageBusInstance: default-security-context
+  apiMessageBusInstance: rabbitmq
   # This is the name of the KeystoneAPI CR we deploy today
   # The Service is labelled with service=keystone,internal=true
   keystoneInstance: keystone
@@ -24,14 +24,13 @@ spec:
   passwordSelectors:
     service: NovaPassword
     apiDatabase: NovaAPIDatabasePassword
-    apiMessageBus: NovaAPIMessageBusPassword
+    cellDatabse: NovaCell0DatabasePassword
   serviceUser: nova
   debug:
     stopDBSync: False
     stopService: False
     preserveJob: False
   apiServiceTemplate:
-    #NOTE(gibi): secret with users is automatically passed by Nova CR
     customServiceConfig: |
       # service config customization
       debug=True
@@ -43,10 +42,10 @@ spec:
     nodeSelector: {}
     resources:
       limits:
-        cpu: 0.5
+        cpu: "0.5"
         memory: 512Mi
       requests:
-        cpu: 0.1
+        cpu: "0.1"
         memory: 200Mi
   schedulerServiceTemplate:
     customServiceConfig: |
@@ -92,7 +91,7 @@ spec:
     cell0:
       cellDatabaseInstance: mariadb-cell0
       cellDatabaseUser: nova_cell0
-      cellMessageBusInstance: rabbitmq-cell0
+      cellMessageBusInstance: rabbitmq
       # cell0 alway needs access to the API DB and MQ as it hosts the super
       # conductor. It will inherit the API DB and MQ access from the Nova CR
       # that creates it.
@@ -169,7 +168,7 @@ spec:
       cellDatabaseInstance: mariadb-cell2
       cellDatabaseUser: nova_cell2
       cellMessageBusInstance: rabbitmq-cell2
-      # cell2 will not get the API DB and MQ connection if from the Nova CR
+      # cell2 will not get the API DB and MQ connection info from the Nova CR
       hasAPIAccess: false
       conductorServiceTemplate:
         customServiceConfig: |

--- a/config/samples/nova_v1beta1_novaapi.yaml
+++ b/config/samples/nova_v1beta1_novaapi.yaml
@@ -3,38 +3,9 @@ kind: NovaAPI
 metadata:
   name: novaapi-sample
 spec:
-  secret: osp-secret
-  passwordSelectors:
-    service: NovaPassword
-    apiDatabase: NovaAPIDatabasePassword
-    apiMessageBus: NovaAPIMessageBusPassword
-    cellDatabase: NovaCell0DatabasePassword
-    cellMessageBus: null
-  serviceUser: nova
-  keystoneAuthURL: http://keystone-internal-openstack.apps-crc.testing
-  apiDatabaseUser: nova
-  # This is the hostname of the default DB today
   apiDatabaseHostname: openstack
-  # Q: do we need db an rabbit port? it seems today we use the default port
-  # This is the hostname of the default Rabbit today
-  apiMessageBusHostname: default-security-context
-  customServiceConfig: |
-    # service config customization
-    debug=True
-  defaultConfigOverwrite:
-    policy.yaml: |
-      # my custom policy
+  apiMessageBusSecretName: rabbitmq-transport-url-nova-api-transport
+  cell0DatabaseHostname: openstack
   containerImage: quay.io/tripleozedcentos9/openstack-nova-api:current-tripleo
-  replicas: 1
-  nodeSelector: {}
-  resources:
-    limits:
-      cpu: 0.5
-      memory: 512Mi
-    requests:
-      cpu: 0.1
-      memory: 200Mi
-  debug:
-    stopDBSync: False
-    stopService: False
-    preserveJob: False
+  keystoneAuthURL: http://keystone-public-openstack.apps-crc.testing
+  secret: osp-secret

--- a/config/samples/nova_v1beta1_novacell.yaml
+++ b/config/samples/nova_v1beta1_novacell.yaml
@@ -1,6 +1,0 @@
-apiVersion: nova.openstack.org/v1beta1
-kind: NovaCell
-metadata:
-  name: novacell-sample
-spec:
-  # TODO(user): Add fields here

--- a/config/samples/nova_v1beta1_novacell1-upcall.yaml
+++ b/config/samples/nova_v1beta1_novacell1-upcall.yaml
@@ -3,63 +3,12 @@ kind: NovaCell
 metadata:
   name: novacell1-with-upcall-sample
 spec:
-  cellName: cell1
-  secret: osp-secret
-  # Here we have to have both api and cell passwords selectors
-  # as cell1 will support upcalls
-  passwordSelectors:
-    service: NovaPassword
-    apiDatabase: NovaAPIDatabasePassword
-    apiMessageBus: NovaAPIMessageBusPassword
-    cellDatabase: NovaCell1DatabasePassword
-    cellMessageBus: NovaCell1MessageBusPassword
-  serviceUser: nova
-  keystoneAuthURL: http://keystone-internal-openstack.apps-crc.testing
-  apiDatabaseUser: nova
-  # This is the hostname of the default DB today
+  # By having access to the API DB this cell has upcall support
   apiDatabaseHostname: openstack
-  # Q: do we need db an rabbit port? it seems today we use the default port
-  # This is the hostname of the default Rabbit today
-  apiMessageBusHostname: default-security-context
-  cellDatabaseUser: nova
   cellDatabaseHostname: openstack
-  cellMessageBusUser: nova
-  cellMessageBusHostname: default-security-context
-  conductorServiceTemplate:
-    customServiceConfig: >
-      # service config customization
-      [DEFAULT]
-      debug=True
-    defaultConfigOverwrite:
-      logging.conf: >
-      # my custom logging configuration
-    containerImage: quay.io/tripleozedcentos9/openstack-nova-conductor:current-tripleo
-    replicate: 3
-    nodeSelector: {}
-    resources:
-      limits:
-        cpu: 500m
-        memory: 128Mi
-      requests:
-        cpu: 10m
-        memory: 64Mi
-  # lets assume in this example that metadata is at the top
-  metadataServiceTemplate: null
-  noVNCProxyServiceTemplate:
-    customServiceConfig: >
-      # service config customization
-      [DEFAULT]
-      debug=True
-    defaultConfigOverwrite:
-      logging.conf: >
-      # my custom logging configuration
-    containerImage: quay.io/tripleozedcentos9/openstack-nova-novncproxy:current-tripleo
-    replicate: 3
-    nodeSelector: {}
-    resources:
-      limits:
-        cpu: 500m
-        memory: 128Mi
-      requests:
-        cpu: 10m
-        memory: 64Mi
+  cellMessageBusSecretName: rabbitmq-transport-url-cell1-transport
+  cellName: cell1
+  conductorServiceTemplate: {}
+  keystoneAuthURL: http://keystone-public-openstack.apps-crc.testing
+  noVNCProxyServiceTemplate: {}
+  secret: osp-secret

--- a/config/samples/nova_v1beta1_novacell2-without-upcall.yaml
+++ b/config/samples/nova_v1beta1_novacell2-without-upcall.yaml
@@ -3,83 +3,10 @@ kind: NovaCell
 metadata:
   name: novacell2-without-upcall-sample
 spec:
-  cellName: cell2
-  secret: osp-secret
-  passwordSelectors:
-    service: NovaPassword
-    # this cell will not support upcalls
-    apiDatabase: null
-    apiMessageBus: null
-    cellDatabase: NovaCell2DatabasePassword
-    cellMessageBus: NovaCell2MessageBusPassword
-  serviceUser: nova
-  keystoneAuthURL: http://keystone-internal-openstack.apps-crc.testing
-  apiDatabaseUser: null
-  # cell2 doesn't have access to the api DB
-  apiDatabaseHostname: null
-  # cell2 doesn't have access to api message bus
-  apiMessageBusHostname: null
-  cellDatabaseUser: nova
   cellDatabaseHostname: openstack
-  cellMessageBusUser: nova
-  cellMessageBusHostname: default-security-context
-  conductorServiceTemplate:
-    customServiceConfig: >
-      # service config customization
-      [DEFAULT]
-      debug=True
-    defaultConfigOverwrite:
-      logging.conf: >
-      # my custom logging configuration
-    containerImage: quay.io/tripleozedcentos9/openstack-nova-conductor:current-tripleo
-    replicate: 3
-    nodeSelector: {}
-    resources:
-      limits:
-        cpu: 500m
-        memory: 128Mi
-      requests:
-        cpu: 10m
-        memory: 64Mi
-  # lets assume in this example that metadata is at cell level
-  metadataServiceTemplate:
-    customServiceConfig: >
-      # service config customization
-      [DEFAULT]
-      debug=True
-      [api]
-      # make sure this is in sync with the fact that this nova-metadata
-      # service is expected to run on the cell level
-      local_metadata_per_cell = True
-    defaultConfigOverwrite:
-      logging.conf: >
-        # my custom logging configuration
-    # TODO: what is the name of the container for metadata?
-    containerImage: quay.io/tripleozedcentos9/openstack-nova-metadata-api:current-tripleo
-    replicate: 3
-    nodeSelector: {}
-    resources:
-      limits:
-        cpu: 500m
-        memory: 128Mi
-      requests:
-        cpu: 10m
-        memory: 64Mi
-  noVNCProxyServiceTemplate:
-    customServiceConfig: >
-      # service config customization
-      [DEFAULT]
-      debug=True
-    defaultConfigOverwrite:
-      logging.conf: >
-      # my custom logging configuration
-    containerImage: quay.io/tripleozedcentos9/openstack-nova-novncproxy:current-tripleo
-    replicate: 3
-    nodeSelector: {}
-    resources:
-      limits:
-        cpu: 500m
-        memory: 128Mi
-      requests:
-        cpu: 10m
-        memory: 64Mi
+  cellMessageBusSecretName: rabbitmq-transport-url-cell2-transport
+  cellName: cell2
+  conductorServiceTemplate: {}
+  keystoneAuthURL: http://keystone-public-openstack.apps-crc.testing
+  noVNCProxyServiceTemplate: {}
+  secret: osp-secret

--- a/config/samples/nova_v1beta1_novaconductor-cell.yaml
+++ b/config/samples/nova_v1beta1_novaconductor-cell.yaml
@@ -1,0 +1,10 @@
+apiVersion: nova.openstack.org/v1beta1
+kind: NovaConductor
+metadata:
+  name: novaconductor-sample
+spec:
+  cellMessageBusSecretName: rabbitmq-transport-url-cell1-transport
+  cellName: cell1
+  containerImage: quay.io/tripleozedcentos9/openstack-nova-conductor:current-tripleo
+  keystoneAuthURL: http://keystone-public-openstack.apps-crc.testing
+  secret: osp-secret

--- a/config/samples/nova_v1beta1_novaconductor-super.yaml
+++ b/config/samples/nova_v1beta1_novaconductor-super.yaml
@@ -1,14 +1,11 @@
 apiVersion: nova.openstack.org/v1beta1
-kind: NovaCell
+kind: NovaConductor
 metadata:
-  name: novacell0-sample
+  name: novaconductor-sample
 spec:
-  # cell0 always needs API DB access
   apiDatabaseHostname: openstack
-  cellDatabaseHostname: openstack
   cellMessageBusSecretName: rabbitmq-transport-url-nova-api-transport
   cellName: cell0
-  conductorServiceTemplate: {}
+  containerImage: quay.io/tripleozedcentos9/openstack-nova-conductor:current-tripleo
   keystoneAuthURL: http://keystone-public-openstack.apps-crc.testing
-  noVNCProxyServiceTemplate: {}
   secret: osp-secret

--- a/config/samples/nova_v1beta1_novaconductor.yaml
+++ b/config/samples/nova_v1beta1_novaconductor.yaml
@@ -1,6 +1,0 @@
-apiVersion: nova.openstack.org/v1beta1
-kind: NovaConductor
-metadata:
-  name: novaconductor-sample
-spec:
-  # TODO(user): Add fields here

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/openstack-k8s-operators/nova-operator/api v0.0.0-00010101000000-000000000000
 	github.com/openstack-k8s-operators/openstack-operator/apis v0.0.0-20221201150228-f59193372831
 	go.uber.org/zap v1.24.0
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.25.5
 	k8s.io/apimachinery v0.26.0
 	k8s.io/client-go v0.25.4
@@ -78,7 +79,6 @@ require (
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.25.0 // indirect
 	k8s.io/component-base v0.25.0 // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect

--- a/test/functional/sample_test.go
+++ b/test/functional/sample_test.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package functional_test
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v3"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const SamplesDir = "../../config/samples/"
+
+func ReadSample(sampleFileName string) map[string]interface{} {
+	rawSample := make(map[string]interface{})
+
+	bytes, err := os.ReadFile(filepath.Join(SamplesDir, sampleFileName))
+	Expect(err).ShouldNot(HaveOccurred())
+	Expect(yaml.Unmarshal(bytes, rawSample)).Should(Succeed())
+
+	return rawSample
+}
+
+func CreateNovaFromSample(sampleFileName string, namespace string) types.NamespacedName {
+	novaName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      uuid.New().String(),
+	}
+
+	raw := ReadSample(sampleFileName)
+	CreateNova(novaName, raw["spec"].(map[string]interface{}))
+	DeferCleanup(DeleteNova, novaName)
+	return novaName
+}
+
+func CreateNovaAPIFromSample(sampleFileName string, namespace string) types.NamespacedName {
+	raw := ReadSample(sampleFileName)
+	name := CreateNovaAPI(namespace, raw["spec"].(map[string]interface{}))
+	DeferCleanup(DeleteNova, name)
+	return name
+}
+
+func CreateNovaCellFromSample(sampleFileName string, namespace string) types.NamespacedName {
+	raw := ReadSample(sampleFileName)
+	name := CreateNovaCell(namespace, raw["spec"].(map[string]interface{}))
+	DeferCleanup(DeleteNova, name)
+	return name
+}
+
+func CreateNovaConductorFromSample(sampleFileName string, namespace string) types.NamespacedName {
+	raw := ReadSample(sampleFileName)
+	name := CreateNovaConductor(namespace, raw["spec"].(map[string]interface{}))
+	DeferCleanup(DeleteNova, name)
+	return name
+}
+
+// This is a set of test for our samples. It only validates that the sample
+// file has all the required field with proper types. But it does not
+// validate that using a sample file will result in a working deployment.
+// TODO(gibi): By building up all the prerequisits (e.g. MariaDBDatabase) in
+// the test and by simulating Job and Deploymnet success we could assert
+// that each sample creates a CR in Ready state.
+var _ = Describe("Samples", func() {
+	var namespace string
+	BeforeEach(func() {
+		// NOTE(gibi): We need to create a unique namespace for each test run
+		// as namespaces cannot be deleted in a locally running envtest. See
+		// https://book.kubebuilder.io/reference/envtest.html#namespace-usage-limitation
+		namespace = uuid.New().String()
+		CreateNamespace(namespace)
+		// We still request the delete of the Namespace to properly cleanup if
+		// we run the test in an existing cluster.
+		DeferCleanup(DeleteNamespace, namespace)
+		// NOTE(gibi): ConfigMap generation looks up the local templates
+		// directory via ENV, so provide it
+		DeferCleanup(os.Setenv, "OPERATOR_TEMPLATES", os.Getenv("OPERATOR_TEMPLATES"))
+		os.Setenv("OPERATOR_TEMPLATES", "../../templates")
+
+		// Uncomment this if you need the full output in the logs from gomega
+		// matchers
+		// format.MaxLength = 0
+
+	})
+
+	When("nova_v1beta1_nova.yaml sample is applied", func() {
+		It("Nova is created", func() {
+			name := CreateNovaFromSample("nova_v1beta1_nova.yaml", namespace)
+			GetNova(name)
+		})
+	})
+	When("nova_v1beta1_nova_only_cell0.yaml sample is applied", func() {
+		It("Nova is created", func() {
+			name := CreateNovaFromSample("nova_v1beta1_nova_only_cell0.yaml", namespace)
+			GetNova(name)
+		})
+	})
+	When("nova_v1beta1_nova-multi-cell.yaml sample is applied", func() {
+		It("Nova is created", func() {
+			name := CreateNovaFromSample("nova_v1beta1_nova-multi-cell.yaml", namespace)
+			GetNova(name)
+		})
+	})
+	When("nova_v1beta1_novaapi.yaml sample is applied", func() {
+		It("NovaAPI is created", func() {
+			name := CreateNovaAPIFromSample("nova_v1beta1_novaapi.yaml", namespace)
+			GetNovaAPI(name)
+		})
+	})
+	When("nova_v1beta1_novacell0.yaml sample is applied", func() {
+		It("NovaCell is created", func() {
+			name := CreateNovaCellFromSample("nova_v1beta1_novacell0.yaml", namespace)
+			GetNovaCell(name)
+		})
+	})
+	When("nova_v1beta1_novacell1-upcall.yaml sample is applied", func() {
+		It("NovaCell is created", func() {
+			name := CreateNovaCellFromSample("nova_v1beta1_novacell1-upcall.yaml", namespace)
+			GetNovaCell(name)
+		})
+	})
+	When("nova_v1beta1_novacell2-without-upcall.yaml sample is applied", func() {
+		It("NovaCell is created", func() {
+			name := CreateNovaCellFromSample("nova_v1beta1_novacell2-without-upcall.yaml", namespace)
+			GetNovaCell(name)
+		})
+	})
+	When("nova_v1beta1_novaconductor-super.yaml sample is applied", func() {
+		It("NovaConductor is created", func() {
+			name := CreateNovaConductorFromSample("nova_v1beta1_novaconductor-super.yaml", namespace)
+			GetNovaConductor(name)
+		})
+	})
+	When("nova_v1beta1_novaconductor-cell.yaml sample is applied", func() {
+		It("NovaConductor is created", func() {
+			name := CreateNovaConductorFromSample("nova_v1beta1_novaconductor-cell.yaml", namespace)
+			GetNovaConductor(name)
+		})
+	})
+})


### PR DESCRIPTION
With envtest we can validate that our CRD samples are well formed and has all the required parameters.

This patch also took the opportunity to clean up the samples.