### PR TITLE
Improve logging

### DIFF
--- a/controllers/nova_controller.go
+++ b/controllers/nova_controller.go
@@ -180,6 +180,7 @@ func (r *NovaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 
 	// We have to wait until our service is registered to keystone
 	if !instance.Status.Conditions.IsTrue(condition.KeystoneServiceReadyCondition) {
+		util.LogForObject(h, "Waiting for the KeystoneService to become Ready", instance)
 		return ctrl.Result{}, nil
 	}
 
@@ -417,6 +418,7 @@ func (r *NovaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 	// until cell0 is ready as top level services need cell0 to register in
 	if cell0, ok := cells[Cell0Name]; !ok || !cell0.IsReady() {
 		// we need to stop here until cell0 is ready
+		util.LogForObject(h, "Waiting for cell0 to become Ready before creating the top level services", instance)
 		return ctrl.Result{}, nil
 	}
 

--- a/controllers/novaapi_controller.go
+++ b/controllers/novaapi_controller.go
@@ -221,6 +221,7 @@ func (r *NovaAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 
 	// Only expose the service is the deployment succeeded
 	if !instance.Status.Conditions.IsTrue(condition.DeploymentReadyCondition) {
+		util.LogForObject(h, "Waiting for the Deployment to become Ready before exposing the sevice in Keystone", instance)
 		return ctrl.Result{}, nil
 	}
 
@@ -237,6 +238,7 @@ func (r *NovaAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		return ctrl.Result{}, err
 	}
 
+	util.LogForObject(h, "Successfully reconciled", instance)
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/novacell_controller.go
+++ b/controllers/novacell_controller.go
@@ -124,6 +124,7 @@ func (r *NovaCellReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 		return result, err
 	}
 
+	util.LogForObject(h, "Successfully reconciled", instance)
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/novaconductor_controller.go
+++ b/controllers/novaconductor_controller.go
@@ -182,6 +182,7 @@ func (r *NovaConductorReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return result, err
 	}
 
+	util.LogForObject(h, "Successfully reconciled", instance)
 	return ctrl.Result{}, nil
 }
 


### PR DESCRIPTION
To help troubleshooting this patch adds log when the controller returns form reconcile either due to waiting for some external condition or because it succeeded. All the other return point have a non nil error causing the controller to print a stacktrace. So with this patch every return either logs a message or throws an error.