### PR TITLE
Extend the timeout for golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,3 +3,5 @@ linters:
   # https://golangci-lint.run/usage/linters/#enabled-by-default
   enable:
     errorlint
+run:
+  timeout: 5m

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
   rev: v1.50.1
   hooks:
     - id: golangci-lint
+      args: ["--verbose"]
 
 - repo: local
   hooks:


### PR DESCRIPTION
The default timeout is 1 minutes that seems to be not enough in CI. This is probably a fallout from the change where we limited the memory usage of golangci-lint in CI as that is expected to decrease the speed of the lint.