### PR TITLE
Make pre-commit.ci's gofmt happy

### DIFF
--- a/api/v1beta1/conditions.go
+++ b/api/v1beta1/conditions.go
@@ -20,9 +20,7 @@ import (
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 )
 
-//
 // Nova Condition Types used by API objects.
-//
 const (
 	// NovaAPIReadyCondition indicates if the NovaAPI is operational
 	NovaAPIReadyCondition condition.Type = "NovaAPIReady"
@@ -43,9 +41,7 @@ const (
 	NovaAllCellsMQReadyCondition condition.Type = "NovaAllCellsMQReady"
 )
 
-//
 // Common Messages used by API objects.
-//
 const (
 	// NovaAPIReadyInitMessage
 	NovaAPIReadyInitMessage = "NovaAPI not started"

--- a/api/v1beta1/groupversion_info.go
+++ b/api/v1beta1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1beta1 contains API Schema definitions for the nova v1beta1 API group
-//+kubebuilder:object:generate=true
-//+groupName=nova.openstack.org
+// +kubebuilder:object:generate=true
+// +groupName=nova.openstack.org
 package v1beta1
 
 import (

--- a/api/v1beta1/novacell_types.go
+++ b/api/v1beta1/novacell_types.go
@@ -199,7 +199,7 @@ func (s NovaCellStatus) GetConditions() condition.Conditions {
 	return s.Conditions
 }
 
-//IsReady returns true if the Cell reconciled successfully
+// IsReady returns true if the Cell reconciled successfully
 func (c NovaCell) IsReady() bool {
 	readyCond := c.Status.Conditions.Get(condition.ReadyCondition)
 	return readyCond != nil && readyCond.Status == corev1.ConditionTrue

--- a/controllers/novaconductor_controller.go
+++ b/controllers/novaconductor_controller.go
@@ -253,7 +253,6 @@ func (r *NovaConductorReconciler) ensureConfigMaps(
 //
 // generateServiceConfigMaps - create create configmaps which hold scripts and service configuration
 // TODO add DefaultConfigOverwrite
-//
 func (r *NovaConductorReconciler) generateServiceConfigMaps(
 	ctx context.Context,
 	h *helper.Helper,

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/functional/nova_controller_test.go
+++ b/test/functional/nova_controller_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/functional/nova_multicell_test.go
+++ b/test/functional/nova_multicell_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/functional/nova_reconfiguration_test.go
+++ b/test/functional/nova_reconfiguration_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/functional/novaapi_controller_test.go
+++ b/test/functional/novaapi_controller_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/functional/novacell_controller_test.go
+++ b/test/functional/novacell_controller_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/functional/novaconductor_controller_test.go
+++ b/test/functional/novaconductor_controller_test.go
@@ -1,8 +1,9 @@
-/*Licensed under the Apache License, Version 2.0 (the "License");
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
It seems pre-commit.ci changed to go1.19.4 where gofmt does a bit more
compared to the 1.18 version we use. This patch adapts the code style to
conform to 1.19 as well.