### PR TITLE
Run pre-commit with make

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,21 +1,37 @@
 repos:
-- repo: https://github.com/dnephin/pre-commit-golang
-  rev: v0.5.1
-  hooks:
-    - id: go-fmt
-      exclude: ^vendor
-    - id: go-vet
-    - id: go-mod-tidy
-    - id: go-lint
-
-- repo: https://github.com/golangci/golangci-lint
-  rev: v1.50.1
-  hooks:
-    - id: golangci-lint
-      args: ["--verbose"]
-
 - repo: local
   hooks:
+    - id: golangci-lint
+      name: golangci-lint
+      language: golang
+      types: [go]
+      entry: make
+      args: ["golangci-lint"]
+      pass_filenames: false
+    - id: golint
+      name: golint
+      language: system
+      entry: make
+      args: ["golint"]
+      pass_filenames: false
+    - id: gofmt
+      name: gofmt
+      language: system
+      entry: make
+      args: ["fmt"]
+      pass_filenames: false
+    - id: govet
+      name: govet
+      language: system
+      entry: make
+      args: ["vet"]
+      pass_filenames: false
+    - id: gotidy
+      name: gotidy
+      language: system
+      entry: make
+      args: ["tidy"]
+      pass_filenames: false
     - id: make-manifests
       name: make-manifests
       language: system
@@ -62,4 +78,13 @@ repos:
   rev: 2.1.1
   hooks:
     - id: bashate
-      entry: bashate --error . --ignore=E006,E040,E043
+      entry: bashate --error . --ignore=E006,E040,E020,E012
+      # Run bashate check for all bash scripts
+      # Ignores the following rules:
+      # E006: Line longer than 79 columns (as many scripts use jinja
+      #       templating, this is very difficult)
+      # E040: Syntax error determined using `bash -n` (as many scripts
+      #       use jinja templating, this will often fail and the syntax
+      #       error will be discovered in execution anyway)
+      # E020: Function declaration not in format ^function name {$
+      # E012: here doc didn't end before EOF

--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,19 @@ vet: gowork ## Run go vet against code.
 	go vet ./...
 	go vet ./api/...
 
+.PHONY: tidy
+tidy: fmt
+	go mod tidy; \
+	pushd "$(LOCALBIN)/../api"; \
+	go mod tidy; \
+	popd
+
+.PHONY: golangci-lint
+golangci-lint:
+	# NOTE this will install golangci-lint in to local bin dir
+	test -s $(LOCALBIN)/golangci-lint || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.51.2
+	$(LOCALBIN)/golangci-lint run --fix
+
 PROCS?=$(shell expr $(shell nproc --ignore 2) / 2)
 PROC_CMD = --procs ${PROCS}
 


### PR DESCRIPTION
Updating pre-commit hook with make. pre-commit-golang repo is no longer maintained[1]. Instead of using
unmaintained repo we can use make to run pre-commit.

[1] https://github.com/dnephin/pre-commit-golang/issues/98