### PR TITLE
Re-add go-lint to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,7 @@ repos:
       exclude: ^vendor
     - id: go-vet
     - id: go-mod-tidy
+    - id: go-lint
 
 - repo: https://github.com/golangci/golangci-lint
   rev: v1.50.1

--- a/test/functional/nova_controller_test.go
+++ b/test/functional/nova_controller_test.go
@@ -162,12 +162,12 @@ var _ = Describe("Nova controller", func() {
 					},
 				),
 			)
-			keystoneApiName := th.CreateKeystoneAPI(namespace)
-			DeferCleanup(th.DeleteKeystoneAPI, keystoneApiName)
-			keystoneApi := th.GetKeystoneAPI(keystoneApiName)
-			keystoneApi.Status.APIEndpoints["internal"] = "http://keystone-internal-openstack.testing"
+			keystoneAPIName := th.CreateKeystoneAPI(namespace)
+			DeferCleanup(th.DeleteKeystoneAPI, keystoneAPIName)
+			keystoneAPI := th.GetKeystoneAPI(keystoneAPIName)
+			keystoneAPI.Status.APIEndpoints["internal"] = "http://keystone-internal-openstack.testing"
 			Eventually(func(g Gomega) {
-				g.Expect(k8sClient.Status().Update(ctx, keystoneApi.DeepCopy())).Should(Succeed())
+				g.Expect(k8sClient.Status().Update(ctx, keystoneAPI.DeepCopy())).Should(Succeed())
 			}, timeout, interval).Should(Succeed())
 
 			DeferCleanup(DeleteInstance, CreateNovaWithCell0(novaName))
@@ -379,12 +379,12 @@ var _ = Describe("Nova controller", func() {
 					},
 				),
 			)
-			keystoneApiName := th.CreateKeystoneAPI(namespace)
-			DeferCleanup(th.DeleteKeystoneAPI, keystoneApiName)
-			keystoneApi := th.GetKeystoneAPI(keystoneApiName)
-			keystoneApi.Status.APIEndpoints["internal"] = "http://keystone-internal-openstack.testing"
+			keystoneAPIName := th.CreateKeystoneAPI(namespace)
+			DeferCleanup(th.DeleteKeystoneAPI, keystoneAPIName)
+			keystoneAPI := th.GetKeystoneAPI(keystoneAPIName)
+			keystoneAPI.Status.APIEndpoints["internal"] = "http://keystone-internal-openstack.testing"
 			Eventually(func(g Gomega) {
-				g.Expect(k8sClient.Status().Update(ctx, keystoneApi.DeepCopy())).Should(Succeed())
+				g.Expect(k8sClient.Status().Update(ctx, keystoneAPI.DeepCopy())).Should(Succeed())
 			}, timeout, interval).Should(Succeed())
 
 			DeferCleanup(DeleteInstance, CreateNovaWithCell0(novaName))
@@ -465,12 +465,12 @@ var _ = Describe("Nova controller", func() {
 					},
 				),
 			)
-			keystoneApiName := th.CreateKeystoneAPI(namespace)
-			DeferCleanup(th.DeleteKeystoneAPI, keystoneApiName)
-			keystoneApi := th.GetKeystoneAPI(keystoneApiName)
-			keystoneApi.Status.APIEndpoints["internal"] = "http://keystone-internal-openstack.testing"
+			keystoneAPIName := th.CreateKeystoneAPI(namespace)
+			DeferCleanup(th.DeleteKeystoneAPI, keystoneAPIName)
+			keystoneAPI := th.GetKeystoneAPI(keystoneAPIName)
+			keystoneAPI.Status.APIEndpoints["internal"] = "http://keystone-internal-openstack.testing"
 			Eventually(func(g Gomega) {
-				g.Expect(k8sClient.Status().Update(ctx, keystoneApi.DeepCopy())).Should(Succeed())
+				g.Expect(k8sClient.Status().Update(ctx, keystoneAPI.DeepCopy())).Should(Succeed())
 			}, timeout, interval).Should(Succeed())
 
 			spec := GetDefaultNovaSpec()
@@ -592,12 +592,12 @@ var _ = Describe("Nova controller", func() {
 					},
 				),
 			)
-			keystoneApiName := th.CreateKeystoneAPI(namespace)
-			DeferCleanup(th.DeleteKeystoneAPI, keystoneApiName)
-			keystoneApi := th.GetKeystoneAPI(keystoneApiName)
-			keystoneApi.Status.APIEndpoints["internal"] = "http://keystone-internal-openstack.testing"
+			keystoneAPIName := th.CreateKeystoneAPI(namespace)
+			DeferCleanup(th.DeleteKeystoneAPI, keystoneAPIName)
+			keystoneAPI := th.GetKeystoneAPI(keystoneAPIName)
+			keystoneAPI.Status.APIEndpoints["internal"] = "http://keystone-internal-openstack.testing"
 			Eventually(func(g Gomega) {
-				g.Expect(k8sClient.Status().Update(ctx, keystoneApi.DeepCopy())).Should(Succeed())
+				g.Expect(k8sClient.Status().Update(ctx, keystoneAPI.DeepCopy())).Should(Succeed())
 			}, timeout, interval).Should(Succeed())
 
 			DeferCleanup(DeleteInstance, CreateNovaWithCell0(novaName))
@@ -655,12 +655,12 @@ var _ = Describe("Nova controller", func() {
 					},
 				),
 			)
