### PR TITLE
Add GINKGO_ARGS env var to test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ PROC_CMD = --procs ${PROCS}
 
 .PHONY: test
 test: manifests generate fmt vet envtest ginkgo ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) -v debug --bin-dir $(LOCALBIN) use $(ENVTEST_K8S_VERSION) -p path)" OPERATOR_TEMPLATES="$(PWD)/templates" OPERATOR_PLAYBOOKS="$(PWD)/playbooks" $(GINKGO) -v --trace --cover --coverpkg=../../pkg/nova,../../pkg/novaapi,../../pkg/novaconductor,../../controllers,../../api/v1beta1 --coverprofile cover.out --covermode=atomic --randomize-all ${PROC_CMD} ./test/...
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) -v debug --bin-dir $(LOCALBIN) use $(ENVTEST_K8S_VERSION) -p path)" OPERATOR_TEMPLATES="$(PWD)/templates" OPERATOR_PLAYBOOKS="$(PWD)/playbooks" $(GINKGO) -v --trace --cover --coverpkg=../../pkg/nova,../../pkg/novaapi,../../pkg/novaconductor,../../controllers,../../api/v1beta1 --coverprofile cover.out --covermode=atomic --randomize-all ${PROC_CMD} $(GINKGO_ARGS) ./test/...
 
 ##@ Build
 


### PR DESCRIPTION
With this change you can pass arbitrary parameters to the ginkgo test executor via the make target.

E.g. if you want to run only a subset of test sequentially failing on the first error then you can do that with:

 `make test GINKGO_ARGS="--focus 'does not create cell1 if cell0 fails as cell1 needs API access' --fail-fast  --procs 1"`