### PR TITLE
Fix conductor ready with 0 replicas requested

### DIFF
--- a/controllers/novaconductor_controller.go
+++ b/controllers/novaconductor_controller.go
@@ -393,6 +393,9 @@ func (r *NovaConductorReconciler) ensureDeployment(
 	if instance.Status.ReadyCount > 0 {
 		util.LogForObject(h, "Deployment is ready", instance)
 		instance.Status.Conditions.MarkTrue(condition.DeploymentReadyCondition, condition.DeploymentReadyMessage)
+	} else if instance.Spec.Replicas == 0 {
+		util.LogForObject(h, "Deployment with 0 replicas is ready", instance)
+		instance.Status.Conditions.MarkTrue(condition.DeploymentReadyCondition, condition.DeploymentReadyMessage)
 	} else {
 		util.LogForObject(h, "Deployment is not ready", instance, "Status", ss.GetStatefulSet().Status)
 		instance.Status.Conditions.Set(condition.FalseCondition(


### PR DESCRIPTION
There is a bug supporting collapsed cell deployments. If the cell0 and cell1 deployed with the same message bus and then cell0 conductor replica is set to 0 afterwards then the deployment succeeds. But if the deployment started with:

      cellTemplates:
          cell0:
            cellDatabaseUser: nova_cell0
            conductorServiceTemplate:
              replicas: 0
            hasAPIAccess: true
          cell1:
            cellDatabaseUser: nova_cell1
            conductorServiceTemplate:
              replicas: 1
            hasAPIAccess: true

Then NovaConductor=cell0 never becomes Ready as the deployment ready condition is defined as StatefulSet.Status.ReadyCount > 0 . In this special case when 0 replicas is requested by the user the NovaConductor should be ready after the DB sync job succeeded as the user requested not to have any running service in the deployment.

This patch handles this special case.