### PR TITLE
Make TransportURL name depend on Nova CR name

### DIFF
--- a/controllers/nova_controller.go
+++ b/controllers/nova_controller.go
@@ -240,7 +240,7 @@ func (r *NovaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 	// message bus is always the same as the top level API message bus so
 	// we create API MQ separately first
 	apiMQSecretName, apiMQStatus, apiMQError := r.ensureMQ(
-		ctx, h, instance, "nova-api-transport", instance.Spec.APIMessageBusInstance)
+		ctx, h, instance, instance.Name+"-api-transport", instance.Spec.APIMessageBusInstance)
 	if apiMQStatus == nova.MQFailed {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			novav1.NovaAPIMQReadyCondition,
@@ -279,7 +279,7 @@ func (r *NovaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 			err = apiMQError
 		} else {
 			cellMQ, status, err = r.ensureMQ(
-				ctx, h, instance, cellName+"-transport", cellTemplate.CellMessageBusInstance)
+				ctx, h, instance, instance.Name+"-"+cellName+"-transport", cellTemplate.CellMessageBusInstance)
 		}
 		if err != nil {
 			failedMQs = append(failedMQs, fmt.Sprintf("%s(%v)", cellName, err.Error()))

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -811,14 +811,14 @@ func GetCellNames(novaName types.NamespacedName, cell string) CellNames {
 		},
 		TransportURLName: types.NamespacedName{
 			Namespace: novaName.Namespace,
-			Name:      cell + "-transport",
+			Name:      cellName.Name + "-transport",
 		},
 	}
 
 	if cell == "cell0" {
 		c.TransportURLName = types.NamespacedName{
 			Namespace: novaName.Namespace,
-			Name:      "nova-api-transport",
+			Name:      novaName.Name + "-api-transport",
 		}
 	}
 


### PR DESCRIPTION
So far nova-api-transport as TransportURL name was hardcoded. Also the cell TransportURL names only depended on the name of the cell but did not depend on the name of the Nova CR. Now both issue if fixed.