### PR TITLE
Drop paths-ignore from build-nova-operator workflow

### DIFF
--- a/.github/workflows/build-nova-operator.yaml
+++ b/.github/workflows/build-nova-operator.yaml
@@ -4,17 +4,6 @@ on:
   push:
     branches:
       - '*'
-    paths-ignore:
-      - .gitignore
-      - .pull_request_pipeline
-      - changelog.txt
-      - LICENSE
-      - Makefile
-      - OWNERS
-      - PROJECT
-      - README.md
-      - .github/
-      - build/
 
 env:
   imageregistry: 'quay.io'


### PR DESCRIPTION
We use build-nova-operator workflow as a post merge to build containers and push to registry. Not building container for each hash can cause issue becuase of missing container tags.