### PR TITLE
Pass GITHUB_TOKEN to install_kustomize.sh to avoid rate-limit

### DIFF
--- a/.github/workflows/build-operator-dont-publish.yaml
+++ b/.github/workflows/build-operator-dont-publish.yaml
@@ -18,6 +18,9 @@ jobs:
       env:
         # By not providing any remote repository here the build artifact will not be pushed
         IMAGE_TAG_BASE: nova-operator
+        # To avoid getting rate limited during kustomize install
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       # Ideally we would add catalog-build target at the end but that requires
       # the bundle to be pushed to a registry due to opm limitations:
       # https://github.com/operator-framework/operator-registry/issues/933


### PR DESCRIPTION
The PR #256  fixed this to the post merge image build but missed it to the pre merge image build job. Now it is fixed there.