### PR TITLE
Get rid of deprecated [DEFAULT] use_forwarded_for

### DIFF
--- a/templates/nova.conf
+++ b/templates/nova.conf
@@ -99,7 +99,6 @@ ssl_minimum_version=tlsv1_3
 
 {{if eq .service_name "nova-api" "nova-metadata-api"}}
 [api]
-use_forwarded_for = true
 auth_strategy = keystone
 [oslo_middleware]
 enable_proxy_headers_parsing = True


### PR DESCRIPTION
This option was deprecated during Zed cycle[1] because it is basically duplicate of the oslo_middleware functionality.

[1] https://review.opendev.org/c/openstack/nova/+/836253