### PR TITLE
Switch Nova default to cell separation

### DIFF
--- a/api/v1beta1/nova_types.go
+++ b/api/v1beta1/nova_types.go
@@ -50,7 +50,7 @@ type NovaSpec struct {
 	APIMessageBusInstance string `json:"apiMessageBusInstance"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={cell0: {cellDatabaseInstance: openstack, cellDatabaseUser: nova_cell0, cellMessageBusInstance: unused, hasAPIAccess: true, conductorServiceTemplate: {containerImage: "quay.io/tripleozedcentos9/openstack-nova-conductor:current-tripleo"}}}
+	// +kubebuilder:default={cell0: {cellDatabaseUser: nova_cell0, hasAPIAccess: true}, cell1: {cellDatabaseUser: nova_cell1, cellMessageBusInstance: rabbitmq-cell1, hasAPIAccess: true}}
 	// Cells is a mapping of cell names to NovaCellTemplate objects defining
 	// the cells in the deployment. The "cell0" cell is a mandatory cell in
 	// every deployment. Moreover any real deployment needs at least one

--- a/config/crd/bases/nova.openstack.org_nova.yaml
+++ b/config/crd/bases/nova.openstack.org_nova.yaml
@@ -436,11 +436,11 @@ spec:
                   type: object
                 default:
                   cell0:
-                    cellDatabaseInstance: openstack
                     cellDatabaseUser: nova_cell0
-                    cellMessageBusInstance: unused
-                    conductorServiceTemplate:
-                      containerImage: quay.io/tripleozedcentos9/openstack-nova-conductor:current-tripleo
+                    hasAPIAccess: true
+                  cell1:
+                    cellDatabaseUser: nova_cell1
+                    cellMessageBusInstance: rabbitmq-cell1
                     hasAPIAccess: true
                 description: Cells is a mapping of cell names to NovaCellTemplate
                   objects defining the cells in the deployment. The "cell0" cell is

--- a/config/samples/nova_v1beta1_nova.yaml
+++ b/config/samples/nova_v1beta1_nova.yaml
@@ -4,11 +4,3 @@ metadata:
   name: nova
 spec:
   secret: osp-secret
-  cellTemplates:
-    cell0:
-      cellDatabaseUser: nova_cell0
-      # cell0 always needs API access as it hosts the super conductor
-      hasAPIAccess: true
-    cell1:
-      cellDatabaseUser: nova_cell1
-      hasAPIAccess: true

--- a/config/samples/nova_v1beta1_nova_only_cell0.yaml
+++ b/config/samples/nova_v1beta1_nova_only_cell0.yaml
@@ -1,6 +1,0 @@
-apiVersion: nova.openstack.org/v1beta1
-kind: Nova
-metadata:
-  name: nova
-spec:
-  secret: osp-secret

--- a/test/functional/sample_test.go
+++ b/test/functional/sample_test.go
@@ -105,12 +105,6 @@ var _ = Describe("Samples", func() {
 			GetNova(name)
 		})
 	})
-	When("nova_v1beta1_nova_only_cell0.yaml sample is applied", func() {
-		It("Nova is created", func() {
-			name := CreateNovaFromSample("nova_v1beta1_nova_only_cell0.yaml", namespace)
-			GetNova(name)
-		})
-	})
 	When("nova_v1beta1_nova-multi-cell.yaml sample is applied", func() {
 		It("Nova is created", func() {
 			name := CreateNovaFromSample("nova_v1beta1_nova-multi-cell.yaml", namespace)


### PR DESCRIPTION
Now that OpenStackControlPlane supports deploying multiple RabbitMQCluster the default value of Nova.Spec.CellTemplates is changed to have cell0 and cell1 on different message buses to support proper cell separation. The new default assumes that besides to common bus named "rabbitmq" there is another bus name "rabbitmq-cell1" deployed.

Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/157 (merged)
Depends-On: #241 (merged)
Depends-On: https://github.com/openstack-k8s-operators/nova-operator/pull/244 (merged)
Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/76 (merged)