### PR TITLE
Limit the conductor workers

### DIFF
--- a/templates/novaconductor/config/nova.conf
+++ b/templates/novaconductor/config/nova.conf
@@ -1,3 +1,6 @@
+[conductor]
+workers = 1
+
 [api]
 auth_strategy = keystone
 


### PR DESCRIPTION
By default the number of conductor workers is equal to the number of CPU
on the node. Since we want to scale by number of replicas in a
deployment and not by number of workers in a pod this patch limits the
number of conductor workers to 1 per pod.

This is a stopgap solution until:
- conductor is moved to use the new config gen codepath and use the
  common config template that already has [conductor]workers set to 1
- we find a proper default for this value by running tempest against the
  clusters to see if 1 worker becomes a bottleneck or not