### PR TITLE
Fix service labels for NovaMetadata

### DIFF
--- a/controllers/novaapi_controller.go
+++ b/controllers/novaapi_controller.go
@@ -390,7 +390,7 @@ func (r *NovaAPIReconciler) ensureDeployment(
 	inputHash string,
 	annotations map[string]string,
 ) (ctrl.Result, error) {
-	ss := statefulset.NewStatefulSet(novaapi.StatefulSet(instance, inputHash, getServiceLabels(), annotations), r.RequeueTimeout)
+	ss := statefulset.NewStatefulSet(novaapi.StatefulSet(instance, inputHash, getAPIServiceLabels(), annotations), r.RequeueTimeout)
 	ctrlResult, err := ss.CreateOrPatch(ctx, h)
 	if err != nil && !k8s_errors.IsNotFound(err) {
 		util.LogErrorForObject(h, err, "Deployment failed", instance)
@@ -419,7 +419,7 @@ func (r *NovaAPIReconciler) ensureDeployment(
 		ctx,
 		h,
 		instance.Spec.NetworkAttachments,
-		getServiceLabels(),
+		getAPIServiceLabels(),
 		instance.Status.ReadyCount)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -482,7 +482,7 @@ func (r *NovaAPIReconciler) ensureServiceExposed(
 		ctx,
 		h,
 		novaapi.ServiceName,
-		getServiceLabels(),
+		getAPIServiceLabels(),
 		ports,
 		r.RequeueTimeout,
 	)
@@ -525,7 +525,7 @@ func (r *NovaAPIReconciler) ensureKeystoneEndpoint(
 		novaapi.ServiceName,
 		instance.Namespace,
 		endpointSpec,
-		getServiceLabels(),
+		getAPIServiceLabels(),
 		r.RequeueTimeout,
 	)
 	ctrlResult, err := endpoint.CreateOrPatch(ctx, h)
@@ -600,7 +600,7 @@ func (r *NovaAPIReconciler) reconcileDelete(
 	return nil
 }
 
-func getServiceLabels() map[string]string {
+func getAPIServiceLabels() map[string]string {
 	return map[string]string{
 		common.AppSelector: NovaAPILabelPrefix,
 	}

--- a/controllers/novametadata_controller.go
+++ b/controllers/novametadata_controller.go
@@ -344,9 +344,7 @@ func (r *NovaMetadataReconciler) ensureDeployment(
 	inputHash string,
 	annotations map[string]string,
 ) (ctrl.Result, error) {
-	serviceLabels := map[string]string{
-		common.AppSelector: NovaMetadataLabelPrefix,
-	}
+	serviceLabels := getMetadataServiceLabels()
 	ss := statefulset.NewStatefulSet(novametadata.StatefulSet(instance, inputHash, serviceLabels, annotations), r.RequeueTimeout)
 	ctrlResult, err := ss.CreateOrPatch(ctx, h)
 	if err != nil && !k8s_errors.IsNotFound(err) {
@@ -438,7 +436,7 @@ func (r *NovaMetadataReconciler) ensureServiceExposed(
 		ctx,
 		h,
 		novametadata.ServiceName,
-		getServiceLabels(),
+		getMetadataServiceLabels(),
 		ports,
 		r.RequeueTimeout,
 	)
@@ -478,6 +476,12 @@ func (r *NovaMetadataReconciler) reconcileDelete(
 	// when the service is scaled in or deleted
 	util.LogForObject(h, "Reconciled delete successfully", instance)
 	return nil
+}
+
+func getMetadataServiceLabels() map[string]string {
+	return map[string]string{
+		common.AppSelector: NovaMetadataLabelPrefix,
+	}
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/test/functional/nova_metadata_controller_test.go
+++ b/test/functional/nova_metadata_controller_test.go
@@ -18,6 +18,7 @@ package functional_test
 import (
 	"encoding/json"
 	"fmt"
+
 	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -245,6 +246,7 @@ var _ = Describe("NovaMetadata controller", func() {
 				Expect(int(*ss.Spec.Replicas)).To(Equal(1))
 				Expect(ss.Spec.Template.Spec.Volumes).To(HaveLen(2))
 				Expect(ss.Spec.Template.Spec.Containers).To(HaveLen(2))
+				Expect(ss.Spec.Selector.MatchLabels).To(Equal(map[string]string{"service": "nova-metadata"}))
 
 				container := ss.Spec.Template.Spec.Containers[0]
 				Expect(container.VolumeMounts).To(HaveLen(2))
@@ -290,7 +292,8 @@ var _ = Describe("NovaMetadata controller", func() {
 					condition.ExposeServiceReadyCondition,
 					corev1.ConditionTrue,
 				)
-				GetService(types.NamespacedName{Namespace: namespace, Name: "nova-metadata-internal"})
+				service := GetService(types.NamespacedName{Namespace: namespace, Name: "nova-metadata-internal"})
+				Expect(service.Labels["service"]).To(Equal("nova-metadata"))
 			})
 
 			It("is Ready", func() {

--- a/test/functional/novaapi_controller_test.go
+++ b/test/functional/novaapi_controller_test.go
@@ -273,6 +273,7 @@ var _ = Describe("NovaAPI controller", func() {
 			Expect(int(*ss.Spec.Replicas)).To(Equal(1))
 			Expect(ss.Spec.Template.Spec.Volumes).To(HaveLen(2))
 			Expect(ss.Spec.Template.Spec.Containers).To(HaveLen(2))
+			Expect(ss.Spec.Selector.MatchLabels).To(Equal(map[string]string{"service": "nova-api"}))
 
 			container := ss.Spec.Template.Spec.Containers[0]
 			Expect(container.VolumeMounts).To(HaveLen(2))
@@ -317,8 +318,10 @@ var _ = Describe("NovaAPI controller", func() {
 				condition.ExposeServiceReadyCondition,
 				corev1.ConditionTrue,
 			)
-			GetService(types.NamespacedName{Namespace: namespace, Name: "nova-public"})
-			GetService(types.NamespacedName{Namespace: namespace, Name: "nova-internal"})
+			public := GetService(types.NamespacedName{Namespace: namespace, Name: "nova-public"})
+			Expect(public.Labels["service"]).To(Equal("nova-api"))
+			internal := GetService(types.NamespacedName{Namespace: namespace, Name: "nova-internal"})
+			Expect(internal.Labels["service"]).To(Equal("nova-api"))
 			AssertRouteExists(types.NamespacedName{Namespace: namespace, Name: "nova-public"})
 		})
 


### PR DESCRIPTION
The nova-metadata service wrongly used the service=nova-api selector to route requests. This is fixed now.

Closes: #309