### PR TITLE
Remove build in the git hash to the operator binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN mkdir -p ${DEST_ROOT}/usr/local/bin/
 RUN if [ ! -f $CACHITO_ENV_FILE ]; then go mod download ; fi
 
 # Build manager
-RUN if [ -f $CACHITO_ENV_FILE ] ; then source $CACHITO_ENV_FILE ; fi ; export GIT_COMMIT=$(git describe --always --dirty 2>/dev/null || echo "<failed to generate>") && echo $GIT_COMMIT && CGO_ENABLED=0  GO111MODULE=on go build -ldflags "-X main.gitBuildHash=$GIT_COMMIT" ${GO_BUILD_EXTRA_ARGS} -a -o ${DEST_ROOT}/manager main.go
+RUN if [ -f $CACHITO_ENV_FILE ] ; then source $CACHITO_ENV_FILE ; fi ; CGO_ENABLED=0  GO111MODULE=on go build ${GO_BUILD_EXTRA_ARGS} -a -o ${DEST_ROOT}/manager main.go
 
 RUN cp -r templates ${DEST_ROOT}/templates
 RUN cp -r playbooks ${DEST_ROOT}/playbooks

--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,6 @@ endif
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
-BUILD_HASH = "main.gitBuildHash=$(shell git describe --always --dirty 2>/dev/null || echo "<failed to generate>")"
-
 .PHONY: all
 all: build
 
@@ -132,11 +130,11 @@ test: manifests generate fmt vet envtest ginkgo ## Run tests.
 
 .PHONY: build
 build: generate fmt vet ## Build manager binary.
-	go build -ldflags "-X $(BUILD_HASH)" -o bin/manager main.go
+	go build -o bin/manager main.go
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run -ldflags "-X $(BUILD_HASH)" ./main.go
+	go run ./main.go
 
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.

--- a/main.go
+++ b/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"os"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -53,9 +52,8 @@ import (
 )
 
 var (
-	scheme       = runtime.NewScheme()
-	setupLog     = ctrl.Log.WithName("setup")
-	gitBuildHash = "<not provided during build>"
+	scheme   = runtime.NewScheme()
+	setupLog = ctrl.Log.WithName("setup")
 )
 
 func init() {
@@ -89,8 +87,6 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
-
-	setupLog.Info(fmt.Sprintf("Git build hash: %s", gitBuildHash))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,


### PR DESCRIPTION
This effectively reverts c2a6415b13549eeda1d363285e548100da7531f7.

We learned over the months that while this can be useful in some limited cases we have similar data anyhow built into the operator container image hash. Also we learned that our builds might need to be performed outside of a git repository making this approach unmaintainable.