### PR TITLE
Include roles using their FQCN

### DIFF
--- a/playbooks/deploy-libvirt.yaml
+++ b/playbooks/deploy-libvirt.yaml
@@ -93,7 +93,7 @@
         }
     - name: deploy nova container
       ansible.builtin.include_role:
-        name: edpm_container_manage
+        name: osp.edpm.edpm_container_manage
       vars:
         edpm_container_manage_config: "/var/lib/openstack/config/containers"
         edpm_container_manage_healthcheck_disabled: true

--- a/playbooks/deploy-nova.yaml
+++ b/playbooks/deploy-nova.yaml
@@ -43,7 +43,7 @@
       - { 'src': "/var/lib/openstack/config/novacompute__nova-compute.json", "dest": "/var/lib/openstack/config/nova/nova-compute.json" }
     - name: deploy nova container
       ansible.builtin.include_role:
-        name: edpm_container_manage
+        name: osp.edpm.edpm_container_manage
       vars:
         edpm_container_manage_config: '/var/lib/openstack/config/containers'
         edpm_container_manage_healthcheck_disabled: true


### PR DESCRIPTION
Since edpm-ansible now is a "real" collection and it's installed in the ee runner image with ansible-galaxy, its roles should be called with their FQCN.

Depends-On: https://github.com/openstack-k8s-operators/edpm-ansible/pull/86
