### PR TITLE
Revert "Use the new lib-common/common/log interface"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -90,5 +90,3 @@ require (
 )
 
 replace github.com/openstack-k8s-operators/nova-operator/api => ./api
-
-replace github.com/openstack-k8s-operators/lib-common/modules/common => github.com/gibizer/lib-common/modules/common v0.0.0-20221219140315-47b042183a5b

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,6 @@ github.com/flowstack/go-jsonschema v0.1.1/go.mod h1:yL7fNggx1o8rm9RlgXv7hTBWxdBM
 github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/gibizer/lib-common/modules/common v0.0.0-20221219140315-47b042183a5b h1:J7HneemRRPUAFpBUxlTEIXQ3za4J/kUwpSwWf8fNchw=
-github.com/gibizer/lib-common/modules/common v0.0.0-20221219140315-47b042183a5b/go.mod h1:qV9OlokZRpqbHI3lmeN5EOmIKynWphw6GPl3zP9KOGM=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -286,6 +284,8 @@ github.com/openshift/api v3.9.0+incompatible h1:fJ/KsefYuZAjmrr3+5U9yZIZbTOpVkDD
 github.com/openshift/api v3.9.0+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openstack-k8s-operators/keystone-operator/api v0.0.0-20221123090515-e2561e258f0a h1:x1MGRitaQNIKdcyJUtcXRvKFhN3l5hcYlc7lD5N0APg=
 github.com/openstack-k8s-operators/keystone-operator/api v0.0.0-20221123090515-e2561e258f0a/go.mod h1:SwhyYcQUbpT4QLuqdsLjAlM0oPouHIJy1gVOkM4O5xQ=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20221124114404-c42a739be111 h1:X5Y2zXwOiPPFoQN0Ox8C2jL1tZo3+S9BjcOf9h/EYbU=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20221124114404-c42a739be111/go.mod h1:qV9OlokZRpqbHI3lmeN5EOmIKynWphw6GPl3zP9KOGM=
 github.com/openstack-k8s-operators/lib-common/modules/database v0.0.0-20221115095652-2c390a9d20b4 h1:RSIOKTJoJivtHJPhXXU6raTApSXsHK/CJS10iFqeI8s=
 github.com/openstack-k8s-operators/lib-common/modules/database v0.0.0-20221115095652-2c390a9d20b4/go.mod h1:umGUqQO4JtgefAaIwZjP+TxfxsLMEEeK/6VNzk8ooaI=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.0.0-20220915080953-f73a201a1da6 h1:MVNEHyqD0ZdO9jiyUSKw5M2T9Lc4l4Wx1pdC2/BSJ5Y=

--- a/go.work.sum
+++ b/go.work.sum
@@ -75,8 +75,6 @@ github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/getkin/kin-openapi v0.76.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
-github.com/gibizer/lib-common/modules/common v0.0.0-20221219140315-47b042183a5b h1:J7HneemRRPUAFpBUxlTEIXQ3za4J/kUwpSwWf8fNchw=
-github.com/gibizer/lib-common/modules/common v0.0.0-20221219140315-47b042183a5b/go.mod h1:qV9OlokZRpqbHI3lmeN5EOmIKynWphw6GPl3zP9KOGM=
 github.com/gibizer/openstack-operator/apis v0.0.0-20221117131348-5458078589f5/go.mod h1:ScmKvwvPeQv9qbFQ5wPnVE3y7iRuxic29NxX+P7iWG8=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=


### PR DESCRIPTION
Reverts openstack-k8s-operators/nova-operator#206 as it was depending on a forked lib-common