### PR TITLE
Add a collapsed cell sample

### DIFF
--- a/config/samples/nova_v1beta1_nova_collapsed_cell.yaml
+++ b/config/samples/nova_v1beta1_nova_collapsed_cell.yaml
@@ -1,0 +1,19 @@
+apiVersion: nova.openstack.org/v1beta1
+kind: Nova
+metadata:
+  name: nova
+spec:
+  secret: osp-secret
+  cellTemplates:
+    cell0:
+      cellDatabaseUser: nova_cell0
+      conductorServiceTemplate:
+        # conductor in cell1 will act both as the super conductor and as the
+        # cell1 conductor
+        replicas: 0
+      hasAPIAccess: true
+    cell1:
+      cellDatabaseUser: nova_cell1
+      conductorServiceTemplate:
+        replicas: 1
+      hasAPIAccess: true

--- a/test/functional/sample_test.go
+++ b/test/functional/sample_test.go
@@ -117,6 +117,12 @@ var _ = Describe("Samples", func() {
 			GetNova(name)
 		})
 	})
+	When("nova_v1beta1_nova_collapsed_cell.yaml sample is applied", func() {
+		It("Nova is created", func() {
+			name := CreateNovaFromSample("nova_v1beta1_nova_collapsed_cell.yaml", namespace)
+			GetNova(name)
+		})
+	})
 	When("nova_v1beta1_novaapi.yaml sample is applied", func() {
 		It("NovaAPI is created", func() {
 			name := CreateNovaAPIFromSample("nova_v1beta1_novaapi.yaml", namespace)


### PR DESCRIPTION
We will switch our default deployment model to proper cell separation. As a preparation this patch adds a new sample file that does a collapsed cell setup. This will be then used by install_yamls by default to keep the dev environment resource usage low by only deploying a single RabbitMQCluster.