### PR TITLE
[Compute] Add NewNovaExternalComputeSpec default ctor

### DIFF
--- a/api/v1beta1/novaexternalcompute_types.go
+++ b/api/v1beta1/novaexternalcompute_types.go
@@ -137,3 +137,21 @@ func (c NovaExternalCompute) IsReady() bool {
 	readyCond := c.Status.Conditions.Get(condition.ReadyCondition)
 	return readyCond != nil && readyCond.Status == corev1.ConditionTrue
 }
+
+// NewNovaExternalComputeSpec returns a NovaExternalComputeSpec where the fields are defaulted according
+// to the CRD definition
+func NewNovaExternalComputeSpec(inventoryConfigMapName string, sshKeySecretName string) NovaExternalComputeSpec {
+	return NovaExternalComputeSpec{
+		NovaInstance:              "nova",
+		CellName:                  "cell1",
+		CustomServiceConfig:       "",
+		DefaultConfigOverwrite:    nil,
+		InventoryConfigMapName:    inventoryConfigMapName,
+		SSHKeySecretName:          sshKeySecretName,
+		Deploy:                    true,
+		NovaComputeContainerImage: "quay.io/tripleozedcentos9/openstack-nova-compute:current-tripleo",
+		NovaLibvirtContainerImage: "quay.io/tripleozedcentos9/openstack-nova-libvirt:current-tripleo",
+		AnsibleEEContainerImage:   "quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest",
+		NetworkAttachments:        nil,
+	}
+}


### PR DESCRIPTION
The dataplane-operator instantiate NovaExternalCompute directly from golang. But wants to rely on defaulted NovaExternalCompute.Spec fields by not filling them. Instantiating the NovaExternalComputeSpec struct directly would result in not defined field to get its golang defaults values instead of the defaults defined in the CRD. The omitempty json tag would only be helpful for those fields where we never want to set the golang default value explicitly as a field value, as that would be ignored.

So this patch introduces the NewNovaExternalComputeSpec struct constructor that fills the defaulted fields to its CRD defaults.

Unfortunately the CRD defaults are defined in as kubebuilder annotations comments so the default values now duplicated in the implementation. To avoid getting the default values out of sync between the CRD and the NewNovaExternalComputeSpec implementation a test is added that creates the NovaExternalCompute twice with only the required fields provided. First created via unstructured map[string]interface{} construct to leave out the undefined fields from the request. Secondly created via the NewNovaExternalComputeSpec constructor and a normal golang Create API request. Then the two NovaExternalCompute instances are read back from the API and their spec is compared with DeepEqual.