### PR TITLE
Fix hard-coded playbooks path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ PROC_CMD = --procs ${PROCS}
 
 .PHONY: test
 test: manifests generate fmt vet envtest ginkgo ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) -v debug --bin-dir $(LOCALBIN) use $(ENVTEST_K8S_VERSION) -p path)" $(GINKGO) -v --trace --cover --coverpkg=../../pkg/nova,../../pkg/novaapi,../../pkg/novaconductor,../../controllers,../../api/v1beta1 --coverprofile cover.out --covermode=atomic --randomize-all ${PROC_CMD} ./test/...
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) -v debug --bin-dir $(LOCALBIN) use $(ENVTEST_K8S_VERSION) -p path)" OPERATOR_TEMPLATES="$(PWD)/templates" OPERATOR_PLAYBOOKS="$(PWD)/playbooks" $(GINKGO) -v --trace --cover --coverpkg=../../pkg/nova,../../pkg/novaapi,../../pkg/novaconductor,../../controllers,../../api/v1beta1 --coverprofile cover.out --covermode=atomic --randomize-all ${PROC_CMD} ./test/...
 
 ##@ Build
 

--- a/controllers/novaexternalcompute_controller.go
+++ b/controllers/novaexternalcompute_controller.go
@@ -507,7 +507,7 @@ func (r *NovaExternalComputeReconciler) ensurePlaybooks(
 ) error {
 	playbookPath, found := os.LookupEnv("OPERATOR_PLAYBOOKS")
 	if !found {
-		playbookPath = "../../playbooks"
+		playbookPath = "playbooks"
 		os.Setenv("OPERATOR_PLAYBOOKS", playbookPath)
 		util.LogForObject(
 			h, "OPERATOR_PLAYBOOKS not set in env when reconciling ", instance,

--- a/test/functional/nova_controller_test.go
+++ b/test/functional/nova_controller_test.go
@@ -17,7 +17,6 @@ package functional_test
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
@@ -58,8 +57,6 @@ var _ = Describe("Nova controller", func() {
 		DeferCleanup(th.DeleteNamespace, namespace)
 		// NOTE(gibi): ConfigMap generation looks up the local templates
 		// directory via ENV, so provide it
-		DeferCleanup(os.Setenv, "OPERATOR_TEMPLATES", os.Getenv("OPERATOR_TEMPLATES"))
-		os.Setenv("OPERATOR_TEMPLATES", "../../templates")
 
 		// Uncomment this if you need the full output in the logs from gomega
 		// matchers

--- a/test/functional/nova_multicell_test.go
+++ b/test/functional/nova_multicell_test.go
@@ -17,7 +17,6 @@ package functional_test
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
@@ -103,8 +102,6 @@ var _ = Describe("Nova controller", func() {
 		DeferCleanup(th.DeleteNamespace, namespace)
 		// NOTE(gibi): ConfigMap generation looks up the local templates
 		// directory via ENV, so provide it
-		DeferCleanup(os.Setenv, "OPERATOR_TEMPLATES", os.Getenv("OPERATOR_TEMPLATES"))
-		os.Setenv("OPERATOR_TEMPLATES", "../../templates")
 
 		// Uncomment this if you need the full output in the logs from gomega
 		// matchers

--- a/test/functional/nova_reconfiguration_test.go
+++ b/test/functional/nova_reconfiguration_test.go
@@ -16,8 +16,6 @@ limitations under the License.
 package functional_test
 
 import (
-	"os"
-
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -191,8 +189,6 @@ var _ = Describe("Nova reconfiguration", func() {
 		DeferCleanup(th.DeleteNamespace, namespace)
 		// NOTE(gibi): ConfigMap generation looks up the local templates
 		// directory via ENV, so provide it
-		DeferCleanup(os.Setenv, "OPERATOR_TEMPLATES", os.Getenv("OPERATOR_TEMPLATES"))
-		os.Setenv("OPERATOR_TEMPLATES", "../../templates")
 
 		// Uncomment this if you need the full output in the logs from gomega
 		// matchers

--- a/test/functional/nova_scheduler_test.go
+++ b/test/functional/nova_scheduler_test.go
@@ -16,7 +16,6 @@ package functional_test
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/google/uuid"
 	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
@@ -46,8 +45,6 @@ var _ = Describe("NovaScheduler controller", func() {
 		DeferCleanup(th.DeleteNamespace, namespace)
 		// NOTE(gibi): ConfigMap generation looks up the local templates
 		// directory via ENV, so provide it
-		DeferCleanup(os.Setenv, "OPERATOR_TEMPLATES", os.Getenv("OPERATOR_TEMPLATES"))
-		os.Setenv("OPERATOR_TEMPLATES", "../../templates")
 
 		// Uncomment this if you need the full output in the logs from gomega
 		// matchers

--- a/test/functional/novaapi_controller_test.go
+++ b/test/functional/novaapi_controller_test.go
@@ -18,7 +18,6 @@ package functional_test
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
@@ -49,8 +48,6 @@ var _ = Describe("NovaAPI controller", func() {
 		DeferCleanup(th.DeleteNamespace, namespace)
 		// NOTE(gibi): ConfigMap generation looks up the local templates
 		// directory via ENV, so provide it
-		DeferCleanup(os.Setenv, "OPERATOR_TEMPLATES", os.Getenv("OPERATOR_TEMPLATES"))
-		os.Setenv("OPERATOR_TEMPLATES", "../../templates")
 
 		// Uncomment this if you need the full output in the logs from gomega
 		// matchers

--- a/test/functional/novacell_controller_test.go
+++ b/test/functional/novacell_controller_test.go
@@ -16,8 +16,6 @@ limitations under the License.
 package functional_test
 
 import (
-	"os"
-
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -46,8 +44,6 @@ var _ = Describe("NovaCell controller", func() {
 		DeferCleanup(th.DeleteNamespace, namespace)
 		// NOTE(gibi): ConfigMap generation looks up the local templates
 		// directory via ENV, so provide it
-		DeferCleanup(os.Setenv, "OPERATOR_TEMPLATES", os.Getenv("OPERATOR_TEMPLATES"))
-		os.Setenv("OPERATOR_TEMPLATES", "../../templates")
 
 		// Uncomment this if you need the full output in the logs from gomega
 		// matchers

--- a/test/functional/novaconductor_controller_test.go
+++ b/test/functional/novaconductor_controller_test.go
@@ -16,7 +16,6 @@ package functional_test
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/google/uuid"
 	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
@@ -50,8 +49,6 @@ var _ = Describe("NovaConductor controller", func() {
 		DeferCleanup(th.DeleteNamespace, namespace)
 		// NOTE(gibi): ConfigMap generation looks up the local templates
 		// directory via ENV, so provide it
-		DeferCleanup(os.Setenv, "OPERATOR_TEMPLATES", os.Getenv("OPERATOR_TEMPLATES"))
-		os.Setenv("OPERATOR_TEMPLATES", "../../templates")
 
 		// Uncomment this if you need the full output in the logs from gomega
 		// matchers

--- a/test/functional/novaexternalcompute_controller_test.go
+++ b/test/functional/novaexternalcompute_controller_test.go
@@ -16,7 +16,6 @@ package functional_test
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
@@ -84,8 +83,6 @@ var _ = Describe("NovaExternalCompute", func() {
 		DeferCleanup(th.DeleteNamespace, namespace)
 		// NOTE(gibi): ConfigMap generation looks up the local templates
 		// directory via ENV, so provide it
-		DeferCleanup(os.Setenv, "OPERATOR_TEMPLATES", os.Getenv("OPERATOR_TEMPLATES"))
-		os.Setenv("OPERATOR_TEMPLATES", "../../templates")
 
 		// Uncomment this if you need the full output in the logs from gomega
 		// matchers

--- a/test/functional/sample_test.go
+++ b/test/functional/sample_test.go
@@ -106,8 +106,6 @@ var _ = Describe("Samples", func() {
 		DeferCleanup(th.DeleteNamespace, namespace)
 		// NOTE(gibi): ConfigMap generation looks up the local templates
 		// directory via ENV, so provide it
-		DeferCleanup(os.Setenv, "OPERATOR_TEMPLATES", os.Getenv("OPERATOR_TEMPLATES"))
-		os.Setenv("OPERATOR_TEMPLATES", "../../templates")
 
 		// Uncomment this if you need the full output in the logs from gomega
 		// matchers


### PR DESCRIPTION
When running with `make run` the hard-coded path to the playbooks is
wrong and makes the operator unable to find them. Running with the
OPERATOR_PLAYBOOKS variable set appropriately *does* work, and changing
this path makes it work for me without as well.
