### PR TITLE
[NovaConductor]Init DeploymentReadyCondition

### DIFF
--- a/controllers/novaconductor_controller.go
+++ b/controllers/novaconductor_controller.go
@@ -226,6 +226,11 @@ func (r *NovaConductorReconciler) initConditions(
 				condition.InitReason,
 				condition.DBSyncReadyInitMessage,
 			),
+			condition.UnknownCondition(
+				condition.DeploymentReadyCondition,
+				condition.InitReason,
+				condition.DeploymentReadyInitMessage,
+			),
 		)
 
 		instance.Status.Conditions.Init(&cl)


### PR DESCRIPTION
We missed the init for this condition this cause that NovaConductor goes to Ready=True even before the Deployment is ready.