### PR TITLE
Update renovate config to use go 1.19

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
   "enabledManagers": ["gomod"],
   "postUpdateOptions": ["gomodTidy"],
   "constraints": {
-    "go": "1.18"
+    "go": "1.19"
   },
   "schedule":[
     "every weekend"


### PR DESCRIPTION
I missed to bump this when I bumped nova-operator to go 1.19 and renovate post update taaks are failing due to this.