### PR TITLE
Make sure renovate runs make manifests generate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -36,5 +36,10 @@
       ],
       "allowedVersions": "< 1.0.0"
     }
-  ]
+  ],
+  "postUpgradeTasks": {
+    "commands": ["go mod tidy", "make manifests generate"],
+    "fileFilters": ["**/go.mod", "**/go.sum", "**/*.go", "**/*.yaml"],
+    "executionMode": "update"
+  }
 }


### PR DESCRIPTION
After a dependency bump the yaml and go code generators need to be run to pick up changes. Now that we have a hosted renovate runner we can configure a postUpgradeTask to do so.

Note that the fileFilters defining what changes are added to the commit after the commands are run.