### PR TITLE
Enable errorlint in golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,5 @@
+linters:
+  # Enable specific linter
+  # https://golangci-lint.run/usage/linters/#enabled-by-default
+  enable:
+    errorlint


### PR DESCRIPTION
It is disabled by default but based on the discussion in https://github.com/openstack-k8s-operators/lib-common/pull/125 we think this is useful.

https://github.com/polyfloyd/go-errorlint