### PR TITLE
[CI] workflow for bundle and image build

### DIFF
--- a/.github/workflows/build-operator-dont-publish.yaml
+++ b/.github/workflows/build-operator-dont-publish.yaml
@@ -1,0 +1,29 @@
+name: Build operator without publishing it
+
+on:
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  build-nova-operator-with-bunlde-and-index:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout nova-operator repository
+      uses: actions/checkout@v3
+
+    - name: Build
+      env:
+        # By not providing any remote repository here the build artifact will not be pushed
+        IMAGE_TAG_BASE: nova-operator
+      # Ideally we would add catalog-build target at the end but that requires
+      # the bundle to be pushed to a registry due to opm limitations:
+      # https://github.com/operator-framework/operator-registry/issues/933
+      # Having a local registry for the catalog-build is would require a
+      # registry with TLS support or we would need to modify the catalog-build
+      # target to add flags to the opm call. None of which worth the effort
+      # since right now I don't how a change of this repo could break that
+      # step.
+      run: make manifests generate build docker-build bundle bundle-build

--- a/Makefile
+++ b/Makefile
@@ -164,10 +164,12 @@ KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GINKGO ?= $(LOCALBIN)/ginkgo
+OPERATOR_SDK ?= $(LOCALBIN)/operator-sdk
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.8.7
 CONTROLLER_TOOLS_VERSION ?= v0.9.2
+OPERATOR_SDK_VERSION ?= v1.23.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize
@@ -192,11 +194,11 @@ $(GINKGO): $(LOCALBIN)
 	test -s $(LOCALBIN)/ginkgo || GOBIN=$(LOCALBIN) go install github.com/onsi/ginkgo/v2/ginkgo
 
 .PHONY: bundle
-bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.
-	operator-sdk generate kustomize manifests -q
+bundle: operator-sdk manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.
+	$(OPERATOR_SDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
-	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle $(BUNDLE_GEN_FLAGS)
-	operator-sdk bundle validate ./bundle
+	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
+	$(OPERATOR_SDK) bundle validate ./bundle
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.
@@ -290,3 +292,7 @@ operator-lint: ## Runs operator-lint
 	#TODO(gibi): bump this to v0.2.2 as soon as that version is tagged
 	GOBIN=$(LOCALBIN) go install github.com/gibizer/operator-lint@2ffa25b7f1c13fb2bdae5444a3dd1b5bbad529b1
 	go vet -vettool=$(LOCALBIN)/operator-lint ./... ./api/...
+
+.PHONY: operator-sdk
+operator-sdk: ## Download operator-sdk locally if necessary.
+	test -s $(OPERATOR_SDK) || curl -o $(LOCALBIN)/operator-sdk -L https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_linux_amd64 && chmod +x $(LOCALBIN)/operator-sdk


### PR DESCRIPTION
This patch adds a github workflow to build the nova-operator image, and bundle for each PR to see if the PR does not break the build. This job will not publish the build artifacts. Another build will run after the PR is merged to build the official artifacts and publish them.