### PR TITLE
Refactor our defer calls

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -274,3 +274,39 @@ func (r *ReconcilerBase) GenerateConfigs(
 	// to enable unit testing at some point.
 	return configmap.EnsureConfigMaps(ctx, h, instance, cms, envVars)
 }
+
+func (r *ReconcilerBase) patchInstance(ctx context.Context, h *helper.Helper, instance client.Object) error {
+	var err error
+
+	if err = h.SetAfter(instance); err != nil {
+		util.LogErrorForObject(h, err, "Set after and calc patch/diff", instance)
+		return err
+	}
+
+	changes := h.GetChanges()
+	patch := client.MergeFrom(h.GetBeforeObject())
+
+	if changes["metadata"] {
+		err = r.Client.Patch(ctx, instance, patch)
+		if k8s_errors.IsConflict(err) {
+			util.LogForObject(h, "Metadata update conflict", instance)
+			return err
+		} else if err != nil && !k8s_errors.IsNotFound(err) {
+			util.LogErrorForObject(h, err, "Metadate update failed", instance)
+			return err
+		}
+	}
+
+	if changes["status"] {
+		err = r.Client.Status().Patch(ctx, instance, patch)
+		if k8s_errors.IsConflict(err) {
+			util.LogForObject(h, "Status update conflict", instance)
+			return err
+
+		} else if err != nil && !k8s_errors.IsNotFound(err) {
+			util.LogErrorForObject(h, err, "Status update failed", instance)
+			return err
+		}
+	}
+	return nil
+}

--- a/controllers/nova_controller.go
+++ b/controllers/nova_controller.go
@@ -25,7 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -112,39 +111,10 @@ func (r *NovaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 			instance.Status.Conditions.MarkTrue(
 				condition.ReadyCondition, condition.ReadyMessage)
 		}
-		if err := h.SetAfter(instance); err != nil {
-			util.LogErrorForObject(h, err, "Set after and calc patch/diff", instance)
+		err := r.patchInstance(ctx, h, instance)
+		if err != nil {
 			_err = err
 			return
-		}
-
-		changes := h.GetChanges()
-		patch := client.MergeFrom(h.GetBeforeObject())
-
-		if changes["metadata"] {
-			err = r.Client.Patch(ctx, instance, patch)
-			if k8s_errors.IsConflict(err) {
-				util.LogForObject(h, "Metadata update conflict", instance)
-				_err = err
-				return
-			} else if err != nil && !k8s_errors.IsNotFound(err) {
-				util.LogErrorForObject(h, err, "Metadate update failed", instance)
-				_err = err
-				return
-			}
-		}
-
-		if changes["status"] {
-			err = r.Client.Status().Patch(ctx, instance, patch)
-			if k8s_errors.IsConflict(err) {
-				util.LogForObject(h, "Status update conflict", instance)
-				_err = err
-				return
-			} else if err != nil && !k8s_errors.IsNotFound(err) {
-				util.LogErrorForObject(h, err, "Status update failed", instance)
-				_err = err
-				return
-			}
 		}
 	}()
 

--- a/controllers/novaapi_controller.go
+++ b/controllers/novaapi_controller.go
@@ -23,7 +23,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -116,39 +115,10 @@ func (r *NovaAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 			instance.Status.Conditions.MarkTrue(
 				condition.ReadyCondition, condition.ReadyMessage)
 		}
-		if err := h.SetAfter(instance); err != nil {
-			util.LogErrorForObject(h, err, "Set after and calc patch/diff", instance)
+		err := r.patchInstance(ctx, h, instance)
+		if err != nil {
 			_err = err
 			return
-		}
-
-		changes := h.GetChanges()
-		patch := client.MergeFrom(h.GetBeforeObject())
-
-		if changes["metadata"] {
-			err = r.Client.Patch(ctx, instance, patch)
-			if k8s_errors.IsConflict(err) {
-				util.LogForObject(h, "Metadata update conflict", instance)
-				_err = err
-				return
-			} else if err != nil && !k8s_errors.IsNotFound(err) {
-				util.LogErrorForObject(h, err, "Metadate update failed", instance)
-				_err = err
-				return
-			}
-		}
-
-		if changes["status"] {
-			err = r.Client.Status().Patch(ctx, instance, patch)
-			if k8s_errors.IsConflict(err) {
-				util.LogForObject(h, "Status update conflict", instance)
-				_err = err
-				return
-			} else if err != nil && !k8s_errors.IsNotFound(err) {
-				util.LogErrorForObject(h, err, "Status update failed", instance)
-				_err = err
-				return
-			}
 		}
 	}()
 

--- a/controllers/novacell_controller.go
+++ b/controllers/novacell_controller.go
@@ -23,7 +23,6 @@ import (
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -97,25 +96,10 @@ func (r *NovaCellReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 			instance.Status.Conditions.MarkTrue(
 				condition.ReadyCondition, condition.ReadyMessage)
 		}
-		if err := h.SetAfter(instance); err != nil {
-			util.LogErrorForObject(h, err, "Set after and calc patch/diff", instance)
+		err := r.patchInstance(ctx, h, instance)
+		if err != nil {
 			_err = err
 			return
-		}
-
-		if changed := h.GetChanges()["status"]; changed {
-			patch := client.MergeFrom(h.GetBeforeObject())
-
-			err = r.Client.Status().Patch(ctx, instance, patch)
-			if k8s_errors.IsConflict(err) {
-				util.LogForObject(h, "Status update conflict", instance)
-				_err = err
-				return
-			} else if err != nil && !k8s_errors.IsNotFound(err) {
-				util.LogErrorForObject(h, err, "Status update failed", instance)
-				_err = err
-				return
-			}
 		}
 	}()
 


### PR DESCRIPTION
Our defer call at the end of Reconcile does two things:
1. update the Ready condition of the instance if all the other
   conditions are in True state
2. persist the metadata and the status changes of the object into etcd.

The 2 is complicated but common for each of our controllers so it is pulled out and the impl moved to ReconcileBase. Note that this automatically adds metadata patching capabilities to those controllers (e.g. cell) that does not need it today.