### PR TITLE
Fix the bundle build

### DIFF
--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -2,9 +2,9 @@
 resources:
 - nova_v1beta1_novaapi.yaml
 - nova_v1beta1_novascheduler.yaml
-- nova_v1beta1_novaconductor.yaml
+- nova_v1beta1_novaconductor-cell.yaml
 - nova_v1beta1_novametadata.yaml
 - nova_v1beta1_novanovncproxy.yaml
-- nova_v1beta1_novacell.yaml
+- nova_v1beta1_novacell1-upcall.yaml
 - nova_v1beta1_nova.yaml
 #+kubebuilder:scaffold:manifestskustomizesamples


### PR DESCRIPTION
The PR #179 break the bundle build by renaming sample files that are listed in the samples/kustomization.yaml. This patch restores the bundle build. A follow up PR will introduce a test build job to prevent such break in the future.