### PR TITLE
[envtest]Bump envtest timeout to 10 secs

### DIFF
--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -41,12 +41,13 @@ const (
 	MessageBusSecretName = "rabbitmq-secret"
 	ContainerImage       = "test://nova"
 
-	interval = time.Millisecond * 10
-	timeout  = interval * 200
+	timeout = 10 * time.Second
+	// have maximum 100 retries before the timeout hits
+	interval = timeout / 100
 	// consistencyTimeout is the amount of time we use to repeatedly check
 	// that a condition is still valid. This is intendet to be used in
 	// asserts using `Consistently`.
-	consistencyTimeout = interval * 200
+	consistencyTimeout = timeout
 )
 
 func CreateUnstructured(rawObj map[string]interface{}) {


### PR DESCRIPTION
We saw some slow CI nodes where our default 2secs envtest step timeout is not enough. So this patch dumps the timeout to 10secs. Also we adjusts interval based on the timeout value