### PR TITLE
[NovaConductor]Properly remove logging.conf

### DIFF
--- a/templates/novaconductor/config/nova-conductor-config.json
+++ b/templates/novaconductor/config/nova-conductor-config.json
@@ -12,12 +12,6 @@
             "dest": "/etc/nova/nova.conf.d/custom.conf",
             "owner": "nova",
             "perm": "0600"
-        },
-        {
-            "source": "/var/lib/config-data/merged/logging.conf",
-            "dest": "/etc/nova/logging.conf",
-            "owner": "root",
-            "perm": "0644"
         }
     ],
     "permissions": [


### PR DESCRIPTION
Th #189 removed the usage of logging.conf for now, but I forgot to remove it from the reference of it from the kolla config.json.