### PR TITLE
Fix wrong option to determine cinder endpoint type

### DIFF
--- a/templates/nova.conf
+++ b/templates/nova.conf
@@ -259,5 +259,5 @@ username = {{ .nova_keystone_user }}
 password = {{ .nova_keystone_password }}
 cafile = {{ .openstack_cacert }}
 region_name = {{ .openstack_region_name }}
-valid_interfaces = internal
+catalog_info = volumev3:cinderv3:internalURL
 {{end}}


### PR DESCRIPTION
The [cinder] section does not support the interface option and we should use the catalo_info option instead.