### PR TITLE
Use constant to define restart policy

### DIFF
--- a/pkg/novaconductor/dbsync.go
+++ b/pkg/novaconductor/dbsync.go
@@ -87,7 +87,7 @@ func CellDBSyncJob(
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					RestartPolicy:      "OnFailure",
+					RestartPolicy:      corev1.RestartPolicyOnFailure,
 					ServiceAccountName: nova.ServiceAccount,
 					Volumes: nova.GetVolumes(
 						nova.GetScriptConfigMapName(instance.Name),


### PR DESCRIPTION
... instead hard-coding the string in our own logic.