### PR TITLE
Reset ready status during reconfiguration

### DIFF
--- a/api/v1beta1/conditions.go
+++ b/api/v1beta1/conditions.go
@@ -75,7 +75,7 @@ const (
 	NovaAllCellsReadyInitMessage = "NovaCells are not started"
 
 	// NovaAllCellsReadyCreatingMessage
-	NovaAllCellsReadyCreatingMessage = "NovaCell creation ongoing for %s"
+	NovaAllCellsReadyNotReadyMessage = "NovaCell %s is not Ready"
 
 	// NovaAllCellsReadyWaitingMessage
 	NovaAllCellsReadyWaitingMessage = "NovaCell creation waits for DB creation for %s"

--- a/controllers/novaapi_controller.go
+++ b/controllers/novaapi_controller.go
@@ -113,10 +113,17 @@ func (r *NovaAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 	// Always update the instance status when exiting this function so we can
 	// persist any changes happend during the current reconciliation.
 	defer func() {
-		// update the overall status condition if service is ready
+		// update the Ready condition based on the sub conditions
 		if allSubConditionIsTrue(instance.Status) {
 			instance.Status.Conditions.MarkTrue(
 				condition.ReadyCondition, condition.ReadyMessage)
+		} else {
+			// something is not ready so reset the Ready condition
+			instance.Status.Conditions.MarkUnknown(
+				condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage)
+			// and recalculate it based on the state of the rest of the conditions
+			instance.Status.Conditions.Set(
+				instance.Status.Conditions.Mirror(condition.ReadyCondition))
 		}
 		err := h.PatchInstance(ctx, instance)
 		if err != nil {

--- a/controllers/novaconductor_controller.go
+++ b/controllers/novaconductor_controller.go
@@ -105,11 +105,19 @@ func (r *NovaConductorReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// Always update the instance status when exiting this function so we can
 	// persist any changes happend during the current reconciliation.
 	defer func() {
-		// update the overall status condition if service is ready
+		// update the Ready condition based on the sub conditions
 		if allSubConditionIsTrue(instance.Status) {
 			instance.Status.Conditions.MarkTrue(
 				condition.ReadyCondition, condition.ReadyMessage)
+		} else {
+			// something is not ready so reset the Ready condition
+			instance.Status.Conditions.MarkUnknown(
+				condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage)
+			// and recalculate it based on the state of the rest of the conditions
+			instance.Status.Conditions.Set(
+				instance.Status.Conditions.Mirror(condition.ReadyCondition))
 		}
+
 		err := h.PatchInstance(ctx, instance)
 		if err != nil {
 			_err = err

--- a/controllers/novascheduler_controller.go
+++ b/controllers/novascheduler_controller.go
@@ -104,10 +104,17 @@ func (r *NovaSchedulerReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// Always update the instance status when exiting this function so we can
 	// persist any changes happend during the current reconciliation.
 	defer func() {
-		// update the overall status condition if service is ready
+		// update the Ready condition based on the sub conditions
 		if allSubConditionIsTrue(instance.Status) {
 			instance.Status.Conditions.MarkTrue(
 				condition.ReadyCondition, condition.ReadyMessage)
+		} else {
+			// something is not ready so reset the Ready condition
+			instance.Status.Conditions.MarkUnknown(
+				condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage)
+			// and recalculate it based on the state of the rest of the conditions
+			instance.Status.Conditions.Set(
+				instance.Status.Conditions.Mirror(condition.ReadyCondition))
 		}
 		err := h.PatchInstance(ctx, instance)
 		if err != nil {

--- a/test/functional/nova_controller_test.go
+++ b/test/functional/nova_controller_test.go
@@ -134,7 +134,7 @@ var _ = Describe("Nova controller", func() {
 				novaName,
 				ConditionGetterFunc(NovaConditionGetter),
 				condition.ReadyCondition,
-				corev1.ConditionUnknown,
+				corev1.ConditionFalse,
 			)
 		})
 

--- a/test/functional/nova_scheduler_test.go
+++ b/test/functional/nova_scheduler_test.go
@@ -67,7 +67,8 @@ var _ = Describe("NovaScheduler controller", func() {
 			th.ExpectCondition(
 				novaSchedulerName,
 				ConditionGetterFunc(NovaSchedulerConditionGetter),
-				condition.ReadyCondition, corev1.ConditionUnknown,
+				condition.ReadyCondition,
+				corev1.ConditionFalse,
 			)
 		})
 
@@ -108,7 +109,7 @@ var _ = Describe("NovaScheduler controller", func() {
 				novaSchedulerName,
 				ConditionGetterFunc(NovaSchedulerConditionGetter),
 				condition.ReadyCondition,
-				corev1.ConditionUnknown,
+				corev1.ConditionFalse,
 			)
 		})
 
@@ -143,7 +144,7 @@ var _ = Describe("NovaScheduler controller", func() {
 				novaSchedulerName,
 				ConditionGetterFunc(NovaSchedulerConditionGetter),
 				condition.ReadyCondition,
-				corev1.ConditionUnknown,
+				corev1.ConditionFalse,
 			)
 		})
 
@@ -329,7 +330,7 @@ var _ = Describe("NovaScheduler controller", func() {
 				novaSchedulerName,
 				ConditionGetterFunc(NovaSchedulerConditionGetter),
 				condition.ReadyCondition,
-				corev1.ConditionUnknown,
+				corev1.ConditionFalse,
 			)
 		})
 		It("reports that network attachment is missing", func() {
@@ -491,23 +492,14 @@ var _ = Describe("NovaScheduler controller", func() {
 				"NetworkAttachment resources missing: internalapi",
 			)
 
-			// This is a bug that Ready is not reset
-			th.ExpectCondition(
+			th.ExpectConditionWithDetails(
 				novaSchedulerName,
 				ConditionGetterFunc(NovaSchedulerConditionGetter),
 				condition.ReadyCondition,
-				corev1.ConditionTrue,
+				corev1.ConditionFalse,
+				condition.RequestedReason,
+				"NetworkAttachment resources missing: internalapi",
 			)
-
-			// but it should be reset to False
-			// th.ExpectConditionWithDetails(
-			// 	novaSchedulerName,
-			// 	ConditionGetterFunc(NovaSchedulerConditionGetter),
-			// 	condition.ReadyCondition,
-			// 	corev1.ConditionFalse,
-			// 	condition.RequestedReason,
-			// 	"NetworkAttachment resources missing: internalapi",
-			// )
 
 			internalAPINADName := types.NamespacedName{Namespace: namespace, Name: "internalapi"}
 			DeferCleanup(DeleteInstance, CreateNetworkAttachmentDefinition(internalAPINADName))
@@ -521,24 +513,16 @@ var _ = Describe("NovaScheduler controller", func() {
 				"NetworkAttachments error occured "+
 					"not all pods have interfaces with ips as configured in NetworkAttachments: [internalapi]",
 			)
-			// This is a bug that Ready is not reset
-			th.ExpectCondition(
+
+			th.ExpectConditionWithDetails(
 				novaSchedulerName,
 				ConditionGetterFunc(NovaSchedulerConditionGetter),
 				condition.ReadyCondition,
-				corev1.ConditionTrue,
+				corev1.ConditionFalse,
+				condition.ErrorReason,
+				"NetworkAttachments error occured "+
+					"not all pods have interfaces with ips as configured in NetworkAttachments: [internalapi]",
 			)
-
-			// but it should be reset to False
-			// th.ExpectConditionWithDetails(
-			// 	novaSchedulerName,
-			// 	ConditionGetterFunc(NovaSchedulerConditionGetter),
-			// 	condition.ReadyCondition,
-			// 	corev1.ConditionFalse,
-			// 	condition.ErrorReason,
-			// 	"NetworkAttachments error occured "+
-			// 		"not all pods have interfaces with ips as configured in NetworkAttachments: [internalapi]",
-			// )
 
 			SimulateStatefulSetReplicaReadyWithPods(
 				statefulSetName,

--- a/test/functional/novaapi_controller_test.go
+++ b/test/functional/novaapi_controller_test.go
@@ -73,7 +73,8 @@ var _ = Describe("NovaAPI controller", func() {
 			th.ExpectCondition(
 				novaAPIName,
 				ConditionGetterFunc(NovaAPIConditionGetter),
-				condition.ReadyCondition, corev1.ConditionUnknown,
+				condition.ReadyCondition,
+				corev1.ConditionFalse,
 			)
 		})
 
@@ -116,7 +117,7 @@ var _ = Describe("NovaAPI controller", func() {
 					novaAPIName,
 					ConditionGetterFunc(NovaAPIConditionGetter),
 					condition.ReadyCondition,
-					corev1.ConditionUnknown,
+					corev1.ConditionFalse,
 				)
 			})
 
@@ -152,7 +153,7 @@ var _ = Describe("NovaAPI controller", func() {
 					novaAPIName,
 					ConditionGetterFunc(NovaAPIConditionGetter),
 					condition.ReadyCondition,
-					corev1.ConditionUnknown,
+					corev1.ConditionFalse,
 				)
 			})
 
@@ -434,7 +435,7 @@ var _ = Describe("NovaAPI controller", func() {
 				novaAPIName,
 				ConditionGetterFunc(NovaAPIConditionGetter),
 				condition.ReadyCondition,
-				corev1.ConditionUnknown,
+				corev1.ConditionFalse,
 			)
 		})
 		It("reports that network attachment is missing", func() {
@@ -667,23 +668,14 @@ var _ = Describe("NovaAPI controller", func() {
 				condition.RequestedReason,
 				"NetworkAttachment resources missing: internalapi",
 			)
-
-			// This is a bug that Ready is not reset
-			th.ExpectCondition(
+			th.ExpectConditionWithDetails(
 				novaAPIName,
 				ConditionGetterFunc(NovaAPIConditionGetter),
 				condition.ReadyCondition,
-				corev1.ConditionTrue,
+				corev1.ConditionFalse,
+				condition.RequestedReason,
+				"NetworkAttachment resources missing: internalapi",
 			)
-			// It is expecte that Ready is reset to False
-			// th.ExpectConditionWithDetails(
-			// 	novaAPIName,
-			// 	ConditionGetterFunc(NovaAPIConditionGetter),
-			// 	condition.ReadyCondition,
-			// 	corev1.ConditionFalse,
-			// 	condition.RequestedReason,
-			// 	"NetworkAttachment resources missing: internalapi",
-			// )
 
 			internalAPINADName := types.NamespacedName{Namespace: namespace, Name: "internalapi"}
 			DeferCleanup(DeleteInstance, CreateNetworkAttachmentDefinition(internalAPINADName))
@@ -697,23 +689,15 @@ var _ = Describe("NovaAPI controller", func() {
 				"NetworkAttachments error occured "+
 					"not all pods have interfaces with ips as configured in NetworkAttachments: [internalapi]",
 			)
-			// This is a bug that Ready is not reset
-			th.ExpectCondition(
+			th.ExpectConditionWithDetails(
 				novaAPIName,
 				ConditionGetterFunc(NovaAPIConditionGetter),
 				condition.ReadyCondition,
-				corev1.ConditionTrue,
+				corev1.ConditionFalse,
+				condition.ErrorReason,
+				"NetworkAttachments error occured "+
+					"not all pods have interfaces with ips as configured in NetworkAttachments: [internalapi]",
 			)
-			// It is expecte that Ready is reset to False
-			// th.ExpectConditionWithDetails(
-			// 	novaAPIName,
-			// 	ConditionGetterFunc(NovaAPIConditionGetter),
-			// 	condition.ReadyCondition,
-			// 	corev1.ConditionFalse,
-			// 	condition.ErrorReason,
-			// 	"NetworkAttachments error occured "+
-			// 		"not all pods have interfaces with ips as configured in NetworkAttachments: [internalapi]",
-			// )
 
 			SimulateStatefulSetReplicaReadyWithPods(
 				statefulSetName,

--- a/test/functional/novaapi_controller_test.go
+++ b/test/functional/novaapi_controller_test.go
@@ -27,6 +27,7 @@ import (
 
 	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	corev1 "k8s.io/api/core/v1"
+	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -605,6 +606,133 @@ var _ = Describe("NovaAPI controller", func() {
 			Expect(service.Annotations).NotTo(HaveKey("metallb.universe.tf/allow-shared-ip"))
 			Expect(service.Annotations).NotTo(HaveKey("metallb.universe.tf/loadBalancerIPs"))
 			AssertRouteExists(types.NamespacedName{Namespace: namespace, Name: "nova-public"})
+
+			th.ExpectCondition(
+				novaAPIName,
+				ConditionGetterFunc(NovaAPIConditionGetter),
+				condition.ReadyCondition,
+				corev1.ConditionTrue,
+			)
+		})
+	})
+
+	When("NovAPI is reconfigured", func() {
+		var statefulSetName types.NamespacedName
+
+		BeforeEach(func() {
+			DeferCleanup(
+				k8sClient.Delete, ctx, CreateNovaAPISecret(namespace, SecretName))
+			DeferCleanup(
+				k8sClient.Delete, ctx, CreateNovaMessageBusSecret(namespace, MessageBusSecretName))
+
+			api := CreateNovaAPI(namespace, GetDefaultNovaAPISpec())
+			novaAPIName = types.NamespacedName{Name: api.GetName(), Namespace: api.GetNamespace()}
+			DeferCleanup(DeleteInstance, api)
+
+			th.ExpectCondition(
+				novaAPIName,
+				ConditionGetterFunc(NovaAPIConditionGetter),
+				condition.ServiceConfigReadyCondition,
+				corev1.ConditionTrue,
+			)
+
+			statefulSetName = types.NamespacedName{
+				Namespace: namespace,
+				Name:      novaAPIName.Name,
+			}
+			th.SimulateStatefulSetReplicaReady(statefulSetName)
+			th.SimulateKeystoneEndpointReady(types.NamespacedName{Namespace: namespace, Name: "nova"})
+			th.ExpectCondition(
+				novaAPIName,
+				ConditionGetterFunc(NovaAPIConditionGetter),
+				condition.ReadyCondition,
+				corev1.ConditionTrue,
+			)
+		})
+
+		It("applys new NetworkAttachments configuration", func() {
+			Eventually(func(g Gomega) {
+				novaAPI := GetNovaAPI(novaAPIName)
+				novaAPI.Spec.NetworkAttachments = append(novaAPI.Spec.NetworkAttachments, "internalapi")
+
+				err := k8sClient.Update(ctx, novaAPI)
+				g.Expect(err == nil || k8s_errors.IsConflict(err)).To(BeTrue())
+			}, timeout, interval).Should(Succeed())
+
+			th.ExpectConditionWithDetails(
+				novaAPIName,
+				ConditionGetterFunc(NovaAPIConditionGetter),
+				condition.NetworkAttachmentsReadyCondition,
+				corev1.ConditionFalse,
+				condition.RequestedReason,
+				"NetworkAttachment resources missing: internalapi",
+			)
+
+			// This is a bug that Ready is not reset
+			th.ExpectCondition(
+				novaAPIName,
+				ConditionGetterFunc(NovaAPIConditionGetter),
+				condition.ReadyCondition,
+				corev1.ConditionTrue,
+			)
+			// It is expecte that Ready is reset to False
+			// th.ExpectConditionWithDetails(
+			// 	novaAPIName,
+			// 	ConditionGetterFunc(NovaAPIConditionGetter),
+			// 	condition.ReadyCondition,
+			// 	corev1.ConditionFalse,
+			// 	condition.RequestedReason,
+			// 	"NetworkAttachment resources missing: internalapi",
+			// )
+
+			internalAPINADName := types.NamespacedName{Namespace: namespace, Name: "internalapi"}
+			DeferCleanup(DeleteInstance, CreateNetworkAttachmentDefinition(internalAPINADName))
+
+			th.ExpectConditionWithDetails(
+				novaAPIName,
+				ConditionGetterFunc(NovaAPIConditionGetter),
+				condition.NetworkAttachmentsReadyCondition,
+				corev1.ConditionFalse,
+				condition.ErrorReason,
+				"NetworkAttachments error occured "+
+					"not all pods have interfaces with ips as configured in NetworkAttachments: [internalapi]",
+			)
+			// This is a bug that Ready is not reset
+			th.ExpectCondition(
+				novaAPIName,
+				ConditionGetterFunc(NovaAPIConditionGetter),
+				condition.ReadyCondition,
+				corev1.ConditionTrue,
+			)
+			// It is expecte that Ready is reset to False
+			// th.ExpectConditionWithDetails(
+			// 	novaAPIName,
+			// 	ConditionGetterFunc(NovaAPIConditionGetter),
+			// 	condition.ReadyCondition,
+			// 	corev1.ConditionFalse,
+			// 	condition.ErrorReason,
+			// 	"NetworkAttachments error occured "+
+			// 		"not all pods have interfaces with ips as configured in NetworkAttachments: [internalapi]",
+			// )
+
+			SimulateStatefulSetReplicaReadyWithPods(
+				statefulSetName,
+				map[string][]string{namespace + "/internalapi": {"10.0.0.1"}},
+			)
+
+			th.ExpectCondition(
+				novaAPIName,
+				ConditionGetterFunc(NovaAPIConditionGetter),
+				condition.NetworkAttachmentsReadyCondition,
+				corev1.ConditionTrue,
+			)
+
+			Eventually(func(g Gomega) {
+				novaAPI := GetNovaAPI(novaAPIName)
+				g.Expect(novaAPI.Status.NetworkAttachments).To(
+					Equal(map[string][]string{namespace + "/internalapi": {"10.0.0.1"}}))
+
+			}, timeout, interval).Should(Succeed())
 
 			th.ExpectCondition(
 				novaAPIName,

--- a/test/functional/novacell_controller_test.go
+++ b/test/functional/novacell_controller_test.go
@@ -70,7 +70,7 @@ var _ = Describe("NovaCell controller", func() {
 				novaCellName,
 				ConditionGetterFunc(NovaCellConditionGetter),
 				condition.ReadyCondition,
-				corev1.ConditionUnknown,
+				corev1.ConditionFalse,
 			)
 		})
 
@@ -227,23 +227,14 @@ var _ = Describe("NovaCell controller", func() {
 				"NetworkAttachment resources missing: internalapi",
 			)
 
-			// This is a bug that Ready is not reset
-			th.ExpectCondition(
+			th.ExpectConditionWithDetails(
 				novaCellName,
 				ConditionGetterFunc(NovaCellConditionGetter),
 				condition.ReadyCondition,
-				corev1.ConditionTrue,
+				corev1.ConditionFalse,
+				condition.RequestedReason,
+				"NetworkAttachment resources missing: internalapi",
 			)
-
-			// but it should be reset to False
-			// th.ExpectConditionWithDetails(
-			// 	novaCellName,
-			// 	ConditionGetterFunc(NovaCellConditionGetter),
-			// 	condition.ReadyCondition,
-			// 	corev1.ConditionFalse,
-			// 	condition.RequestedReason,
-			// 	"NetworkAttachment resources missing: internalapi",
-			// )
 
 			internalAPINADName := types.NamespacedName{Namespace: namespace, Name: "internalapi"}
 			DeferCleanup(DeleteInstance, CreateNetworkAttachmentDefinition(internalAPINADName))
@@ -257,24 +248,16 @@ var _ = Describe("NovaCell controller", func() {
 				"NetworkAttachments error occured "+
 					"not all pods have interfaces with ips as configured in NetworkAttachments: [internalapi]",
 			)
-			// This is a bug that Ready is not reset
-			th.ExpectCondition(
+
+			th.ExpectConditionWithDetails(
 				novaCellName,
 				ConditionGetterFunc(NovaCellConditionGetter),
 				condition.ReadyCondition,
-				corev1.ConditionTrue,
+				corev1.ConditionFalse,
+				condition.ErrorReason,
+				"NetworkAttachments error occured "+
+					"not all pods have interfaces with ips as configured in NetworkAttachments: [internalapi]",
 			)
-
-			// but it should be reset to False
-			// th.ExpectConditionWithDetails(
-			// 	novaCellName,
-			// 	ConditionGetterFunc(NovaCellConditionGetter),
-			// 	condition.ReadyCondition,
-			// 	corev1.ConditionFalse,
-			// 	condition.ErrorReason,
-			// 	"NetworkAttachments error occured "+
-			// 		"not all pods have interfaces with ips as configured in NetworkAttachments: [internalapi]",
-			// )
 
 			SimulateStatefulSetReplicaReadyWithPods(
 				conductorStatefulSetName,

--- a/test/functional/novaconductor_controller_test.go
+++ b/test/functional/novaconductor_controller_test.go
@@ -70,7 +70,8 @@ var _ = Describe("NovaConductor controller", func() {
 			th.ExpectCondition(
 				novaConductorName,
 				ConditionGetterFunc(NovaConductorConditionGetter),
-				condition.ReadyCondition, corev1.ConditionUnknown,
+				condition.ReadyCondition,
+				corev1.ConditionFalse,
 			)
 		})
 
@@ -109,7 +110,7 @@ var _ = Describe("NovaConductor controller", func() {
 					novaConductorName,
 					ConditionGetterFunc(NovaConductorConditionGetter),
 					condition.ReadyCondition,
-					corev1.ConditionUnknown,
+					corev1.ConditionFalse,
 				)
 			})
 
@@ -144,7 +145,7 @@ var _ = Describe("NovaConductor controller", func() {
 					novaConductorName,
 					ConditionGetterFunc(NovaConductorConditionGetter),
 					condition.ReadyCondition,
-					corev1.ConditionUnknown,
+					corev1.ConditionFalse,
 				)
 			})
 
@@ -552,7 +553,7 @@ var _ = Describe("NovaConductor controller", func() {
 				novaConductorName,
 				ConditionGetterFunc(NovaConductorConditionGetter),
 				condition.ReadyCondition,
-				corev1.ConditionUnknown,
+				corev1.ConditionFalse,
 			)
 		})
 		It("reports that network attachment is missing", func() {
@@ -725,23 +726,14 @@ var _ = Describe("NovaConductor controller", func() {
 				"NetworkAttachment resources missing: internalapi",
 			)
 
-			// This is a bug that Ready is not reset
-			th.ExpectCondition(
+			th.ExpectConditionWithDetails(
 				novaConductorName,
 				ConditionGetterFunc(NovaConductorConditionGetter),
 				condition.ReadyCondition,
-				corev1.ConditionTrue,
+				corev1.ConditionFalse,
+				condition.RequestedReason,
+				"NetworkAttachment resources missing: internalapi",
 			)
-
-			// but it should be reset to False
-			// th.ExpectConditionWithDetails(
-			// 	novaConductorName,
-			// 	ConditionGetterFunc(NovaConductorConditionGetter),
-			// 	condition.ReadyCondition,
-			// 	corev1.ConditionFalse,
-			// 	condition.RequestedReason,
-			// 	"NetworkAttachment resources missing: internalapi",
-			// )
 
 			internalAPINADName := types.NamespacedName{Namespace: namespace, Name: "internalapi"}
 			DeferCleanup(DeleteInstance, CreateNetworkAttachmentDefinition(internalAPINADName))
@@ -755,24 +747,16 @@ var _ = Describe("NovaConductor controller", func() {
 				"NetworkAttachments error occured "+
 					"not all pods have interfaces with ips as configured in NetworkAttachments: [internalapi]",
 			)
-			// This is a bug that Ready is not reset
-			th.ExpectCondition(
+
+			th.ExpectConditionWithDetails(
 				novaConductorName,
 				ConditionGetterFunc(NovaConductorConditionGetter),
 				condition.ReadyCondition,
-				corev1.ConditionTrue,
+				corev1.ConditionFalse,
+				condition.ErrorReason,
+				"NetworkAttachments error occured "+
+					"not all pods have interfaces with ips as configured in NetworkAttachments: [internalapi]",
 			)
-
-			// but it should be reset to False
-			// th.ExpectConditionWithDetails(
-			// 	novaConductorName,
-			// 	ConditionGetterFunc(NovaConductorConditionGetter),
-			// 	condition.ReadyCondition,
-			// 	corev1.ConditionFalse,
-			// 	condition.ErrorReason,
-			// 	"NetworkAttachments error occured "+
-			// 		"not all pods have interfaces with ips as configured in NetworkAttachments: [internalapi]",
-			// )
 
 			SimulateStatefulSetReplicaReadyWithPods(
 				statefulSetName,

--- a/test/functional/novaconductor_controller_test.go
+++ b/test/functional/novaconductor_controller_test.go
@@ -26,6 +26,7 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -657,6 +658,139 @@ var _ = Describe("NovaConductor controller", func() {
 				novaConductor := GetNovaConductor(novaConductorName)
 				g.Expect(novaConductor.Status.NetworkAttachments).To(
 					Equal(map[string][]string{namespace + "/internalapi": {"10.0.0.1"}}))
+			}, timeout, interval).Should(Succeed())
+
+			th.ExpectCondition(
+				novaConductorName,
+				ConditionGetterFunc(NovaConductorConditionGetter),
+				condition.ReadyCondition,
+				corev1.ConditionTrue,
+			)
+		})
+	})
+	When("NovaConductor is reconfigured", func() {
+		var statefulSetName types.NamespacedName
+		var jobName types.NamespacedName
+
+		BeforeEach(func() {
+			DeferCleanup(
+				k8sClient.Delete, ctx, CreateNovaConductorSecret(namespace, SecretName))
+			DeferCleanup(
+				k8sClient.Delete, ctx, CreateNovaMessageBusSecret(namespace, MessageBusSecretName))
+
+			conductor := CreateNovaConductor(namespace, GetDefaultNovaConductorSpec())
+			novaConductorName = types.NamespacedName{Name: conductor.GetName(), Namespace: conductor.GetNamespace()}
+			DeferCleanup(DeleteInstance, conductor)
+
+			th.ExpectCondition(
+				novaConductorName,
+				ConditionGetterFunc(NovaConductorConditionGetter),
+				condition.ServiceConfigReadyCondition,
+				corev1.ConditionTrue,
+			)
+
+			jobName = types.NamespacedName{
+				Namespace: namespace,
+				Name:      novaConductorName.Name + "-db-sync",
+			}
+			th.SimulateJobSuccess(jobName)
+			statefulSetName = types.NamespacedName{
+				Namespace: namespace,
+				Name:      novaConductorName.Name,
+			}
+			th.SimulateStatefulSetReplicaReady(statefulSetName)
+			th.ExpectCondition(
+				novaConductorName,
+				ConditionGetterFunc(NovaConductorConditionGetter),
+				condition.ReadyCondition,
+				corev1.ConditionTrue,
+			)
+		})
+
+		It("applys new NetworkAttachments configuration", func() {
+			Eventually(func(g Gomega) {
+				novaConductor := GetNovaConductor(novaConductorName)
+				novaConductor.Spec.NetworkAttachments = append(novaConductor.Spec.NetworkAttachments, "internalapi")
+
+				err := k8sClient.Update(ctx, novaConductor)
+				g.Expect(err == nil || k8s_errors.IsConflict(err)).To(BeTrue())
+			}, timeout, interval).Should(Succeed())
+
+			th.ExpectConditionWithDetails(
+				novaConductorName,
+				ConditionGetterFunc(NovaConductorConditionGetter),
+				condition.NetworkAttachmentsReadyCondition,
+				corev1.ConditionFalse,
+				condition.RequestedReason,
+				"NetworkAttachment resources missing: internalapi",
+			)
+
+			// This is a bug that Ready is not reset
+			th.ExpectCondition(
+				novaConductorName,
+				ConditionGetterFunc(NovaConductorConditionGetter),
+				condition.ReadyCondition,
+				corev1.ConditionTrue,
+			)
+
+			// but it should be reset to False
+			// th.ExpectConditionWithDetails(
+			// 	novaConductorName,
+			// 	ConditionGetterFunc(NovaConductorConditionGetter),
+			// 	condition.ReadyCondition,
+			// 	corev1.ConditionFalse,
+			// 	condition.RequestedReason,
+			// 	"NetworkAttachment resources missing: internalapi",
+			// )
+
+			internalAPINADName := types.NamespacedName{Namespace: namespace, Name: "internalapi"}
+			DeferCleanup(DeleteInstance, CreateNetworkAttachmentDefinition(internalAPINADName))
+
+			th.ExpectConditionWithDetails(
+				novaConductorName,
+				ConditionGetterFunc(NovaConductorConditionGetter),
+				condition.NetworkAttachmentsReadyCondition,
+				corev1.ConditionFalse,
+				condition.ErrorReason,
+				"NetworkAttachments error occured "+
+					"not all pods have interfaces with ips as configured in NetworkAttachments: [internalapi]",
+			)
+			// This is a bug that Ready is not reset
+			th.ExpectCondition(
+				novaConductorName,
+				ConditionGetterFunc(NovaConductorConditionGetter),
+				condition.ReadyCondition,
+				corev1.ConditionTrue,
+			)
+
+			// but it should be reset to False
+			// th.ExpectConditionWithDetails(
+			// 	novaConductorName,
+			// 	ConditionGetterFunc(NovaConductorConditionGetter),
+			// 	condition.ReadyCondition,
+			// 	corev1.ConditionFalse,
+			// 	condition.ErrorReason,
+			// 	"NetworkAttachments error occured "+
+			// 		"not all pods have interfaces with ips as configured in NetworkAttachments: [internalapi]",
+			// )
+
+			SimulateStatefulSetReplicaReadyWithPods(
+				statefulSetName,
+				map[string][]string{namespace + "/internalapi": {"10.0.0.1"}},
+			)
+
+			th.ExpectCondition(
+				novaConductorName,
+				ConditionGetterFunc(NovaConductorConditionGetter),
+				condition.NetworkAttachmentsReadyCondition,
+				corev1.ConditionTrue,
+			)
+
+			Eventually(func(g Gomega) {
+				novaConductor := GetNovaConductor(novaConductorName)
+				g.Expect(novaConductor.Status.NetworkAttachments).To(
+					Equal(map[string][]string{namespace + "/internalapi": {"10.0.0.1"}}))
+
 			}, timeout, interval).Should(Succeed())
 
 			th.ExpectCondition(


### PR DESCRIPTION
If NovaAPI reaches the Ready True state and then reconfigured then the Ready condition is not reset. So if a reconfiguration step fails then the Status.Conditions inconsistently shows Ready True + a subcondition in False state.

To keep the Status.Conditions consistent the reconciler needs to reset the state of the Ready condition if any of the subcondition is not Ready.

- [x] NovaAPI
- [x] NovaConductor
- [x] NovaCell
- [x] NovaScheduler
- [x] Nova