### PR TITLE
Ensure ./bin exists when downloading operator-sdk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -287,11 +287,12 @@ golint: get-ci-tools
 	export GOWORK=off && PATH=$(GOBIN):$(PATH); $(CI_TOOLS_REPO_DIR)/test-runner/golint.sh ./api
 
 .PHONY: operator-lint
-operator-lint: ## Runs operator-lint
+operator-lint: $(LOCALBIN) ## Runs operator-lint
 	#TODO(gibi): bump this to v0.2.2 as soon as that version is tagged
 	GOBIN=$(LOCALBIN) go install github.com/gibizer/operator-lint@2ffa25b7f1c13fb2bdae5444a3dd1b5bbad529b1
 	go vet -vettool=$(LOCALBIN)/operator-lint ./... ./api/...
 
 .PHONY: operator-sdk
-operator-sdk: ## Download operator-sdk locally if necessary.
+operator-sdk: $(OPERATOR_SDK) ## Download operator-sdk locally if necessary.
+$(OPERATOR_SDK): $(LOCALBIN)
 	test -s $(OPERATOR_SDK) || curl -o $(LOCALBIN)/operator-sdk -L https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_linux_amd64 && chmod +x $(LOCALBIN)/operator-sdk


### PR DESCRIPTION
The make bundle could fail in a fresh repo clone as ./bin direction is not exists.