### PR TITLE
Use service defaults for force_config_drive

### DIFF
--- a/templates/nova.conf
+++ b/templates/nova.conf
@@ -23,8 +23,6 @@ initial_cpu_allocation_ratio=4.0
 initial_ram_allocation_ratio=1.0
 initial_disk_allocation_ratio=0.9
 {{end}}
-{{/*using a config drive will void issues with ovn and metadata*/}}
-force_config_drive=True
 {{if .transport_url}}transport_url={{.transport_url}}{{end}}
 
 {{if eq .service_name "nova-api"}}


### PR DESCRIPTION
OVN/Nova metadata is now working fine so
let's use service defaults i.e metadata
instead of config_drive.