### PR TITLE
Add global BeforeEach and remove duplicate code

### DIFF
--- a/test/functional/nova_controller_test.go
+++ b/test/functional/nova_controller_test.go
@@ -30,7 +30,6 @@ import (
 )
 
 var _ = Describe("Nova controller", func() {
-	var namespace string
 	var novaName types.NamespacedName
 	var mariaDBDatabaseNameForAPI types.NamespacedName
 	var mariaDBDatabaseNameForCell0 types.NamespacedName
@@ -47,17 +46,6 @@ var _ = Describe("Nova controller", func() {
 	var novaSchedulerStatefulSetName types.NamespacedName
 
 	BeforeEach(func() {
-		// NOTE(gibi): We need to create a unique namespace for each test run
-		// as namespaces cannot be deleted in a locally running envtest. See
-		// https://book.kubebuilder.io/reference/envtest.html#namespace-usage-limitation
-		namespace = uuid.New().String()
-		th.CreateNamespace(namespace)
-		// We still request the delete of the Namespace to properly cleanup if
-		// we run the test in an existing cluster.
-		DeferCleanup(th.DeleteNamespace, namespace)
-		// NOTE(gibi): ConfigMap generation looks up the local templates
-		// directory via ENV, so provide it
-
 		// Uncomment this if you need the full output in the logs from gomega
 		// matchers
 		// format.MaxLength = 0

--- a/test/functional/nova_multicell_test.go
+++ b/test/functional/nova_multicell_test.go
@@ -77,8 +77,7 @@ func NewCell(novaName types.NamespacedName, cell string) Cell {
 	return c
 }
 
-var _ = Describe("Nova controller", func() {
-	var namespace string
+var _ = Describe("Nova multicell", func() {
 	var novaName types.NamespacedName
 	var mariaDBDatabaseNameForAPI types.NamespacedName
 	var cell0 Cell
@@ -92,17 +91,6 @@ var _ = Describe("Nova controller", func() {
 	var novaSchedulerStatefulSetName types.NamespacedName
 
 	BeforeEach(func() {
-		// NOTE(gibi): We need to create a unique namespace for each test run
-		// as namespaces cannot be deleted in a locally running envtest. See
-		// https://book.kubebuilder.io/reference/envtest.html#namespace-usage-limitation
-		namespace = uuid.New().String()
-		th.CreateNamespace(namespace)
-		// We still request the delete of the Namespace to properly cleanup if
-		// we run the test in an existing cluster.
-		DeferCleanup(th.DeleteNamespace, namespace)
-		// NOTE(gibi): ConfigMap generation looks up the local templates
-		// directory via ENV, so provide it
-
 		// Uncomment this if you need the full output in the logs from gomega
 		// matchers
 		// format.MaxLength = 0

--- a/test/functional/nova_reconfiguration_test.go
+++ b/test/functional/nova_reconfiguration_test.go
@@ -175,21 +175,9 @@ func CreateNovaWith3CellsAndEnsureReady(namespace string) types.NamespacedName {
 }
 
 var _ = Describe("Nova reconfiguration", func() {
-	var namespace string
 	var novaName types.NamespacedName
 
 	BeforeEach(func() {
-		// NOTE(gibi): We need to create a unique namespace for each test run
-		// as namespaces cannot be deleted in a locally running envtest. See
-		// https://book.kubebuilder.io/reference/envtest.html#namespace-usage-limitation
-		namespace = uuid.New().String()
-		th.CreateNamespace(namespace)
-		// We still request the delete of the Namespace to properly cleanup if
-		// we run the test in an existing cluster.
-		DeferCleanup(th.DeleteNamespace, namespace)
-		// NOTE(gibi): ConfigMap generation looks up the local templates
-		// directory via ENV, so provide it
-
 		// Uncomment this if you need the full output in the logs from gomega
 		// matchers
 		// format.MaxLength = 0

--- a/test/functional/nova_scheduler_test.go
+++ b/test/functional/nova_scheduler_test.go
@@ -17,7 +17,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/google/uuid"
 	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -31,21 +30,9 @@ import (
 )
 
 var _ = Describe("NovaScheduler controller", func() {
-	var namespace string
 	var novaSchedulerName types.NamespacedName
 
 	BeforeEach(func() {
-		// NOTE(gibi): We need to create a unique namespace for each test run
-		// as namespaces cannot be deleted in a locally running envtest. See
-		// https://book.kubebuilder.io/reference/envtest.html#namespace-usage-limitation
-		namespace = uuid.New().String()
-		th.CreateNamespace(namespace)
-		// We still request the delete of the Namespace to properly cleanup if
-		// we run the test in an existing cluster.
-		DeferCleanup(th.DeleteNamespace, namespace)
-		// NOTE(gibi): ConfigMap generation looks up the local templates
-		// directory via ENV, so provide it
-
 		// Uncomment this if you need the full output in the logs from gomega
 		// matchers
 		// format.MaxLength = 0

--- a/test/functional/novaapi_controller_test.go
+++ b/test/functional/novaapi_controller_test.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/openstack-k8s-operators/lib-common/modules/test/helpers"
@@ -34,26 +33,7 @@ import (
 )
 
 var _ = Describe("NovaAPI controller", func() {
-	var namespace string
 	var novaAPIName types.NamespacedName
-
-	BeforeEach(func() {
-		// NOTE(gibi): We need to create a unique namespace for each test run
-		// as namespaces cannot be deleted in a locally running envtest. See
-		// https://book.kubebuilder.io/reference/envtest.html#namespace-usage-limitation
-		namespace = uuid.New().String()
-		th.CreateNamespace(namespace)
-		// We still request the delete of the Namespace to properly cleanup if
-		// we run the test in an existing cluster.
-		DeferCleanup(th.DeleteNamespace, namespace)
-		// NOTE(gibi): ConfigMap generation looks up the local templates
-		// directory via ENV, so provide it
-
-		// Uncomment this if you need the full output in the logs from gomega
-		// matchers
-		// format.MaxLength = 0
-
-	})
 
 	When("a NovaAPI CR is created pointing to a non existent Secret", func() {
 		BeforeEach(func() {

--- a/test/functional/novacell_controller_test.go
+++ b/test/functional/novacell_controller_test.go
@@ -30,21 +30,9 @@ import (
 )
 
 var _ = Describe("NovaCell controller", func() {
-	var namespace string
 	var novaCellName types.NamespacedName
 
 	BeforeEach(func() {
-		// NOTE(gibi): We need to create a unique namespace for each test run
-		// as namespaces cannot be deleted in a locally running envtest. See
-		// https://book.kubebuilder.io/reference/envtest.html#namespace-usage-limitation
-		namespace = uuid.New().String()
-		th.CreateNamespace(namespace)
-		// We still request the delete of the Namespace to properly cleanup if
-		// we run the test in an existing cluster.
-		DeferCleanup(th.DeleteNamespace, namespace)
-		// NOTE(gibi): ConfigMap generation looks up the local templates
-		// directory via ENV, so provide it
-
 		// Uncomment this if you need the full output in the logs from gomega
 		// matchers
 		// format.MaxLength = 0

--- a/test/functional/novaconductor_controller_test.go
+++ b/test/functional/novaconductor_controller_test.go
@@ -17,7 +17,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/google/uuid"
 	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -35,21 +34,9 @@ import (
 const CellMessageBusSecretName = "rabbitmq-transport-url-nova-api-transport"
 
 var _ = Describe("NovaConductor controller", func() {
-	var namespace string
 	var novaConductorName types.NamespacedName
 
 	BeforeEach(func() {
-		// NOTE(gibi): We need to create a unique namespace for each test run
-		// as namespaces cannot be deleted in a locally running envtest. See
-		// https://book.kubebuilder.io/reference/envtest.html#namespace-usage-limitation
-		namespace = uuid.New().String()
-		th.CreateNamespace(namespace)
-		// We still request the delete of the Namespace to properly cleanup if
-		// we run the test in an existing cluster.
-		DeferCleanup(th.DeleteNamespace, namespace)
-		// NOTE(gibi): ConfigMap generation looks up the local templates
-		// directory via ENV, so provide it
-
 		// Uncomment this if you need the full output in the logs from gomega
 		// matchers
 		// format.MaxLength = 0

--- a/test/functional/novaexternalcompute_controller_test.go
+++ b/test/functional/novaexternalcompute_controller_test.go
@@ -68,23 +68,11 @@ func CreateNovaCellAndEnsureReady(namespace string, novaCellName types.Namespace
 }
 
 var _ = Describe("NovaExternalCompute", func() {
-	var namespace string
 	var computeName types.NamespacedName
 	var novaName types.NamespacedName
 	var novaCellName types.NamespacedName
 
 	BeforeEach(func() {
-		// NOTE(gibi): We need to create a unique namespace for each test run
-		// as namespaces cannot be deleted in a locally running envtest. See
-		// https://book.kubebuilder.io/reference/envtest.html#namespace-usage-limitation
-		namespace = uuid.New().String()
-		th.CreateNamespace(namespace)
-		// We still request the delete of the Namespace to properly cleanup if
-		// we run the test in an existing cluster.
-		DeferCleanup(th.DeleteNamespace, namespace)
-		// NOTE(gibi): ConfigMap generation looks up the local templates
-		// directory via ENV, so provide it
-
 		// Uncomment this if you need the full output in the logs from gomega
 		// matchers
 		// format.MaxLength = 0

--- a/test/functional/sample_test.go
+++ b/test/functional/sample_test.go
@@ -94,24 +94,6 @@ func CreateNovaExternalComputeFromSample(sampleFileName string, namespace string
 // the test and by simulating Job and Deploymnet success we could assert
 // that each sample creates a CR in Ready state.
 var _ = Describe("Samples", func() {
-	var namespace string
-	BeforeEach(func() {
-		// NOTE(gibi): We need to create a unique namespace for each test run
-		// as namespaces cannot be deleted in a locally running envtest. See
-		// https://book.kubebuilder.io/reference/envtest.html#namespace-usage-limitation
-		namespace = uuid.New().String()
-		th.CreateNamespace(namespace)
-		// We still request the delete of the Namespace to properly cleanup if
-		// we run the test in an existing cluster.
-		DeferCleanup(th.DeleteNamespace, namespace)
-		// NOTE(gibi): ConfigMap generation looks up the local templates
-		// directory via ENV, so provide it
-
-		// Uncomment this if you need the full output in the logs from gomega
-		// matchers
-		// format.MaxLength = 0
-
-	})
 
 	When("nova_v1beta1_nova.yaml sample is applied", func() {
 		It("Nova is created", func() {

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/zap/zapcore"
@@ -64,6 +65,7 @@ var (
 	cancel    context.CancelFunc
 	logger    logr.Logger
 	th        *TestHelper
+	namespace string
 )
 
 func TestAPIs(t *testing.T) {
@@ -193,4 +195,15 @@ var _ = AfterSuite(func() {
 	cancel()
 	err := testEnv.Stop()
 	Expect(err).NotTo(HaveOccurred())
+})
+
+var _ = BeforeEach(func() {
+	// NOTE(gibi): We need to create a unique namespace for each test run
+	// as namespaces cannot be deleted in a locally running envtest. See
+	// https://book.kubebuilder.io/reference/envtest.html#namespace-usage-limitation
+	namespace = uuid.New().String()
+	th.CreateNamespace(namespace)
+	// We still request the delete of the Namespace to properly cleanup if
+	// we run the test in an existing cluster.
+	DeferCleanup(th.DeleteNamespace, namespace)
 })


### PR DESCRIPTION
Global BeforeEach is supported by ginkgo intentionally based on:

* Author of ginko by design put possibilities of global beforeeach: https://github.com/onsi/ginkgo/issues/18#issuecomment-29078502 
* In documentation pattern for global aftereach is documented. 