### PR TITLE
Drop deprecated ovsdb_interface

### DIFF
--- a/templates/nova.conf
+++ b/templates/nova.conf
@@ -161,9 +161,6 @@ reserve_disk_resource_for_image_cache=true
 # skip_hypervisor_version_check_on_lm=true
 
 {{ if eq .service_name "nova-compute"}}
-[os_vif_ovs]
-ovsdb_interface=vsctl
-
 [libvirt]
 live_migration_permit_post_copy=true
 live_migration_permit_auto_converge=true


### PR DESCRIPTION
This option was deprecated in os-vif 2.2.0, because the vsctl driver was deprecated and only the native driver will be supported.

[1] https://review.opendev.org/c/openstack/os-vif/+/744816