### PR TITLE
Remove unused www_authenticate_uri option

### DIFF
--- a/templates/nova.conf
+++ b/templates/nova.conf
@@ -206,7 +206,6 @@ cafile = {{ .openstack_cacert }}
 region_name = {{ .openstack_region_name }}
 
 [placement]
-www_authenticate_uri = {{ .keystone_internal_url }}
 auth_url =  {{ .keystone_internal_url }}
 auth_type = password
 project_domain_name = {{ .default_project_domain }}
@@ -219,7 +218,6 @@ region_name = {{ .openstack_region_name }}
 valid_interfaces = internal
 
 [glance]
-www_authenticate_uri = {{ .keystone_internal_url }}
 auth_url = {{ .keystone_internal_url }}
 auth_type = password
 project_domain_name = {{ .default_project_domain }}
@@ -233,7 +231,6 @@ valid_interfaces = internal
 {{if .debug }}debug=true{{end}}
 
 [neutron]
-www_authenticate_uri = {{ .keystone_internal_url }}
 auth_url = {{ .keystone_internal_url }}
 auth_type = password
 project_domain_name = {{ .default_project_domain }}
@@ -249,7 +246,6 @@ service_metadata_proxy = true
 
 {{if .enable_cinder }}
 [cinder]
-www_authenticate_uri = {{ .keystone_internal_url }}
 auth_url = {{ .keystone_internal_url }}
 auth_type = password
 project_domain_name = {{ .default_project_domain }}


### PR DESCRIPTION
This option is used only by keystone middleware so should be put only in the keystone_authtoken middleware section.