### PR TITLE
[NovaConductor]Only DB sync the local cell

### DIFF
--- a/templates/novaconductor/bin/dbsync.sh
+++ b/templates/novaconductor/bin/dbsync.sh
@@ -18,4 +18,4 @@ else
     fi
 fi
 
-nova-manage db sync
+nova-manage db sync --local_cell


### PR DESCRIPTION
The nova-manage db sync by default wants to sync all the cell DBs in the deployment and it uses the cell_mappings from the API DB to do so. However when a new cell is added it does not make sense to sync all the other cells. So the per cell (conductor) db sync job is changed to only sync the local cell and do not try to sync all the cells.