-			keystoneApiName := th.CreateKeystoneAPI(namespace)
-			DeferCleanup(th.DeleteKeystoneAPI, keystoneApiName)
-			keystoneApi := th.GetKeystoneAPI(keystoneApiName)
-			keystoneApi.Status.APIEndpoints["internal"] = "http://keystone-internal-openstack.testing"
+			keystoneAPIName := th.CreateKeystoneAPI(namespace)
+			DeferCleanup(th.DeleteKeystoneAPI, keystoneAPIName)
+			keystoneAPI := th.GetKeystoneAPI(keystoneAPIName)
+			keystoneAPI.Status.APIEndpoints["internal"] = "http://keystone-internal-openstack.testing"
 			Eventually(func(g Gomega) {
-				g.Expect(k8sClient.Status().Update(ctx, keystoneApi.DeepCopy())).Should(Succeed())
+				g.Expect(k8sClient.Status().Update(ctx, keystoneAPI.DeepCopy())).Should(Succeed())
 			}, timeout, interval).Should(Succeed())
 
 			internalAPINADName := types.NamespacedName{Namespace: namespace, Name: "internalapi"}

--- a/test/functional/nova_multicell_test.go
+++ b/test/functional/nova_multicell_test.go
@@ -184,12 +184,12 @@ var _ = Describe("Nova multicell", func() {
 			spec["apiMessageBusInstance"] = "mq-for-api"
 
 			DeferCleanup(DeleteInstance, CreateNova(novaName, spec))
-			keystoneApiName := th.CreateKeystoneAPI(namespace)
-			DeferCleanup(th.DeleteKeystoneAPI, keystoneApiName)
-			keystoneApi := th.GetKeystoneAPI(keystoneApiName)
-			keystoneApi.Status.APIEndpoints["internal"] = "http://keystone-internal-openstack.testing"
+			keystoneAPIName := th.CreateKeystoneAPI(namespace)
+			DeferCleanup(th.DeleteKeystoneAPI, keystoneAPIName)
+			keystoneAPI := th.GetKeystoneAPI(keystoneAPIName)
+			keystoneAPI.Status.APIEndpoints["internal"] = "http://keystone-internal-openstack.testing"
 			Eventually(func(g Gomega) {
-				g.Expect(k8sClient.Status().Update(ctx, keystoneApi.DeepCopy())).Should(Succeed())
+				g.Expect(k8sClient.Status().Update(ctx, keystoneAPI.DeepCopy())).Should(Succeed())
 			}, timeout, interval).Should(Succeed())
 			th.SimulateKeystoneServiceReady(novaKeystoneServiceName)
 		})
@@ -586,12 +586,12 @@ var _ = Describe("Nova multicell", func() {
 			spec["apiMessageBusInstance"] = "mq-for-api"
 
 			DeferCleanup(DeleteInstance, CreateNova(novaName, spec))
-			keystoneApiName := th.CreateKeystoneAPI(namespace)
-			DeferCleanup(th.DeleteKeystoneAPI, keystoneApiName)
-			keystoneApi := th.GetKeystoneAPI(keystoneApiName)
-			keystoneApi.Status.APIEndpoints["internal"] = "http://keystone-internal-openstack.testing"
+			keystoneAPIName := th.CreateKeystoneAPI(namespace)
+			DeferCleanup(th.DeleteKeystoneAPI, keystoneAPIName)
+			keystoneAPI := th.GetKeystoneAPI(keystoneAPIName)
+			keystoneAPI.Status.APIEndpoints["internal"] = "http://keystone-internal-openstack.testing"
 			Eventually(func(g Gomega) {
-				g.Expect(k8sClient.Status().Update(ctx, keystoneApi.DeepCopy())).Should(Succeed())
+				g.Expect(k8sClient.Status().Update(ctx, keystoneAPI.DeepCopy())).Should(Succeed())
 			}, timeout, interval).Should(Succeed())
 			th.SimulateKeystoneServiceReady(novaKeystoneServiceName)
 		})

--- a/test/functional/nova_reconfiguration_test.go
+++ b/test/functional/nova_reconfiguration_test.go
@@ -128,12 +128,12 @@ func CreateNovaWith3CellsAndEnsureReady(namespace string) types.NamespacedName {
 	spec["apiMessageBusInstance"] = "mq-for-api"
 
 	DeferCleanup(DeleteInstance, CreateNova(novaName, spec))
-	keystoneApiName := th.CreateKeystoneAPI(namespace)
-	DeferCleanup(th.DeleteKeystoneAPI, keystoneApiName)
-	keystoneApi := th.GetKeystoneAPI(keystoneApiName)
-	keystoneApi.Status.APIEndpoints["internal"] = "http://keystone-internal-openstack.testing"
+	keystoneAPIName := th.CreateKeystoneAPI(namespace)
+	DeferCleanup(th.DeleteKeystoneAPI, keystoneAPIName)
+	keystoneAPI := th.GetKeystoneAPI(keystoneAPIName)
+	keystoneAPI.Status.APIEndpoints["internal"] = "http://keystone-internal-openstack.testing"
 	Eventually(func(g Gomega) {
-		g.Expect(k8sClient.Status().Update(ctx, keystoneApi.DeepCopy())).Should(Succeed())
+		g.Expect(k8sClient.Status().Update(ctx, keystoneAPI.DeepCopy())).Should(Succeed())
 	}, timeout, interval).Should(Succeed())
 
 	th.SimulateKeystoneServiceReady(novaKeystoneServiceName)


### PR DESCRIPTION
The go-lint was accidentally dropped form pre-commit by ff52881. This patch adds it back and fixes the issue found by it.