### PR TITLE
Generate manifests before test run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ PROC_CMD = --procs ${PROCS}
 
 .PHONY: test
 test: manifests generate fmt vet envtest ginkgo ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" $(GINKGO) --trace --cover --coverpkg=../../pkg/nova,../../pkg/novaapi,../../pkg/novaconductor,../../controllers,../../api/v1beta1 --coverprofile cover.out --covermode=atomic --randomize-all ${PROC_CMD} ./test/...
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) -v debug --bin-dir $(LOCALBIN) use $(ENVTEST_K8S_VERSION) -p path)" $(GINKGO) --trace --cover --coverpkg=../../pkg/nova,../../pkg/novaapi,../../pkg/novaconductor,../../controllers,../../api/v1beta1 --coverprofile cover.out --covermode=atomic --randomize-all ${PROC_CMD} ./test/...
 
 ##@ Build
 
@@ -272,8 +272,7 @@ govet: get-ci-tools
 	GOWORK=off $(CI_TOOLS_REPO_DIR)/test-runner/govet.sh ./api
 
 # Run go test against code
-gotest: get-ci-tools envtest
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) -v debug --bin-dir $(LOCALBIN) use $(ENVTEST_K8S_VERSION) -p path)" $(CI_TOOLS_REPO_DIR)/test-runner/gotest.sh
+gotest: test
 
 # Run golangci-lint test against code
 golangci: get-ci-tools


### PR DESCRIPTION
The envtest uses our CRD definitions during test so we need to run `make manifests` and `make generate` before the test run to always test with an up to date CRD yaml and golang definition.

The `make test` target generates manifests today but the `make gotest` target doesn't. The latter is used in the prow CI job[1]. So this patch make `gotest` an alias for the `test` target.

Also this patch switches the github action based test run to use `make gotest` instead of indirectly calling `go test`.

[1] https://github.com/openshift/release/blob/fe0b5ddd5c96f053a654883ae33ec05933ad6c5c/ci-operator/config/openstack-k8s-operators/nova-operator/openstack-k8s-operators-nova-operator-master.yaml#L31