### PR TITLE
Add certain missing omitempty tags

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -57,7 +57,7 @@ type NovaServiceBase struct {
 
 	// +kubebuilder:validation:Optional
 	// NetworkAttachments is a list of NetworkAttachment resource names to expose the services to the given network
-	NetworkAttachments []string `json:"networkAttachments"`
+	NetworkAttachments []string `json:"networkAttachments,omitempty"`
 }
 
 // Debug allows enabling different debug option for the operator

--- a/api/v1beta1/novaapi_types.go
+++ b/api/v1beta1/novaapi_types.go
@@ -66,11 +66,11 @@ type NovaAPITemplate struct {
 
 	// +kubebuilder:validation:Optional
 	// NetworkAttachments is a list of NetworkAttachment resource names to expose the services to the given network
-	NetworkAttachments []string `json:"networkAttachments"`
+	NetworkAttachments []string `json:"networkAttachments,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// ExternalEndpoints, expose a VIP via MetalLB on the pre-created address pool
-	ExternalEndpoints []MetalLBConfig `json:"externalEndpoints"`
+	ExternalEndpoints []MetalLBConfig `json:"externalEndpoints,omitempty"`
 }
 
 // NovaAPISpec defines the desired state of NovaAPI

--- a/api/v1beta1/novaconductor_types.go
+++ b/api/v1beta1/novaconductor_types.go
@@ -62,7 +62,7 @@ type NovaConductorTemplate struct {
 
 	// +kubebuilder:validation:Optional
 	// NetworkAttachments is a list of NetworkAttachment resource names to expose the services to the given network
-	NetworkAttachments []string `json:"networkAttachments"`
+	NetworkAttachments []string `json:"networkAttachments,omitempty"`
 }
 
 // NovaConductorSpec defines the desired state of NovaConductor

--- a/api/v1beta1/novametadata_types.go
+++ b/api/v1beta1/novametadata_types.go
@@ -62,7 +62,7 @@ type NovaMetadataTemplate struct {
 
 	// +kubebuilder:validation:Optional
 	// NetworkAttachments is a list of NetworkAttachment resource names to expose the services to the given network
-	NetworkAttachments []string `json:"networkAttachments"`
+	NetworkAttachments []string `json:"networkAttachments,omitempty"`
 }
 
 // NovaMetadataSpec defines the desired state of NovaMetadata

--- a/api/v1beta1/novanovncproxy_types.go
+++ b/api/v1beta1/novanovncproxy_types.go
@@ -62,7 +62,7 @@ type NovaNoVNCProxyTemplate struct {
 
 	// +kubebuilder:validation:Optional
 	// NetworkAttachments is a list of NetworkAttachment resource names to expose the services to the given network
-	NetworkAttachments []string `json:"networkAttachments"`
+	NetworkAttachments []string `json:"networkAttachments,omitempty"`
 }
 
 // NovaNoVNCProxySpec defines the desired state of NovaNoVNCProxy

--- a/api/v1beta1/novascheduler_types.go
+++ b/api/v1beta1/novascheduler_types.go
@@ -62,7 +62,7 @@ type NovaSchedulerTemplate struct {
 
 	// +kubebuilder:validation:Optional
 	// NetworkAttachments is a list of NetworkAttachment resource names to expose the services to the given network
-	NetworkAttachments []string `json:"networkAttachments"`
+	NetworkAttachments []string `json:"networkAttachments,omitempty"`
 }
 
 // NovaSchedulerSpec defines the desired state of NovaScheduler


### PR DESCRIPTION
As we agreed in https://github.com/openstack-k8s-operators/glance-operator/pull/168, for now we are using `omitempty` tags to avoid certain validation errors.  Without this patch, I am seeing these errors when I use OpenStack operator with the latest Nova bits:

```
* spec.nova.template.metadataServiceTemplate.networkAttachments: Invalid value: "null": spec.nova.template.metadataServiceTemplate.networkAttachments in body must be of type array: "null"
* spec.nova.template.cellTemplates.cell0.noVNCProxyServiceTemplate.networkAttachments: Invalid value: "null": spec.nova.template.cellTemplates.cell0.noVNCProxyServiceTemplate.networkAttachments in body must be of type array: "null"
* spec.nova.template.cellTemplates.cell0.conductorServiceTemplate.networkAttachments: Invalid value: "null": spec.nova.template.cellTemplates.cell0.conductorServiceTemplate.networkAttachments in body must be of type array: "null"
* spec.nova.template.cellTemplates.cell0.metadataServiceTemplate.networkAttachments: Invalid value: "null": spec.nova.template.cellTemplates.cell0.metadataServiceTemplate.networkAttachments in body must be of type array: "null"
* spec.nova.template.cellTemplates.cell1.conductorServiceTemplate.networkAttachments: Invalid value: "null": spec.nova.template.cellTemplates.cell1.conductorServiceTemplate.networkAttachments in body must be of type array: "null"
* spec.nova.template.cellTemplates.cell1.metadataServiceTemplate.networkAttachments: Invalid value: "null": spec.nova.template.cellTemplates.cell1.metadataServiceTemplate.networkAttachments in body must be of type array: "null"
* spec.nova.template.cellTemplates.cell1.noVNCProxyServiceTemplate.networkAttachments: Invalid value: "null": spec.nova.template.cellTemplates.cell1.noVNCProxyServiceTemplate.networkAttachments in body must be of type array: "null"
* spec.nova.template.schedulerServiceTemplate.networkAttachments: Invalid value: "null": spec.nova.template.schedulerServiceTemplate.networkAttachments in body must be of type array: "null"
* spec.nova.template.apiServiceTemplate.externalEndpoints: Invalid value: "null": spec.nova.template.apiServiceTemplate.externalEndpoints in body must be of type array: "null"
* spec.nova.template.apiServiceTemplate.networkAttachments: Invalid value: "null": spec.nova.template.apiServiceTemplate.networkAttachments in body must be of type array: "null"
```