### PR TITLE
[envtest] Factor out name handling

### DIFF
--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -60,15 +60,13 @@ func GetDefaultNovaAPISpec() map[string]interface{} {
 	}
 }
 
-func CreateNovaAPI(namespace string, spec map[string]interface{}) client.Object {
-	novaAPIName := uuid.New().String()
-
+func CreateNovaAPI(name types.NamespacedName, spec map[string]interface{}) client.Object {
 	raw := map[string]interface{}{
 		"apiVersion": "nova.openstack.org/v1beta1",
 		"kind":       "NovaAPI",
 		"metadata": map[string]interface{}{
-			"name":      novaAPIName,
-			"namespace": namespace,
+			"name":      name.Name,
+			"namespace": name.Namespace,
 		},
 		"spec": spec,
 	}
@@ -204,15 +202,13 @@ func GetDefaultNovaConductorSpec() map[string]interface{} {
 	}
 }
 
-func CreateNovaConductor(namespace string, spec map[string]interface{}) client.Object {
-	novaConductorName := uuid.New().String()
-
+func CreateNovaConductor(name types.NamespacedName, spec map[string]interface{}) client.Object {
 	raw := map[string]interface{}{
 		"apiVersion": "nova.openstack.org/v1beta1",
 		"kind":       "NovaConductor",
 		"metadata": map[string]interface{}{
-			"name":      novaConductorName,
-			"namespace": namespace,
+			"name":      name.Name,
+			"namespace": name.Namespace,
 		},
 		"spec": spec,
 	}
@@ -328,15 +324,13 @@ func GetDefaultNovaSchedulerSpec() map[string]interface{} {
 	}
 }
 
-func CreateNovaScheduler(namespace string, spec map[string]interface{}) client.Object {
-	name := uuid.New().String()
-
+func CreateNovaScheduler(name types.NamespacedName, spec map[string]interface{}) client.Object {
 	raw := map[string]interface{}{
 		"apiVersion": "nova.openstack.org/v1beta1",
 		"kind":       "NovaScheduler",
 		"metadata": map[string]interface{}{
-			"name":      name,
-			"namespace": namespace,
+			"name":      name.Name,
+			"namespace": name.Namespace,
 		},
 		"spec": spec,
 	}
@@ -502,24 +496,22 @@ func GetCellNames(novaName types.NamespacedName, cell string) CellNames {
 		Namespace: novaName.Namespace,
 		Name:      novaName.Name + "-" + cell,
 	}
+	cellConductor := types.NamespacedName{
+		Namespace: novaName.Namespace,
+		Name:      cellName.Name + "-conductor",
+	}
 	c := CellNames{
 		CellName: cellName,
 		MariaDBDatabaseName: types.NamespacedName{
 			Namespace: novaName.Namespace,
 			Name:      "nova-" + cell,
 		},
-		CellConductorName: types.NamespacedName{
-			Namespace: novaName.Namespace,
-			Name:      cellName.Name + "-conductor",
-		},
+		CellConductorName: cellConductor,
 		CellDBSyncJobName: types.NamespacedName{
 			Namespace: novaName.Namespace,
-			Name:      cellName.Name + "-conductor-db-sync",
+			Name:      cellConductor.Name + "-db-sync",
 		},
-		ConductorStatefulSetName: types.NamespacedName{
-			Namespace: novaName.Namespace,
-			Name:      cellName.Name + "-conductor",
-		},
+		ConductorStatefulSetName: cellConductor,
 		TransportURLName: types.NamespacedName{
 			Namespace: novaName.Namespace,
 			Name:      cellName.Name + "-transport",
@@ -541,49 +533,179 @@ func GetCellNames(novaName types.NamespacedName, cell string) CellNames {
 }
 
 type NovaNames struct {
-	NovaName               types.NamespacedName
-	APIName                types.NamespacedName
-	APIMariaDBDatabaseName types.NamespacedName
-	APIDeploymentName      types.NamespacedName
-	KeystoneServiceName    types.NamespacedName
-	Cells                  map[string]CellNames
+	NovaName                        types.NamespacedName
+	InternalNovaServiceName         types.NamespacedName
+	PublicNovaServiceName           types.NamespacedName
+	AdminNovaServiceName            types.NamespacedName
+	InternalNovaRouteName           types.NamespacedName
+	PublicNovaRouteName             types.NamespacedName
+	AdminNovaRouteName              types.NamespacedName
+	ComputeName                     types.NamespacedName
+	KeystoneServiceName             types.NamespacedName
+	APIName                         types.NamespacedName
+	APIMariaDBDatabaseName          types.NamespacedName
+	APIDeploymentName               types.NamespacedName
+	APIKeystoneEndpointName         types.NamespacedName
+	APIStatefulSetName              types.NamespacedName
+	APIConfigDataName               types.NamespacedName
+	InternalAPINetworkNADName       types.NamespacedName // refers internalapi network, not Nova API
+	SchedulerName                   types.NamespacedName
+	SchedulerStatefulSetName        types.NamespacedName
+	SchedulerConfigDataName         types.NamespacedName
+	ConductorName                   types.NamespacedName
+	ConductorDBSyncJobName          types.NamespacedName
+	ConductorStatefulSetName        types.NamespacedName
+	ConductorConfigDataName         types.NamespacedName
+	ConductorScriptDataName         types.NamespacedName
+	MetadataName                    types.NamespacedName
+	MetadataStatefulSetName         types.NamespacedName
+	ServiceAccountName              types.NamespacedName
+	RoleName                        types.NamespacedName
+	RoleBindingName                 types.NamespacedName
+	MetadataConfigDataName          types.NamespacedName
+	InternalNovaMetadataServiceName types.NamespacedName
+	InternalNovaMetadataRouteName   types.NamespacedName
+	Cells                           map[string]CellNames
 }
 
 func GetNovaNames(novaName types.NamespacedName, cellNames []string) NovaNames {
+	// NOTE(bogdando): use random UUIDs instead of static "nova" part of names.
+	// These **must** replicate existing Nova*/Dataplane controllers suffixing/prefixing logic.
+	// While dynamic UUIDs also provide enhanced testing coverage for "synthetic" cases,
+	// which could not be caught for normal names with static "nova" prefixes.
+	computeExt := types.NamespacedName{
+		Namespace: novaName.Namespace,
+		Name:      uuid.New().String(),
+	}
 	novaAPI := types.NamespacedName{
 		Namespace: novaName.Namespace,
-		Name:      novaName.Name + "-api",
+		Name:      fmt.Sprintf("%s-api", novaName.Name),
+	}
+	novaScheduler := types.NamespacedName{
+		Namespace: novaName.Namespace,
+		Name:      fmt.Sprintf("%s-scheduler", novaName.Name),
+	}
+	novaConductor := types.NamespacedName{
+		Namespace: novaName.Namespace,
+		Name:      fmt.Sprintf("%s-conductor", novaName.Name),
+	}
+	novaMetadata := types.NamespacedName{
+		Namespace: novaName.Namespace,
+		Name:      fmt.Sprintf("%s-metadata", novaName.Name),
 	}
 	cells := map[string]CellNames{}
 	for _, cellName := range cellNames {
 		cells[cellName] = GetCellNames(novaName, cellName)
 	}
+
 	return NovaNames{
 		NovaName: novaName,
-		APIName:  novaAPI,
-		APIMariaDBDatabaseName: types.NamespacedName{
+		InternalNovaServiceName: types.NamespacedName{ // TODO replace for nova-internal
 			Namespace: novaName.Namespace,
-			Name:      "nova-api",
+			Name:      novaName.Name + "-internal",
 		},
-		APIDeploymentName: novaAPI,
+		PublicNovaServiceName: types.NamespacedName{ // TODO replace for nova-public
+			Namespace: novaName.Namespace,
+			Name:      novaName.Name + "-public",
+		},
+		AdminNovaServiceName: types.NamespacedName{ // TODO replace for nova-admin
+			Namespace: novaName.Namespace,
+			Name:      novaName.Name + "-admin",
+		},
+		InternalNovaRouteName: types.NamespacedName{ // TODO replace for nova-internal
+			Namespace: novaName.Namespace,
+			Name:      novaName.Name + "-internal",
+		},
+		PublicNovaRouteName: types.NamespacedName{ // TODO replace for nova-public
+			Namespace: novaName.Namespace,
+			Name:      novaName.Name + "-public",
+		},
+		AdminNovaRouteName: types.NamespacedName{ // TODO replace for nova-admin
+			Namespace: novaName.Namespace,
+			Name:      novaName.Name + "-admin",
+		},
+		ComputeName: computeExt,
 		KeystoneServiceName: types.NamespacedName{
 			Namespace: novaName.Namespace,
-			Name:      "nova",
+			Name:      "nova", // static value hardcoded in controller code
+		},
+		APIName: novaAPI,
+		APIMariaDBDatabaseName: types.NamespacedName{
+			Namespace: novaAPI.Namespace,
+			Name:      "nova-api", // a static DB name for nova
+		},
+		APIDeploymentName: novaAPI,
+		APIKeystoneEndpointName: types.NamespacedName{
+			Namespace: novaName.Namespace,
+			Name:      "nova", // a static keystone endpoint name for nova
+		},
+		APIStatefulSetName: novaAPI,
+		APIConfigDataName: types.NamespacedName{ // TODO replace configDataMap for API
+			Namespace: novaAPI.Namespace,
+			Name:      novaAPI.Name + "-config-data",
+		},
+		InternalAPINetworkNADName: types.NamespacedName{ // TODO replace for internalAPINADName
+			Namespace: novaAPI.Namespace,
+			Name:      "internalapi",
+		},
+		SchedulerName:            novaScheduler,
+		SchedulerStatefulSetName: novaScheduler,
+		SchedulerConfigDataName: types.NamespacedName{ // TODO replace configDataMap for Sched
+			Namespace: novaScheduler.Namespace,
+			Name:      novaScheduler.Name + "-config-data",
+		},
+		ConductorName: novaConductor,
+		ConductorDBSyncJobName: types.NamespacedName{
+			Namespace: novaConductor.Namespace,
+			Name:      novaConductor.Name + "-db-sync",
+		},
+		ConductorStatefulSetName: novaConductor,
+		ConductorConfigDataName: types.NamespacedName{ // TODO replace configDataMap for Cond
+			Namespace: novaConductor.Namespace,
+			Name:      novaConductor.Name + "-config-data",
+		},
+		ConductorScriptDataName: types.NamespacedName{ // TODO replace scriptMap for Cond
+			Namespace: novaConductor.Namespace,
+			Name:      novaConductor.Name + "-script",
+		},
+		MetadataName:            novaMetadata,
+		MetadataStatefulSetName: novaMetadata,
+		ServiceAccountName: types.NamespacedName{
+			Namespace: novaName.Namespace,
+			Name:      "nova-" + novaName.Name,
+		},
+		RoleName: types.NamespacedName{
+			Namespace: novaName.Namespace,
+			Name:      "nova-" + novaName.Name + "-role",
+		},
+		RoleBindingName: types.NamespacedName{
+			Namespace: novaName.Namespace,
+			Name:      "nova-" + novaName.Name + "-rolebinding",
+		},
+		MetadataConfigDataName: types.NamespacedName{ // TODO replace configDataMap for Sched
+			Namespace: novaMetadata.Namespace,
+			Name:      novaMetadata.Name + "-config-data",
+		},
+		InternalNovaMetadataServiceName: types.NamespacedName{ // TODO replace for nova-metadata-internal
+			Namespace: novaMetadata.Namespace,
+			Name:      novaMetadata.Name + "-internal",
+		},
+		InternalNovaMetadataRouteName: types.NamespacedName{ // TODO replace for nova-metadata-internal
+			Namespace: novaMetadata.Namespace,
+			Name:      novaMetadata.Name + "-internal",
 		},
 
 		Cells: cells,
 	}
 }
 
-func CreateNovaMetadata(namespace string, spec map[string]interface{}) client.Object {
-	novaMetadataName := uuid.New().String()
-
+func CreateNovaMetadata(name types.NamespacedName, spec map[string]interface{}) client.Object {
 	raw := map[string]interface{}{
 		"apiVersion": "nova.openstack.org/v1beta1",
 		"kind":       "NovaMetadata",
 		"metadata": map[string]interface{}{
-			"name":      novaMetadataName,
-			"namespace": namespace,
+			"name":      name.Name,
+			"namespace": name.Namespace,
 		},
 		"spec": spec,
 	}

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -487,6 +487,94 @@ func SimulateAEESucceeded(name types.NamespacedName) {
 	logger.Info("Simulated AEE success", "on", name)
 }
 
+type CellNames struct {
+	CellName                 types.NamespacedName
+	MariaDBDatabaseName      types.NamespacedName
+	CellConductorName        types.NamespacedName
+	CellDBSyncJobName        types.NamespacedName
+	ConductorStatefulSetName types.NamespacedName
+	TransportURLName         types.NamespacedName
+	CellMappingJobName       types.NamespacedName
+}
+
+func GetCellNames(novaName types.NamespacedName, cell string) CellNames {
+	cellName := types.NamespacedName{
+		Namespace: novaName.Namespace,
+		Name:      novaName.Name + "-" + cell,
+	}
+	c := CellNames{
+		CellName: cellName,
+		MariaDBDatabaseName: types.NamespacedName{
+			Namespace: novaName.Namespace,
+			Name:      "nova-" + cell,
+		},
+		CellConductorName: types.NamespacedName{
+			Namespace: novaName.Namespace,
+			Name:      cellName.Name + "-conductor",
+		},
+		CellDBSyncJobName: types.NamespacedName{
+			Namespace: novaName.Namespace,
+			Name:      cellName.Name + "-conductor-db-sync",
+		},
+		ConductorStatefulSetName: types.NamespacedName{
+			Namespace: novaName.Namespace,
+			Name:      cellName.Name + "-conductor",
+		},
+		TransportURLName: types.NamespacedName{
+			Namespace: novaName.Namespace,
+			Name:      cellName.Name + "-transport",
+		},
+		CellMappingJobName: types.NamespacedName{
+			Namespace: novaName.Namespace,
+			Name:      cellName.Name + "-cell-mapping",
+		},
+	}
+
+	if cell == "cell0" {
+		c.TransportURLName = types.NamespacedName{
+			Namespace: novaName.Namespace,
+			Name:      novaName.Name + "-api-transport",
+		}
+	}
+
+	return c
+}
+
+type NovaNames struct {
+	NovaName               types.NamespacedName
+	APIName                types.NamespacedName
+	APIMariaDBDatabaseName types.NamespacedName
+	APIDeploymentName      types.NamespacedName
+	KeystoneServiceName    types.NamespacedName
+	Cells                  map[string]CellNames
+}
+
+func GetNovaNames(novaName types.NamespacedName, cellNames []string) NovaNames {
+	novaAPI := types.NamespacedName{
+		Namespace: novaName.Namespace,
+		Name:      novaName.Name + "-api",
+	}
+	cells := map[string]CellNames{}
+	for _, cellName := range cellNames {
+		cells[cellName] = GetCellNames(novaName, cellName)
+	}
+	return NovaNames{
+		NovaName: novaName,
+		APIName:  novaAPI,
+		APIMariaDBDatabaseName: types.NamespacedName{
+			Namespace: novaName.Namespace,
+			Name:      "nova-api",
+		},
+		APIDeploymentName: novaAPI,
+		KeystoneServiceName: types.NamespacedName{
+			Namespace: novaName.Namespace,
+			Name:      "nova",
+		},
+
+		Cells: cells,
+	}
+}
+
 func CreateNovaMetadata(namespace string, spec map[string]interface{}) client.Object {
 	novaMetadataName := uuid.New().String()
 

--- a/test/functional/nova_controller_test.go
+++ b/test/functional/nova_controller_test.go
@@ -18,7 +18,6 @@ package functional_test
 import (
 	"fmt"
 
-	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/openstack-k8s-operators/lib-common/modules/test/helpers"
@@ -30,123 +29,14 @@ import (
 )
 
 var _ = Describe("Nova controller", func() {
-	var novaName types.NamespacedName
-	var mariaDBDatabaseNameForAPI types.NamespacedName
-	var mariaDBDatabaseNameForCell0 types.NamespacedName
-	var cell0Name types.NamespacedName
-	var cell0ConductorName types.NamespacedName
-	var cell0DBSyncJobName types.NamespacedName
-	var cell0MappingJobName types.NamespacedName
-	var novaAPIName types.NamespacedName
-	var novaAPIdeploymentName types.NamespacedName
-	var novaAPIKeystoneEndpointName types.NamespacedName
-	var novaKeystoneServiceName types.NamespacedName
-	var novaCell0ConductorStatefulSetName types.NamespacedName
-	var apiTransportURLName types.NamespacedName
-	var novaSchedulerName types.NamespacedName
-	var novaSchedulerStatefulSetName types.NamespacedName
-	var novaMetadataName types.NamespacedName
-	var novaMetadataStatefulSetName types.NamespacedName
-	var novaServiceAccountName types.NamespacedName
-	var novaRoleName types.NamespacedName
-	var novaRoleBindingName types.NamespacedName
-
-	BeforeEach(func() {
-		// Uncomment this if you need the full output in the logs from gomega
-		// matchers
-		// format.MaxLength = 0
-
-		novaName = types.NamespacedName{
-			Namespace: namespace,
-			Name:      uuid.New().String(),
-		}
-		mariaDBDatabaseNameForAPI = types.NamespacedName{
-			Namespace: namespace,
-			Name:      "nova-api",
-		}
-		mariaDBDatabaseNameForCell0 = types.NamespacedName{
-			Namespace: namespace,
-			Name:      "nova-cell0",
-		}
-		cell0Name = types.NamespacedName{
-			Namespace: namespace,
-			Name:      novaName.Name + "-cell0",
-		}
-		cell0ConductorName = types.NamespacedName{
-			Namespace: namespace,
-			Name:      cell0Name.Name + "-conductor",
-		}
-		cell0DBSyncJobName = types.NamespacedName{
-			Namespace: namespace,
-			Name:      cell0ConductorName.Name + "-db-sync",
-		}
-		novaAPIName = types.NamespacedName{
-			Namespace: namespace,
-			Name:      novaName.Name + "-api",
-		}
-		novaAPIdeploymentName = types.NamespacedName{
-			Namespace: namespace,
-			Name:      novaAPIName.Name,
-		}
-		novaAPIKeystoneEndpointName = types.NamespacedName{
-			Namespace: namespace,
-			Name:      "nova",
-		}
-		novaKeystoneServiceName = types.NamespacedName{
-			Namespace: namespace,
-			Name:      "nova",
-		}
-		novaCell0ConductorStatefulSetName = types.NamespacedName{
-			Namespace: namespace,
-			Name:      cell0ConductorName.Name,
-		}
-		apiTransportURLName = types.NamespacedName{
-			Namespace: namespace,
-			Name:      novaName.Name + "-api-transport",
-		}
-		novaSchedulerName = types.NamespacedName{
-			Namespace: namespace,
-			Name:      novaName.Name + "-scheduler",
-		}
-		novaSchedulerStatefulSetName = types.NamespacedName{
-			Namespace: namespace,
-			Name:      novaSchedulerName.Name,
-		}
-		novaMetadataName = types.NamespacedName{
-			Namespace: namespace,
-			Name:      novaName.Name + "-metadata",
-		}
-		novaMetadataStatefulSetName = types.NamespacedName{
-			Namespace: namespace,
-			Name:      novaMetadataName.Name,
-		}
-		novaServiceAccountName = types.NamespacedName{
-			Namespace: namespace,
-			Name:      "nova-" + novaName.Name,
-		}
-		novaRoleName = types.NamespacedName{
-			Namespace: namespace,
-			Name:      novaServiceAccountName.Name + "-role",
-		}
-		novaRoleBindingName = types.NamespacedName{
-			Namespace: namespace,
-			Name:      novaServiceAccountName.Name + "-rolebinding",
-		}
-		cell0MappingJobName = types.NamespacedName{
-			Namespace: namespace,
-			Name:      cell0Name.Name + "-cell-mapping",
-		}
-	})
-
 	When("Nova CR instance is created without cell0", func() {
 		BeforeEach(func() {
-
-			DeferCleanup(th.DeleteInstance, CreateNovaWithoutCell0(novaName))
+			DeferCleanup(th.DeleteInstance, CreateNovaWithoutCell0(novaNames.NovaName))
 		})
 
 		It("is not Ready", func() {
 			th.ExpectCondition(
-				novaName,
+				novaNames.NovaName,
 				ConditionGetterFunc(NovaConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionFalse,
@@ -154,7 +44,7 @@ var _ = Describe("Nova controller", func() {
 		})
 
 		It("has no hash and no services ready", func() {
-			instance := GetNova(novaName)
+			instance := GetNova(novaNames.NovaName)
 			Expect(instance.Status.Hash).To(BeEmpty())
 			Expect(instance.Status.APIServiceReadyCount).To(Equal(int32(0)))
 			Expect(instance.Status.SchedulerServiceReadyCount).To(Equal(int32(0)))
@@ -163,7 +53,7 @@ var _ = Describe("Nova controller", func() {
 
 		It("reports that cell0 is missing from the spec", func() {
 			th.ExpectConditionWithDetails(
-				novaName,
+				novaNames.NovaName,
 				ConditionGetterFunc(NovaConditionGetter),
 				novav1.NovaAllCellsReadyCondition,
 				corev1.ConditionFalse,
@@ -176,23 +66,23 @@ var _ = Describe("Nova controller", func() {
 	When("Nova CR instance is created", func() {
 		BeforeEach(func() {
 			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaSecret(namespace, SecretName))
+				k8sClient.Delete, ctx, CreateNovaSecret(novaNames.NovaName.Namespace, SecretName))
 			DeferCleanup(
 				k8sClient.Delete,
 				ctx,
-				CreateNovaMessageBusSecret(namespace, MessageBusSecretName),
+				CreateNovaMessageBusSecret(novaNames.NovaName.Namespace, MessageBusSecretName),
 			)
 			DeferCleanup(
 				th.DeleteDBService,
 				th.CreateDBService(
-					namespace,
+					novaNames.NovaName.Namespace,
 					"openstack",
 					corev1.ServiceSpec{
 						Ports: []corev1.ServicePort{{Port: 3306}},
 					},
 				),
 			)
-			keystoneAPIName := th.CreateKeystoneAPI(namespace)
+			keystoneAPIName := th.CreateKeystoneAPI(novaNames.NovaName.Namespace)
 			DeferCleanup(th.DeleteKeystoneAPI, keystoneAPIName)
 			keystoneAPI := th.GetKeystoneAPI(keystoneAPIName)
 			keystoneAPI.Status.APIEndpoints["internal"] = "http://keystone-internal-openstack.testing"
@@ -200,43 +90,43 @@ var _ = Describe("Nova controller", func() {
 				g.Expect(k8sClient.Status().Update(ctx, keystoneAPI.DeepCopy())).Should(Succeed())
 			}, timeout, interval).Should(Succeed())
 
-			DeferCleanup(th.DeleteInstance, CreateNovaWithCell0(novaName))
+			DeferCleanup(th.DeleteInstance, CreateNovaWithCell0(novaNames.NovaName))
 		})
 
 		It("creates service account, role and rolebindig", func() {
 			th.ExpectCondition(
-				novaName,
+				novaNames.NovaName,
 				ConditionGetterFunc(NovaConditionGetter),
 				condition.ServiceAccountReadyCondition,
 				corev1.ConditionTrue,
 			)
-			sa := th.GetServiceAccount(novaServiceAccountName)
+			sa := th.GetServiceAccount(novaNames.ServiceAccountName)
 
 			th.ExpectCondition(
-				novaName,
+				novaNames.NovaName,
 				ConditionGetterFunc(NovaConditionGetter),
 				condition.RoleReadyCondition,
 				corev1.ConditionTrue,
 			)
-			role := th.GetRole(novaRoleName)
+			role := th.GetRole(novaNames.RoleName)
 			Expect(role.Rules).To(HaveLen(2))
 			Expect(role.Rules[0].Resources).To(Equal([]string{"securitycontextconstraints"}))
 			Expect(role.Rules[1].Resources).To(Equal([]string{"pods"}))
 
 			th.ExpectCondition(
-				novaName,
+				novaNames.NovaName,
 				ConditionGetterFunc(NovaConditionGetter),
 				condition.RoleBindingReadyCondition,
 				corev1.ConditionTrue,
 			)
-			binding := th.GetRoleBinding(novaRoleBindingName)
+			binding := th.GetRoleBinding(novaNames.RoleBindingName)
 			Expect(binding.RoleRef.Name).To(Equal(role.Name))
 			Expect(binding.Subjects).To(HaveLen(1))
 			Expect(binding.Subjects[0].Name).To(Equal(sa.Name))
 		})
 
 		It("initializes Status fields", func() {
-			instance := GetNova(novaName)
+			instance := GetNova(novaNames.NovaName)
 			Expect(instance.Status.Hash).To(BeEmpty())
 			Expect(instance.Status.APIServiceReadyCount).To(Equal(int32(0)))
 			Expect(instance.Status.SchedulerServiceReadyCount).To(Equal(int32(0)))
@@ -254,7 +144,7 @@ var _ = Describe("Nova controller", func() {
 			Expect(keystone.Status.Conditions).ToNot(BeNil())
 
 			th.ExpectCondition(
-				novaName,
+				novaNames.NovaName,
 				ConditionGetterFunc(NovaConditionGetter),
 				condition.KeystoneServiceReadyCondition,
 				corev1.ConditionTrue,
@@ -264,7 +154,7 @@ var _ = Describe("Nova controller", func() {
 		It("creates nova_api DB", func() {
 			th.SimulateKeystoneServiceReady(novaNames.KeystoneServiceName)
 			th.ExpectCondition(
-				novaName,
+				novaNames.NovaName,
 				ConditionGetterFunc(NovaConditionGetter),
 				novav1.NovaAPIDBReadyCondition,
 				corev1.ConditionFalse,
@@ -273,7 +163,7 @@ var _ = Describe("Nova controller", func() {
 
 			th.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
 			th.ExpectCondition(
-				novaName,
+				novaNames.NovaName,
 				ConditionGetterFunc(NovaConditionGetter),
 				novav1.NovaAPIDBReadyCondition,
 				corev1.ConditionTrue,
@@ -283,7 +173,7 @@ var _ = Describe("Nova controller", func() {
 		It("creates nova-api MQ", func() {
 			th.SimulateKeystoneServiceReady(novaNames.KeystoneServiceName)
 			th.ExpectCondition(
-				novaName,
+				novaNames.NovaName,
 				ConditionGetterFunc(NovaConditionGetter),
 				novav1.NovaAPIMQReadyCondition,
 				corev1.ConditionFalse,
@@ -292,7 +182,7 @@ var _ = Describe("Nova controller", func() {
 
 			th.SimulateTransportURLReady(cell0.TransportURLName)
 			th.ExpectCondition(
-				novaName,
+				novaNames.NovaName,
 				ConditionGetterFunc(NovaConditionGetter),
 				novav1.NovaAPIMQReadyCondition,
 				corev1.ConditionTrue,
@@ -302,7 +192,7 @@ var _ = Describe("Nova controller", func() {
 		It("creates nova_cell0 DB", func() {
 			th.SimulateKeystoneServiceReady(novaNames.KeystoneServiceName)
 			th.ExpectCondition(
-				novaName,
+				novaNames.NovaName,
 				ConditionGetterFunc(NovaConditionGetter),
 				novav1.NovaAllCellsDBReadyCondition,
 				corev1.ConditionFalse,
@@ -311,7 +201,7 @@ var _ = Describe("Nova controller", func() {
 			th.GetMariaDBDatabase(cell0.MariaDBDatabaseName)
 			th.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
 			th.ExpectCondition(
-				novaName,
+				novaNames.NovaName,
 				ConditionGetterFunc(NovaConditionGetter),
 				novav1.NovaAllCellsDBReadyCondition,
 				corev1.ConditionTrue,
@@ -327,12 +217,12 @@ var _ = Describe("Nova controller", func() {
 			cell := GetNovaCell(cell0.CellName)
 			Expect(cell.Spec.CellMessageBusSecretName).To(Equal("rabbitmq-secret"))
 			Expect(cell.Spec.ServiceUser).To(Equal("nova"))
-			Expect(cell.Spec.ServiceAccount).To(Equal(novaServiceAccountName.Name))
+			Expect(cell.Spec.ServiceAccount).To(Equal(novaNames.ServiceAccountName.Name))
 
 			conductor := GetNovaConductor(cell0.CellConductorName)
 			Expect(conductor.Spec.CellMessageBusSecretName).To(Equal("rabbitmq-secret"))
 			Expect(conductor.Spec.ServiceUser).To(Equal("nova"))
-			Expect(conductor.Spec.ServiceAccount).To(Equal(novaServiceAccountName.Name))
+			Expect(conductor.Spec.ServiceAccount).To(Equal(novaNames.ServiceAccountName.Name))
 
 			th.ExpectCondition(
 				cell0.CellConductorName,
@@ -356,12 +246,13 @@ var _ = Describe("Nova controller", func() {
 				corev1.ConditionTrue,
 			)
 
-			th.SimulateJobSuccess(cell0MappingJobName)
+			th.SimulateJobSuccess(cell0.CellMappingJobName)
 
+			// TODO(bogdando): move to CellNames.MappingJob*
 			mappingJobConfig := th.GetConfigMap(
 				types.NamespacedName{
-					Namespace: namespace,
-					Name:      fmt.Sprintf("%s-config-data", cell0Name.Name+"-manage"),
+					Namespace: cell0.CellName.Namespace,
+					Name:      fmt.Sprintf("%s-config-data", cell0.CellName.Name+"-manage"),
 				},
 			)
 			Expect(mappingJobConfig.Data).Should(HaveKey("01-nova.conf"))
@@ -373,21 +264,21 @@ var _ = Describe("Nova controller", func() {
 			)
 			mappingJobScript := th.GetConfigMap(
 				types.NamespacedName{
-					Namespace: namespace,
-					Name:      fmt.Sprintf("%s-scripts", cell0Name.Name+"-manage"),
+					Namespace: cell0.CellName.Namespace,
+					Name:      fmt.Sprintf("%s-scripts", cell0.CellName.Name+"-manage"),
 				},
 			)
 			Expect(mappingJobScript.Data).Should(HaveKeyWithValue(
 				"ensure_cell_mapping.sh", ContainSubstring("nova-manage cell_v2 update_cell")))
 
 			Eventually(func(g Gomega) {
-				nova := GetNova(novaName)
+				nova := GetNova(novaNames.NovaName)
 				g.Expect(nova.Status.RegisteredCells).To(
-					HaveKeyWithValue(cell0Name.Name, Not(BeEmpty())))
+					HaveKeyWithValue(cell0.CellName.Name, Not(BeEmpty())))
 			}, timeout, interval).Should(Succeed())
 
 			th.ExpectCondition(
-				novaName,
+				novaNames.NovaName,
 				ConditionGetterFunc(NovaConditionGetter),
 				novav1.NovaAllCellsReadyCondition,
 				corev1.ConditionTrue,
@@ -401,17 +292,17 @@ var _ = Describe("Nova controller", func() {
 			th.SimulateTransportURLReady(cell0.TransportURLName)
 			th.SimulateJobSuccess(cell0.CellDBSyncJobName)
 			th.SimulateStatefulSetReplicaReady(cell0.ConductorStatefulSetName)
-                        th.SimulateJobSuccess(cell0MappingJobName) // TODO: move to cell0 Names
-                        th.SimulateStatefulSetReplicaReady(novaNames.SchedulerStatefulSetName)
-                        th.SimulateStatefulSetReplicaReady(novaNames.MetadataStatefulSetName)
+			th.SimulateJobSuccess(cell0.CellMappingJobName)
+			th.SimulateStatefulSetReplicaReady(novaNames.SchedulerStatefulSetName)
+			th.SimulateStatefulSetReplicaReady(novaNames.MetadataStatefulSetName)
 
 			api := GetNovaAPI(novaNames.APIName)
 			Expect(api.Spec.APIMessageBusSecretName).To(Equal("rabbitmq-secret"))
 			Expect(api.Spec.ServiceUser).To(Equal("nova"))
-			Expect(api.Spec.ServiceAccount).To(Equal(novaServiceAccountName.Name))
+			Expect(api.Spec.ServiceAccount).To(Equal(novaNames.ServiceAccountName.Name))
 
 			th.SimulateStatefulSetReplicaReady(novaNames.APIDeploymentName)
-			th.SimulateKeystoneEndpointReady(novaAPIKeystoneEndpointName)
+			th.SimulateKeystoneEndpointReady(novaNames.APIKeystoneEndpointName)
 			th.ExpectCondition(
 				novaNames.APIName,
 				ConditionGetterFunc(NovaAPIConditionGetter),
@@ -419,13 +310,13 @@ var _ = Describe("Nova controller", func() {
 				corev1.ConditionTrue,
 			)
 			th.ExpectCondition(
-				novaName,
+				novaNames.NovaName,
 				ConditionGetterFunc(NovaConditionGetter),
 				novav1.NovaAPIReadyCondition,
 				corev1.ConditionTrue,
 			)
 			th.ExpectCondition(
-				novaName,
+				novaNames.NovaName,
 				ConditionGetterFunc(NovaConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionTrue,
@@ -433,74 +324,75 @@ var _ = Describe("Nova controller", func() {
 		})
 
 		It("create NovaScheduler", func() {
-			th.SimulateKeystoneServiceReady(novaKeystoneServiceName)
-			th.SimulateMariaDBDatabaseCompleted(mariaDBDatabaseNameForAPI)
-			th.SimulateMariaDBDatabaseCompleted(mariaDBDatabaseNameForCell0)
-			th.SimulateTransportURLReady(apiTransportURLName)
-			th.SimulateJobSuccess(cell0DBSyncJobName)
-			th.SimulateStatefulSetReplicaReady(novaCell0ConductorStatefulSetName)
-			th.SimulateJobSuccess(cell0MappingJobName)
-			th.SimulateStatefulSetReplicaReady(novaAPIdeploymentName)
-			th.SimulateKeystoneEndpointReady(novaAPIKeystoneEndpointName)
-			th.SimulateStatefulSetReplicaReady(novaMetadataStatefulSetName)
+			th.SimulateKeystoneServiceReady(novaNames.KeystoneServiceName)
+			th.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
+			th.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
+			th.SimulateTransportURLReady(cell0.TransportURLName)
+			th.SimulateJobSuccess(cell0.CellDBSyncJobName)
+			th.SimulateStatefulSetReplicaReady(cell0.ConductorStatefulSetName)
+			th.SimulateJobSuccess(cell0.CellMappingJobName)
+			th.SimulateStatefulSetReplicaReady(novaNames.APIDeploymentName)
+			th.SimulateKeystoneEndpointReady(novaNames.APIKeystoneEndpointName)
+			th.SimulateStatefulSetReplicaReady(novaNames.MetadataStatefulSetName)
 
-			scheduler := GetNovaScheduler(novaSchedulerName)
+			scheduler := GetNovaScheduler(novaNames.SchedulerName)
 			Expect(scheduler.Spec.APIMessageBusSecretName).To(Equal("rabbitmq-secret"))
-			Expect(scheduler.Spec.ServiceAccount).To(Equal(novaServiceAccountName.Name))
+			Expect(scheduler.Spec.ServiceAccount).To(Equal(novaNames.ServiceAccountName.Name))
 
-			th.SimulateStatefulSetReplicaReady(novaSchedulerStatefulSetName)
+			th.SimulateStatefulSetReplicaReady(novaNames.SchedulerStatefulSetName)
 
 			th.ExpectCondition(
-				novaSchedulerName,
+				novaNames.SchedulerName,
 				ConditionGetterFunc(NovaSchedulerConditionGetter),
 				condition.DeploymentReadyCondition,
 				corev1.ConditionTrue,
 			)
 			th.ExpectCondition(
-				novaName,
+				novaNames.NovaName,
 				ConditionGetterFunc(NovaConditionGetter),
 				novav1.NovaSchedulerReadyCondition,
 				corev1.ConditionTrue,
 			)
 			th.ExpectCondition(
-				novaName,
+				novaNames.NovaName,
 				ConditionGetterFunc(NovaConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionTrue,
 			)
 		})
+
 		It("create NovaMetadata", func() {
-			th.SimulateKeystoneServiceReady(novaKeystoneServiceName)
-			th.SimulateMariaDBDatabaseCompleted(mariaDBDatabaseNameForAPI)
-			th.SimulateMariaDBDatabaseCompleted(mariaDBDatabaseNameForCell0)
-			th.SimulateTransportURLReady(apiTransportURLName)
-			th.SimulateJobSuccess(cell0DBSyncJobName)
-			th.SimulateStatefulSetReplicaReady(novaCell0ConductorStatefulSetName)
-			th.SimulateJobSuccess(cell0MappingJobName)
-			th.SimulateStatefulSetReplicaReady(novaAPIdeploymentName)
-			th.SimulateKeystoneEndpointReady(novaAPIKeystoneEndpointName)
-			th.SimulateStatefulSetReplicaReady(novaSchedulerStatefulSetName)
+			th.SimulateKeystoneServiceReady(novaNames.KeystoneServiceName)
+			th.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
+			th.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
+			th.SimulateTransportURLReady(cell0.TransportURLName)
+			th.SimulateJobSuccess(cell0.CellDBSyncJobName)
+			th.SimulateStatefulSetReplicaReady(cell0.ConductorStatefulSetName)
+			th.SimulateJobSuccess(cell0.CellMappingJobName)
+			th.SimulateStatefulSetReplicaReady(novaNames.APIDeploymentName)
+			th.SimulateKeystoneEndpointReady(novaNames.APIKeystoneEndpointName)
+			th.SimulateStatefulSetReplicaReady(novaNames.SchedulerStatefulSetName)
 
-			metadata := GetNovaMetadata(novaMetadataName)
+			metadata := GetNovaMetadata(novaNames.MetadataName)
 			Expect(metadata.Spec.APIMessageBusSecretName).To(Equal("rabbitmq-secret"))
-			Expect(metadata.Spec.ServiceAccount).To(Equal(novaServiceAccountName.Name))
+			Expect(metadata.Spec.ServiceAccount).To(Equal(novaNames.ServiceAccountName.Name))
 
-			th.SimulateStatefulSetReplicaReady(novaMetadataStatefulSetName)
+			th.SimulateStatefulSetReplicaReady(novaNames.MetadataStatefulSetName)
 
 			th.ExpectCondition(
-				novaMetadataName,
+				novaNames.MetadataName,
 				ConditionGetterFunc(NovaMetadataConditionGetter),
 				condition.DeploymentReadyCondition,
 				corev1.ConditionTrue,
 			)
 			th.ExpectCondition(
-				novaName,
+				novaNames.NovaName,
 				ConditionGetterFunc(NovaConditionGetter),
 				novav1.NovaMetadataReadyCondition,
 				corev1.ConditionTrue,
 			)
 			th.ExpectCondition(
-				novaName,
+				novaNames.NovaName,
 				ConditionGetterFunc(NovaConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionTrue,
@@ -511,23 +403,23 @@ var _ = Describe("Nova controller", func() {
 	When("Nova CR instance is created but cell0 DB sync fails", func() {
 		BeforeEach(func() {
 			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaSecret(namespace, SecretName))
+				k8sClient.Delete, ctx, CreateNovaSecret(novaNames.NovaName.Namespace, SecretName))
 			DeferCleanup(
 				k8sClient.Delete,
 				ctx,
-				CreateNovaMessageBusSecret(namespace, MessageBusSecretName),
+				CreateNovaMessageBusSecret(novaNames.NovaName.Namespace, MessageBusSecretName),
 			)
 			DeferCleanup(
 				th.DeleteDBService,
 				th.CreateDBService(
-					namespace,
+					novaNames.NovaName.Namespace,
 					"openstack",
 					corev1.ServiceSpec{
 						Ports: []corev1.ServicePort{{Port: 3306}},
 					},
 				),
 			)
-			keystoneAPIName := th.CreateKeystoneAPI(namespace)
+			keystoneAPIName := th.CreateKeystoneAPI(novaNames.NovaName.Namespace)
 			DeferCleanup(th.DeleteKeystoneAPI, keystoneAPIName)
 			keystoneAPI := th.GetKeystoneAPI(keystoneAPIName)
 			keystoneAPI.Status.APIEndpoints["internal"] = "http://keystone-internal-openstack.testing"
@@ -535,9 +427,8 @@ var _ = Describe("Nova controller", func() {
 				g.Expect(k8sClient.Status().Update(ctx, keystoneAPI.DeepCopy())).Should(Succeed())
 			}, timeout, interval).Should(Succeed())
 
-			DeferCleanup(th.DeleteInstance, CreateNovaWithCell0(novaName))
+			DeferCleanup(th.DeleteInstance, CreateNovaWithCell0(novaNames.NovaName))
 
-		It("does not create NovaAPI", func() {
 			th.SimulateKeystoneServiceReady(novaNames.KeystoneServiceName)
 			th.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
 			th.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
@@ -546,6 +437,9 @@ var _ = Describe("Nova controller", func() {
 			GetNovaConductor(cell0.CellConductorName)
 
 			th.SimulateJobFailure(cell0.CellDBSyncJobName)
+		})
+
+		It("does not set the cell db sync ready condtion to true", func() {
 			th.ExpectCondition(
 				cell0.CellConductorName,
 				ConditionGetterFunc(NovaConductorConditionGetter),
@@ -565,41 +459,42 @@ var _ = Describe("Nova controller", func() {
 
 		It("does not set the all cell ready condition", func() {
 			th.ExpectCondition(
-				novaName,
+				novaNames.NovaName,
 				ConditionGetterFunc(NovaConditionGetter),
 				novav1.NovaAllCellsReadyCondition,
 				corev1.ConditionFalse,
 			)
 		})
 
+		It("does not create NovaAPI", func() {
 			NovaAPINotExists(novaNames.APIName)
 		})
 
 		It("does not create NovaScheduler", func() {
-			NovaSchedulerNotExists(novaSchedulerName)
+			NovaSchedulerNotExists(novaNames.SchedulerName)
 		})
 	})
 
 	When("Nova CR instance is created but cell0 cell registration fails", func() {
 		BeforeEach(func() {
 			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaSecret(namespace, SecretName))
+				k8sClient.Delete, ctx, CreateNovaSecret(novaNames.NovaName.Namespace, SecretName))
 			DeferCleanup(
 				k8sClient.Delete,
 				ctx,
-				CreateNovaMessageBusSecret(namespace, MessageBusSecretName),
+				CreateNovaMessageBusSecret(novaNames.NovaName.Namespace, MessageBusSecretName),
 			)
 			DeferCleanup(
 				th.DeleteDBService,
 				th.CreateDBService(
-					namespace,
+					novaNames.NovaName.Namespace,
 					"openstack",
 					corev1.ServiceSpec{
 						Ports: []corev1.ServicePort{{Port: 3306}},
 					},
 				),
 			)
-			keystoneAPIName := th.CreateKeystoneAPI(namespace)
+			keystoneAPIName := th.CreateKeystoneAPI(novaNames.NovaName.Namespace)
 			DeferCleanup(th.DeleteKeystoneAPI, keystoneAPIName)
 			keystoneAPI := th.GetKeystoneAPI(keystoneAPIName)
 			keystoneAPI.Status.APIEndpoints["internal"] = "http://keystone-internal-openstack.testing"
@@ -607,21 +502,21 @@ var _ = Describe("Nova controller", func() {
 				g.Expect(k8sClient.Status().Update(ctx, keystoneAPI.DeepCopy())).Should(Succeed())
 			}, timeout, interval).Should(Succeed())
 
-			DeferCleanup(th.DeleteInstance, CreateNovaWithCell0(novaName))
+			DeferCleanup(th.DeleteInstance, CreateNovaWithCell0(novaNames.NovaName))
 
-			th.SimulateKeystoneServiceReady(novaKeystoneServiceName)
-			th.SimulateMariaDBDatabaseCompleted(mariaDBDatabaseNameForAPI)
-			th.SimulateMariaDBDatabaseCompleted(mariaDBDatabaseNameForCell0)
-			th.SimulateTransportURLReady(apiTransportURLName)
-			th.SimulateJobSuccess(cell0DBSyncJobName)
-			th.SimulateStatefulSetReplicaReady(novaCell0ConductorStatefulSetName)
+			th.SimulateKeystoneServiceReady(novaNames.KeystoneServiceName)
+			th.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
+			th.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
+			th.SimulateTransportURLReady(cell0.TransportURLName)
+			th.SimulateJobSuccess(cell0.CellDBSyncJobName)
+			th.SimulateStatefulSetReplicaReady(cell0.ConductorStatefulSetName)
 
-			th.SimulateJobFailure(cell0MappingJobName)
+			th.SimulateJobFailure(cell0.CellMappingJobName)
 		})
 
 		It("does not set the all cell ready condition", func() {
 			th.ExpectCondition(
-				novaName,
+				novaNames.NovaName,
 				ConditionGetterFunc(NovaConditionGetter),
 				novav1.NovaAllCellsReadyCondition,
 				corev1.ConditionFalse,
@@ -629,9 +524,9 @@ var _ = Describe("Nova controller", func() {
 		})
 
 		It("still creates the top level services", func() {
-			GetNovaAPI(novaAPIName)
-			GetNovaScheduler(novaSchedulerName)
-			GetNovaMetadata(novaMetadataName)
+			GetNovaAPI(novaNames.APIName)
+			GetNovaScheduler(novaNames.SchedulerName)
+			GetNovaMetadata(novaNames.MetadataName)
 		})
 
 	})
@@ -639,18 +534,18 @@ var _ = Describe("Nova controller", func() {
 	When("Nova CR instance with different DB Services for nova_api and cell0 DBs", func() {
 		BeforeEach(func() {
 			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaSecret(namespace, SecretName))
+				k8sClient.Delete, ctx, CreateNovaSecret(novaNames.NovaName.Namespace, SecretName))
 			DeferCleanup(
 				k8sClient.Delete,
 				ctx,
-				CreateNovaMessageBusSecret(namespace, MessageBusSecretName),
+				CreateNovaMessageBusSecret(novaNames.NovaName.Namespace, MessageBusSecretName),
 			)
 
 			DeferCleanup(
 				th.DeleteDBService,
 				th.CreateDBService(
-					namespace,
-					"db-for-cell0",
+					cell0.MariaDBDatabaseName.Namespace,
+					cell0.MariaDBDatabaseName.Name,
 					corev1.ServiceSpec{
 						Ports: []corev1.ServicePort{{Port: 3306}},
 					},
@@ -659,14 +554,14 @@ var _ = Describe("Nova controller", func() {
 			DeferCleanup(
 				th.DeleteDBService,
 				th.CreateDBService(
-					namespace,
-					"db-for-api",
+					novaNames.APIMariaDBDatabaseName.Namespace,
+					novaNames.APIMariaDBDatabaseName.Name,
 					corev1.ServiceSpec{
 						Ports: []corev1.ServicePort{{Port: 3306}},
 					},
 				),
 			)
-			keystoneAPIName := th.CreateKeystoneAPI(namespace)
+			keystoneAPIName := th.CreateKeystoneAPI(novaNames.NovaName.Namespace)
 			DeferCleanup(th.DeleteKeystoneAPI, keystoneAPIName)
 			keystoneAPI := th.GetKeystoneAPI(keystoneAPIName)
 			keystoneAPI.Status.APIEndpoints["internal"] = "http://keystone-internal-openstack.testing"
@@ -675,12 +570,12 @@ var _ = Describe("Nova controller", func() {
 			}, timeout, interval).Should(Succeed())
 
 			spec := GetDefaultNovaSpec()
-			cell0 := GetDefaultNovaCellTemplate()
-			cell0["cellDatabaseInstance"] = "db-for-cell0"
-			spec["cellTemplates"] = map[string]interface{}{"cell0": cell0}
-			spec["apiDatabaseInstance"] = "db-for-api"
+			cell0template := GetDefaultNovaCellTemplate()
+			cell0template["cellDatabaseInstance"] = cell0.MariaDBDatabaseName.Name
+			spec["cellTemplates"] = map[string]interface{}{"cell0": cell0template}
+			spec["apiDatabaseInstance"] = novaNames.APIMariaDBDatabaseName.Name
 
-			DeferCleanup(th.DeleteInstance, CreateNova(novaName, spec))
+			DeferCleanup(th.DeleteInstance, CreateNova(novaNames.NovaName, spec))
 		})
 
 		It("uses the correct hostnames to access the different DB services", func() {
@@ -693,54 +588,60 @@ var _ = Describe("Nova controller", func() {
 			Expect(len(cell0DBSync.Spec.Template.Spec.InitContainers)).To(Equal(0))
 			configDataMap := th.GetConfigMap(
 				types.NamespacedName{
-					Namespace: namespace,
-					Name:      fmt.Sprintf("%s-config-data", cell0ConductorName.Name),
+					Namespace: cell0.CellConductorName.Namespace,
+					Name:      fmt.Sprintf("%s-config-data", cell0.CellConductorName.Name),
 				},
 			)
 			Expect(configDataMap.Data).Should(HaveKey("01-nova.conf"))
 			Expect(configDataMap.Data["01-nova.conf"]).To(
-				ContainSubstring("[database]\nconnection = mysql+pymysql://nova_cell0:12345678@hostname-for-db-for-cell0/nova_cell0"),
+				ContainSubstring(fmt.Sprintf("[database]\nconnection = mysql+pymysql://nova_cell0:12345678@hostname-for-%s/nova_cell0", cell0.MariaDBDatabaseName.Name)),
 			)
 			Expect(configDataMap.Data["01-nova.conf"]).To(
-				ContainSubstring("[api_database]\nconnection = mysql+pymysql://nova_api:12345678@hostname-for-db-for-api/nova_api"),
+				ContainSubstring(fmt.Sprintf("[api_database]\nconnection = mysql+pymysql://nova_api:12345678@hostname-for-%s/nova_api", novaNames.APIMariaDBDatabaseName.Name)),
 			)
 
 			th.SimulateJobSuccess(cell0.CellDBSyncJobName)
 			th.SimulateStatefulSetReplicaReady(cell0.ConductorStatefulSetName)
-			th.SimulateJobSuccess(cell0MappingJobName) // TODO: move to cell0 Names
-			th.SimulateStatefulSetReplicaReady(novaSchedulerStatefulSetName)
-			th.SimulateStatefulSetReplicaReady(novaMetadataStatefulSetName)
+			th.SimulateJobSuccess(cell0.CellMappingJobName)
+			th.SimulateStatefulSetReplicaReady(novaNames.SchedulerStatefulSetName)
+			th.SimulateStatefulSetReplicaReady(novaNames.MetadataStatefulSetName)
 
 			configDataMap = th.GetConfigMap(
 				types.NamespacedName{
-					Namespace: namespace,
+					Namespace: novaNames.NovaName.Namespace,
 					Name:      fmt.Sprintf("%s-config-data", novaNames.APIName.Name),
 				},
 			)
 			Expect(configDataMap.Data).Should(HaveKey("01-nova.conf"))
 			Expect(configDataMap.Data["01-nova.conf"]).To(
-				ContainSubstring("[database]\nconnection = mysql+pymysql://nova_cell0:12345678@hostname-for-db-for-cell0/nova_cell0"),
+				ContainSubstring(fmt.Sprintf("[database]\nconnection = mysql+pymysql://nova_cell0:12345678@hostname-for-%s/nova_cell0",
+					cell0.MariaDBDatabaseName.Name)),
 			)
 			Expect(configDataMap.Data["01-nova.conf"]).To(
-				ContainSubstring("[api_database]\nconnection = mysql+pymysql://nova_api:12345678@hostname-for-db-for-api/nova_api"),
+				ContainSubstring(
+					fmt.Sprintf("[api_database]\nconnection = mysql+pymysql://nova_api:12345678@hostname-for-%s/nova_api",
+						novaNames.APIMariaDBDatabaseName.Name)),
 			)
 
 			configDataMap = th.GetConfigMap(
 				types.NamespacedName{
-					Namespace: namespace,
-					Name:      fmt.Sprintf("%s-config-data", novaSchedulerName.Name),
+					Namespace: novaNames.NovaName.Namespace,
+					Name:      fmt.Sprintf("%s-config-data", novaNames.SchedulerName.Name),
 				},
 			)
 			Expect(configDataMap.Data).Should(HaveKey("01-nova.conf"))
 			Expect(configDataMap.Data["01-nova.conf"]).To(
-				ContainSubstring("[database]\nconnection = mysql+pymysql://nova_cell0:12345678@hostname-for-db-for-cell0/nova_cell0"),
+				ContainSubstring(fmt.Sprintf("[database]\nconnection = mysql+pymysql://nova_cell0:12345678@hostname-for-%s/nova_cell0",
+					cell0.MariaDBDatabaseName.Name)),
 			)
 			Expect(configDataMap.Data["01-nova.conf"]).To(
-				ContainSubstring("[api_database]\nconnection = mysql+pymysql://nova_api:12345678@hostname-for-db-for-api/nova_api"),
+				ContainSubstring(
+					fmt.Sprintf("[api_database]\nconnection = mysql+pymysql://nova_api:12345678@hostname-for-%s/nova_api",
+						novaNames.APIMariaDBDatabaseName.Name)),
 			)
 
 			th.SimulateStatefulSetReplicaReady(novaNames.APIName)
-			th.SimulateKeystoneEndpointReady(novaAPIKeystoneEndpointName)
+			th.SimulateKeystoneEndpointReady(novaNames.APIKeystoneEndpointName)
 
 			th.ExpectCondition(
 				cell0.CellConductorName,
@@ -755,25 +656,25 @@ var _ = Describe("Nova controller", func() {
 				corev1.ConditionTrue,
 			)
 			th.ExpectCondition(
-				novaName,
+				novaNames.NovaName,
 				ConditionGetterFunc(NovaConditionGetter),
 				novav1.NovaAllCellsReadyCondition,
 				corev1.ConditionTrue,
 			)
 			th.ExpectCondition(
-				novaName,
+				novaNames.NovaName,
 				ConditionGetterFunc(NovaConditionGetter),
 				novav1.NovaAPIReadyCondition,
 				corev1.ConditionTrue,
 			)
 			th.ExpectCondition(
-				novaName,
+				novaNames.NovaName,
 				ConditionGetterFunc(NovaConditionGetter),
 				novav1.NovaSchedulerReadyCondition,
 				corev1.ConditionTrue,
 			)
 			th.ExpectCondition(
-				novaName,
+				novaNames.NovaName,
 				ConditionGetterFunc(NovaConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionTrue,
@@ -784,23 +685,23 @@ var _ = Describe("Nova controller", func() {
 	When("Nova CR instance is deleted", func() {
 		BeforeEach(func() {
 			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaSecret(namespace, SecretName))
+				k8sClient.Delete, ctx, CreateNovaSecret(novaNames.NovaName.Namespace, SecretName))
 			DeferCleanup(
 				k8sClient.Delete,
 				ctx,
-				CreateNovaMessageBusSecret(namespace, MessageBusSecretName),
+				CreateNovaMessageBusSecret(novaNames.NovaName.Namespace, MessageBusSecretName),
 			)
 			DeferCleanup(
 				th.DeleteDBService,
 				th.CreateDBService(
-					namespace,
+					novaNames.NovaName.Namespace,
 					"openstack",
 					corev1.ServiceSpec{
 						Ports: []corev1.ServicePort{{Port: 3306}},
 					},
 				),
 			)
-			keystoneAPIName := th.CreateKeystoneAPI(namespace)
+			keystoneAPIName := th.CreateKeystoneAPI(novaNames.NovaName.Namespace)
 			DeferCleanup(th.DeleteKeystoneAPI, keystoneAPIName)
 			keystoneAPI := th.GetKeystoneAPI(keystoneAPIName)
 			keystoneAPI.Status.APIEndpoints["internal"] = "http://keystone-internal-openstack.testing"
@@ -808,13 +709,13 @@ var _ = Describe("Nova controller", func() {
 				g.Expect(k8sClient.Status().Update(ctx, keystoneAPI.DeepCopy())).Should(Succeed())
 			}, timeout, interval).Should(Succeed())
 
-			DeferCleanup(th.DeleteInstance, CreateNovaWithCell0(novaName))
+			DeferCleanup(th.DeleteInstance, CreateNovaWithCell0(novaNames.NovaName))
 		})
 
 		It("removes the finalizer from KeystoneService", func() {
 			th.SimulateKeystoneServiceReady(novaNames.KeystoneServiceName)
 			th.ExpectCondition(
-				novaName,
+				novaNames.NovaName,
 				ConditionGetterFunc(NovaConditionGetter),
 				condition.KeystoneServiceReadyCondition,
 				corev1.ConditionTrue,
@@ -823,47 +724,48 @@ var _ = Describe("Nova controller", func() {
 			service := th.GetKeystoneService(novaNames.KeystoneServiceName)
 			Expect(service.Finalizers).To(ContainElement("Nova"))
 
-			DeleteNova(novaName)
+			th.DeleteInstance(GetNova(novaNames.NovaName))
 			service = th.GetKeystoneService(novaNames.KeystoneServiceName)
 			Expect(service.Finalizers).NotTo(ContainElement("Nova"))
 		})
 
 		It("removes the finalizers from the nova dbs", func() {
-			th.SimulateKeystoneServiceReady(novaKeystoneServiceName)
+			th.SimulateKeystoneServiceReady(novaNames.KeystoneServiceName)
 
-			apiDB := th.GetMariaDBDatabase(mariaDBDatabaseNameForAPI)
+			apiDB := th.GetMariaDBDatabase(novaNames.APIMariaDBDatabaseName)
 			Expect(apiDB.Finalizers).To(ContainElement("Nova"))
-			cell0DB := th.GetMariaDBDatabase(mariaDBDatabaseNameForCell0)
+			cell0DB := th.GetMariaDBDatabase(cell0.MariaDBDatabaseName)
 			Expect(cell0DB.Finalizers).To(ContainElement("Nova"))
 
-			th.DeleteInstance(GetNova(novaName))
+			th.DeleteInstance(GetNova(novaNames.NovaName))
 
-			apiDB = th.GetMariaDBDatabase(mariaDBDatabaseNameForAPI)
+			apiDB = th.GetMariaDBDatabase(novaNames.APIMariaDBDatabaseName)
 			Expect(apiDB.Finalizers).NotTo(ContainElement("Nova"))
-			cell0DB = th.GetMariaDBDatabase(mariaDBDatabaseNameForCell0)
+			cell0DB = th.GetMariaDBDatabase(cell0.MariaDBDatabaseName)
 			Expect(cell0DB.Finalizers).NotTo(ContainElement("Nova"))
 		})
 	})
+
 	When("Nova CR instance is created with NetworkAttachment and ExternalEndpoints", func() {
 		BeforeEach(func() {
 			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaSecret(namespace, SecretName))
+				k8sClient.Delete, ctx, CreateNovaSecret(novaNames.NovaName.Namespace, SecretName))
 			DeferCleanup(
 				k8sClient.Delete,
 				ctx,
-				CreateNovaMessageBusSecret(namespace, MessageBusSecretName),
+				CreateNovaMessageBusSecret(novaNames.NovaName.Namespace, MessageBusSecretName),
 			)
 			DeferCleanup(
 				th.DeleteDBService,
 				th.CreateDBService(
-					namespace,
+					novaNames.NovaName.Namespace,
 					"openstack",
 					corev1.ServiceSpec{
 						Ports: []corev1.ServicePort{{Port: 3306}},
 					},
 				),
 			)
-			keystoneAPIName := th.CreateKeystoneAPI(namespace)
+			keystoneAPIName := th.CreateKeystoneAPI(novaNames.NovaName.Namespace)
 			DeferCleanup(th.DeleteKeystoneAPI, keystoneAPIName)
 			keystoneAPI := th.GetKeystoneAPI(keystoneAPIName)
 			keystoneAPI.Status.APIEndpoints["internal"] = "http://keystone-internal-openstack.testing"
@@ -871,7 +773,7 @@ var _ = Describe("Nova controller", func() {
 				g.Expect(k8sClient.Status().Update(ctx, keystoneAPI.DeepCopy())).Should(Succeed())
 			}, timeout, interval).Should(Succeed())
 
-			internalAPINADName := types.NamespacedName{Namespace: namespace, Name: "internalapi"}
+			internalAPINADName := types.NamespacedName{Namespace: novaNames.NovaName.Namespace, Name: "internalapi"}
 			nad := th.CreateNetworkAttachmentDefinition(internalAPINADName)
 			DeferCleanup(th.DeleteInstance, nad)
 
@@ -905,54 +807,54 @@ var _ = Describe("Nova controller", func() {
 					"networkAttachments": []string{"internalapi"},
 				},
 			}
-			DeferCleanup(th.DeleteInstance, CreateNova(novaName, rawSpec))
+			DeferCleanup(th.DeleteInstance, CreateNova(novaNames.NovaName, rawSpec))
 
-			th.SimulateKeystoneServiceReady(novaKeystoneServiceName)
-			th.SimulateMariaDBDatabaseCompleted(mariaDBDatabaseNameForAPI)
-			th.SimulateMariaDBDatabaseCompleted(mariaDBDatabaseNameForCell0)
-			th.SimulateTransportURLReady(apiTransportURLName)
-			th.SimulateJobSuccess(cell0DBSyncJobName)
+			th.SimulateKeystoneServiceReady(novaNames.KeystoneServiceName)
+			th.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
+			th.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
+			th.SimulateTransportURLReady(cell0.TransportURLName)
+			th.SimulateJobSuccess(cell0.CellDBSyncJobName)
 		})
 
 		It("creates all the sub CRs and passes down the network parameters", func() {
 			SimulateStatefulSetReplicaReadyWithPods(
-				novaCell0ConductorStatefulSetName,
-				map[string][]string{namespace + "/internalapi": {"10.0.0.1"}},
+				cell0.ConductorStatefulSetName,
+				map[string][]string{novaNames.NovaName.Namespace + "/internalapi": {"10.0.0.1"}},
 			)
-			th.SimulateJobSuccess(cell0MappingJobName)
+			th.SimulateJobSuccess(cell0.CellMappingJobName)
 
 			SimulateStatefulSetReplicaReadyWithPods(
-				novaSchedulerStatefulSetName,
-				map[string][]string{namespace + "/internalapi": {"10.0.0.1"}},
+				novaNames.SchedulerStatefulSetName,
+				map[string][]string{novaNames.NovaName.Namespace + "/internalapi": {"10.0.0.1"}},
 			)
 			SimulateStatefulSetReplicaReadyWithPods(
-				novaAPIdeploymentName,
-				map[string][]string{namespace + "/internalapi": {"10.0.0.1"}},
+				novaNames.APIDeploymentName,
+				map[string][]string{novaNames.NovaName.Namespace + "/internalapi": {"10.0.0.1"}},
 			)
 			SimulateStatefulSetReplicaReadyWithPods(
-				novaMetadataStatefulSetName,
-				map[string][]string{namespace + "/internalapi": {"10.0.0.1"}},
+				novaNames.MetadataStatefulSetName,
+				map[string][]string{novaNames.NovaName.Namespace + "/internalapi": {"10.0.0.1"}},
 			)
-			th.SimulateKeystoneEndpointReady(novaAPIKeystoneEndpointName)
+			th.SimulateKeystoneEndpointReady(novaNames.APIKeystoneEndpointName)
 
 			th.ExpectCondition(
-				novaName,
+				novaNames.NovaName,
 				ConditionGetterFunc(NovaConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionTrue,
 			)
 
-			nova := GetNova(novaName)
+			nova := GetNova(novaNames.NovaName)
 
-			conductor := GetNovaConductor(cell0ConductorName)
+			conductor := GetNovaConductor(cell0.CellConductorName)
 			Expect(conductor.Spec.NetworkAttachments).To(
 				Equal(nova.Spec.CellTemplates["cell0"].ConductorServiceTemplate.NetworkAttachments))
 
-			api := GetNovaAPI(novaAPIName)
+			api := GetNovaAPI(novaNames.APIName)
 			Expect(api.Spec.NetworkAttachments).To(Equal(nova.Spec.APIServiceTemplate.NetworkAttachments))
 			Expect(api.Spec.ExternalEndpoints).To(Equal(nova.Spec.APIServiceTemplate.ExternalEndpoints))
 
-			scheduler := GetNovaScheduler(novaSchedulerName)
+			scheduler := GetNovaScheduler(novaNames.SchedulerName)
 			Expect(scheduler.Spec.NetworkAttachments).To(Equal(nova.Spec.APIServiceTemplate.NetworkAttachments))
 		})
 
@@ -965,10 +867,10 @@ var _ = Describe("Nova controller", func() {
 			spec["cellTemplates"] = map[string]interface{}{"cell0": cell0}
 			// This nova is created without any container image is specified in
 			// the request
-			DeferCleanup(th.DeleteInstance, CreateNova(novaName, spec))
+			DeferCleanup(th.DeleteInstance, CreateNova(novaNames.NovaName, spec))
 		})
 		It("has the expected container image defaults", func() {
-			novaDefault := GetNova(novaName)
+			novaDefault := GetNova(novaNames.NovaName)
 
 			Expect(novaDefault.Spec.APIServiceTemplate.ContainerImage).To(Equal(novav1.GetEnvDefault("NOVA_API_IMAGE_URL_DEFAULT", novav1.NovaAPIContainerImage)))
 			Expect(novaDefault.Spec.MetadataServiceTemplate.ContainerImage).To(Equal(novav1.GetEnvDefault("NOVA_METADATA_IMAGE_URL_DEFAULT", novav1.NovaMetadataContainerImage)))

--- a/test/functional/nova_metadata_controller_test.go
+++ b/test/functional/nova_metadata_controller_test.go
@@ -33,36 +33,27 @@ import (
 )
 
 var _ = Describe("NovaMetadata controller", func() {
-	var novaMetadataName types.NamespacedName
-
-	BeforeEach(func() {
-		// Uncomment this if you need the full output in the logs from gomega
-		// matchers
-		// format.MaxLength = 0
-		DeferCleanup(
-			k8sClient.Delete, ctx, CreateNovaMessageBusSecret(namespace, MessageBusSecretName))
-
-	})
 	When("with standard spec without network interface", func() {
 		BeforeEach(func() {
+			DeferCleanup(
+				k8sClient.Delete, ctx, CreateNovaMessageBusSecret(novaNames.MetadataName.Namespace, MessageBusSecretName))
+
 			spec := GetDefaultNovaMetadataSpec()
 			spec["customServiceConfig"] = "foo=bar"
-			metadata := CreateNovaMetadata(namespace, spec)
-			novaMetadataName = types.NamespacedName{Name: metadata.GetName(), Namespace: metadata.GetNamespace()}
-			DeferCleanup(th.DeleteInstance, metadata)
+			DeferCleanup(th.DeleteInstance, CreateNovaMetadata(novaNames.MetadataName, spec))
 		})
 		When("a NovaMetadata CR is created pointing to a non existent Secret", func() {
 
 			It("is not Ready", func() {
 				th.ExpectCondition(
-					novaMetadataName,
+					novaNames.MetadataName,
 					ConditionGetterFunc(NovaMetadataConditionGetter),
 					condition.ReadyCondition, corev1.ConditionFalse,
 				)
 			})
 
 			It("has empty Status fields", func() {
-				instance := GetNovaMetadata(novaMetadataName)
+				instance := GetNovaMetadata(novaNames.MetadataName)
 				// NOTE(gibi): Hash has `omitempty` tags so while
 				// they are initialized to an empty map that value is omitted from
 				// the output when sent to the client. So we see nils here.
@@ -71,7 +62,7 @@ var _ = Describe("NovaMetadata controller", func() {
 			})
 			It("is missing the secret", func() {
 				th.ExpectCondition(
-					novaMetadataName,
+					novaNames.MetadataName,
 					ConditionGetterFunc(NovaMetadataConditionGetter),
 					condition.InputReadyCondition,
 					corev1.ConditionFalse,
@@ -84,7 +75,7 @@ var _ = Describe("NovaMetadata controller", func() {
 				secret := &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "not-relevant-secret",
-						Namespace: namespace,
+						Namespace: novaNames.MetadataName.Namespace,
 					},
 				}
 				Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
@@ -93,7 +84,7 @@ var _ = Describe("NovaMetadata controller", func() {
 
 			It("is not Ready", func() {
 				th.ExpectCondition(
-					novaMetadataName,
+					novaNames.MetadataName,
 					ConditionGetterFunc(NovaMetadataConditionGetter),
 					condition.ReadyCondition,
 					corev1.ConditionFalse,
@@ -102,7 +93,7 @@ var _ = Describe("NovaMetadata controller", func() {
 
 			It("is missing the secret", func() {
 				th.ExpectCondition(
-					novaMetadataName,
+					novaNames.MetadataName,
 					ConditionGetterFunc(NovaMetadataConditionGetter),
 					condition.InputReadyCondition,
 					corev1.ConditionFalse,
@@ -115,7 +106,7 @@ var _ = Describe("NovaMetadata controller", func() {
 				secret := &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      SecretName,
-						Namespace: namespace,
+						Namespace: novaNames.MetadataName.Namespace,
 					},
 					Data: map[string][]byte{
 						"NovaPassword": []byte("12345678"),
@@ -127,7 +118,7 @@ var _ = Describe("NovaMetadata controller", func() {
 
 			It("is not Ready", func() {
 				th.ExpectCondition(
-					novaMetadataName,
+					novaNames.MetadataName,
 					ConditionGetterFunc(NovaMetadataConditionGetter),
 					condition.ReadyCondition,
 					corev1.ConditionFalse,
@@ -136,7 +127,7 @@ var _ = Describe("NovaMetadata controller", func() {
 
 			It("reports that the inputs are not ready", func() {
 				th.ExpectCondition(
-					novaMetadataName,
+					novaNames.MetadataName,
 					ConditionGetterFunc(NovaMetadataConditionGetter),
 					condition.InputReadyCondition,
 					corev1.ConditionFalse,
@@ -149,13 +140,13 @@ var _ = Describe("NovaMetadata controller", func() {
 				DeferCleanup(
 					k8sClient.Delete,
 					ctx,
-					CreateNovaMetadataSecret(namespace, SecretName),
+					CreateNovaMetadataSecret(novaNames.MetadataName.Namespace, SecretName),
 				)
 			})
 
 			It("reports that input is ready", func() {
 				th.ExpectCondition(
-					novaMetadataName,
+					novaNames.MetadataName,
 					ConditionGetterFunc(NovaMetadataConditionGetter),
 					condition.InputReadyCondition,
 					corev1.ConditionTrue,
@@ -163,7 +154,7 @@ var _ = Describe("NovaMetadata controller", func() {
 			})
 			It("generated configs successfully", func() {
 				th.ExpectCondition(
-					novaMetadataName,
+					novaNames.MetadataName,
 					ConditionGetterFunc(NovaMetadataConditionGetter),
 					condition.ServiceConfigReadyCondition,
 					corev1.ConditionTrue,
@@ -171,8 +162,8 @@ var _ = Describe("NovaMetadata controller", func() {
 
 				configDataMap := th.GetConfigMap(
 					types.NamespacedName{
-						Namespace: namespace,
-						Name:      fmt.Sprintf("%s-config-data", novaMetadataName.Name),
+						Namespace: novaNames.MetadataName.Namespace,
+						Name:      fmt.Sprintf("%s-config-data", novaNames.MetadataName.Name),
 					},
 				)
 				Expect(configDataMap).ShouldNot(BeNil())
@@ -189,7 +180,7 @@ var _ = Describe("NovaMetadata controller", func() {
 
 			It("stored the input hash in the Status", func() {
 				Eventually(func(g Gomega) {
-					novaMetadata := GetNovaMetadata(novaMetadataName)
+					novaMetadata := GetNovaMetadata(novaNames.MetadataName)
 					g.Expect(novaMetadata.Status.Hash).Should(HaveKeyWithValue("input", Not(BeEmpty())))
 				}, timeout, interval).Should(Succeed())
 
@@ -198,37 +189,30 @@ var _ = Describe("NovaMetadata controller", func() {
 			When("the NovaMetadata is deleted", func() {
 				It("deletes the generated ConfigMaps", func() {
 					th.ExpectCondition(
-						novaMetadataName,
+						novaNames.MetadataName,
 						ConditionGetterFunc(NovaMetadataConditionGetter),
 						condition.ServiceConfigReadyCondition,
 						corev1.ConditionTrue,
 					)
 
-					th.DeleteInstance(GetNovaMetadata(novaMetadataName))
+					th.DeleteInstance(GetNovaMetadata(novaNames.MetadataName))
 
 					Eventually(func() []corev1.ConfigMap {
-						return th.ListConfigMaps(novaMetadataName.Name).Items
+						return th.ListConfigMaps(novaNames.MetadataName.Name).Items
 					}, timeout, interval).Should(BeEmpty())
 				})
 			})
 		})
 
 		When("NovaMetadata is created with a proper Secret", func() {
-			var statefulSetName types.NamespacedName
-
 			BeforeEach(func() {
 				DeferCleanup(
-					k8sClient.Delete, ctx, CreateNovaMetadataSecret(namespace, SecretName))
-
-				statefulSetName = types.NamespacedName{
-					Namespace: namespace,
-					Name:      novaMetadataName.Name,
-				}
+					k8sClient.Delete, ctx, CreateNovaMetadataSecret(novaNames.MetadataName.Namespace, SecretName))
 			})
 
 			It(" reports input ready", func() {
 				th.ExpectCondition(
-					novaMetadataName,
+					novaNames.MetadataName,
 					ConditionGetterFunc(NovaMetadataConditionGetter),
 					condition.InputReadyCondition,
 					corev1.ConditionTrue,
@@ -237,7 +221,7 @@ var _ = Describe("NovaMetadata controller", func() {
 
 			It("creates a StatefulSet for the nova-metadata service", func() {
 				th.ExpectConditionWithDetails(
-					novaMetadataName,
+					novaNames.MetadataName,
 					ConditionGetterFunc(NovaMetadataConditionGetter),
 					condition.DeploymentReadyCondition,
 					corev1.ConditionFalse,
@@ -245,7 +229,7 @@ var _ = Describe("NovaMetadata controller", func() {
 					condition.DeploymentReadyRunningMessage,
 				)
 
-				ss := th.GetStatefulSet(statefulSetName)
+				ss := th.GetStatefulSet(novaNames.MetadataStatefulSetName)
 				Expect(int(*ss.Spec.Replicas)).To(Equal(1))
 				Expect(ss.Spec.Template.Spec.Volumes).To(HaveLen(2))
 				Expect(ss.Spec.Template.Spec.Containers).To(HaveLen(2))
@@ -267,47 +251,47 @@ var _ = Describe("NovaMetadata controller", func() {
 			When("the StatefulSet has at least one Replica ready", func() {
 				BeforeEach(func() {
 					th.ExpectConditionWithDetails(
-						novaMetadataName,
+						novaNames.MetadataName,
 						ConditionGetterFunc(NovaMetadataConditionGetter),
 						condition.DeploymentReadyCondition,
 						corev1.ConditionFalse,
 						condition.RequestedReason,
 						condition.DeploymentReadyRunningMessage,
 					)
-					th.SimulateStatefulSetReplicaReady(statefulSetName)
+					th.SimulateStatefulSetReplicaReady(novaNames.MetadataStatefulSetName)
 				})
 
 				It("reports that the StatefulSet is ready", func() {
-					th.GetStatefulSet(statefulSetName)
+					th.GetStatefulSet(novaNames.MetadataStatefulSetName)
 					th.ExpectCondition(
-						novaMetadataName,
+						novaNames.MetadataName,
 						ConditionGetterFunc(NovaMetadataConditionGetter),
 						condition.DeploymentReadyCondition,
 						corev1.ConditionTrue,
 					)
 
-					novaMetadata := GetNovaMetadata(novaMetadataName)
+					novaMetadata := GetNovaMetadata(novaNames.MetadataName)
 					Expect(novaMetadata.Status.ReadyCount).To(BeNumerically(">", 0))
 				})
 			})
 
 			It("exposes the service", func() {
-				th.SimulateStatefulSetReplicaReady(statefulSetName)
+				th.SimulateStatefulSetReplicaReady(novaNames.MetadataStatefulSetName)
 				th.ExpectCondition(
-					novaMetadataName,
+					novaNames.MetadataName,
 					ConditionGetterFunc(NovaMetadataConditionGetter),
 					condition.ExposeServiceReadyCondition,
 					corev1.ConditionTrue,
 				)
-				service := th.GetService(types.NamespacedName{Namespace: namespace, Name: "nova-metadata-internal"})
+				service := th.GetService(types.NamespacedName{Namespace: novaNames.MetadataName.Namespace, Name: "nova-metadata-internal"})
 				Expect(service.Labels["service"]).To(Equal("nova-metadata"))
 			})
 
 			It("is Ready", func() {
-				th.SimulateStatefulSetReplicaReady(statefulSetName)
+				th.SimulateStatefulSetReplicaReady(novaNames.MetadataStatefulSetName)
 
 				th.ExpectCondition(
-					novaMetadataName,
+					novaNames.MetadataName,
 					ConditionGetterFunc(NovaMetadataConditionGetter),
 					condition.ReadyCondition,
 					corev1.ConditionTrue,
@@ -315,20 +299,27 @@ var _ = Describe("NovaMetadata controller", func() {
 			})
 		})
 	})
+})
+
+var _ = Describe("NovaMetadata controller", func() {
+	BeforeEach(func() {
+		DeferCleanup(
+			k8sClient.Delete, ctx, CreateNovaMessageBusSecret(novaNames.MetadataName.Namespace, MessageBusSecretName))
+	})
+
 	When("NovaMetadata is created with networkAttachments", func() {
 		BeforeEach(func() {
 			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaMetadataSecret(namespace, SecretName))
+				k8sClient.Delete, ctx, CreateNovaMetadataSecret(novaNames.MetadataName.Namespace, SecretName))
+
 			spec := GetDefaultNovaMetadataSpec()
 			spec["networkAttachments"] = []string{"internalapi"}
-			metadata := CreateNovaMetadata(namespace, spec)
-			novaMetadataName = types.NamespacedName{Name: metadata.GetName(), Namespace: metadata.GetNamespace()}
-			DeferCleanup(th.DeleteInstance, metadata)
+			DeferCleanup(th.DeleteInstance, CreateNovaMetadata(novaNames.MetadataName, spec))
 		})
 
 		It("reports that the definition is missing", func() {
 			th.ExpectConditionWithDetails(
-				novaMetadataName,
+				novaNames.MetadataName,
 				ConditionGetterFunc(NovaMetadataConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionFalse,
@@ -336,28 +327,24 @@ var _ = Describe("NovaMetadata controller", func() {
 				"NetworkAttachment resources missing: internalapi",
 			)
 			th.ExpectCondition(
-				novaMetadataName,
+				novaNames.MetadataName,
 				ConditionGetterFunc(NovaMetadataConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionFalse,
 			)
 		})
 		It("reports that network attachment is missing", func() {
-			internalMetadataName := types.NamespacedName{Namespace: namespace, Name: "internalapi"}
+			internalMetadataName := types.NamespacedName{Namespace: novaNames.MetadataName.Namespace, Name: "internalapi"}
 			nad := th.CreateNetworkAttachmentDefinition(internalMetadataName)
 			DeferCleanup(th.DeleteInstance, nad)
 
-			statefulSetName := types.NamespacedName{
-				Namespace: namespace,
-				Name:      novaMetadataName.Name,
-			}
-			ss := th.GetStatefulSet(statefulSetName)
+			ss := th.GetStatefulSet(novaNames.MetadataStatefulSetName)
 
 			expectedAnnotation, err := json.Marshal(
 				[]networkv1.NetworkSelectionElement{
 					{
 						Name:             "internalapi",
-						Namespace:        namespace,
+						Namespace:        novaNames.MetadataName.Namespace,
 						InterfaceRequest: "internalapi",
 					}})
 			Expect(err).ShouldNot(HaveOccurred())
@@ -367,10 +354,10 @@ var _ = Describe("NovaMetadata controller", func() {
 
 			// We don't add network attachment status annotations to the Pods
 			// to simulate that the network attachments are missing.
-			SimulateStatefulSetReplicaReadyWithPods(statefulSetName, map[string][]string{})
+			SimulateStatefulSetReplicaReadyWithPods(novaNames.MetadataStatefulSetName, map[string][]string{})
 
 			th.ExpectConditionWithDetails(
-				novaMetadataName,
+				novaNames.MetadataName,
 				ConditionGetterFunc(NovaMetadataConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionFalse,
@@ -380,21 +367,17 @@ var _ = Describe("NovaMetadata controller", func() {
 			)
 		})
 		It("reports that an IP is missing", func() {
-			internalMetadataName := types.NamespacedName{Namespace: namespace, Name: "internalapi"}
+			internalMetadataName := types.NamespacedName{Namespace: novaNames.MetadataName.Namespace, Name: "internalapi"}
 			nad := th.CreateNetworkAttachmentDefinition(internalMetadataName)
 			DeferCleanup(th.DeleteInstance, nad)
 
-			statefulSetName := types.NamespacedName{
-				Namespace: namespace,
-				Name:      novaMetadataName.Name,
-			}
-			ss := th.GetStatefulSet(statefulSetName)
+			ss := th.GetStatefulSet(novaNames.MetadataStatefulSetName)
 
 			expectedAnnotation, err := json.Marshal(
 				[]networkv1.NetworkSelectionElement{
 					{
 						Name:             "internalapi",
-						Namespace:        namespace,
+						Namespace:        novaNames.MetadataName.Namespace,
 						InterfaceRequest: "internalapi",
 					}})
 			Expect(err).ShouldNot(HaveOccurred())
@@ -405,12 +388,12 @@ var _ = Describe("NovaMetadata controller", func() {
 			// We simulate that there is no IP associated with the internalapi
 			// network attachment
 			SimulateStatefulSetReplicaReadyWithPods(
-				statefulSetName,
-				map[string][]string{namespace + "/internalapi": {}},
+				novaNames.MetadataStatefulSetName,
+				map[string][]string{novaNames.MetadataName.Namespace + "/internalapi": {}},
 			)
 
 			th.ExpectConditionWithDetails(
-				novaMetadataName,
+				novaNames.MetadataName,
 				ConditionGetterFunc(NovaMetadataConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionFalse,
@@ -420,35 +403,31 @@ var _ = Describe("NovaMetadata controller", func() {
 			)
 		})
 		It("reports NetworkAttachmentsReady if the Pods got the proper annotations", func() {
-			internalMetadataName := types.NamespacedName{Namespace: namespace, Name: "internalapi"}
+			internalMetadataName := types.NamespacedName{Namespace: novaNames.MetadataName.Namespace, Name: "internalapi"}
 			nad := th.CreateNetworkAttachmentDefinition(internalMetadataName)
 			DeferCleanup(th.DeleteInstance, nad)
 
-			statefulSetName := types.NamespacedName{
-				Namespace: namespace,
-				Name:      novaMetadataName.Name,
-			}
 			SimulateStatefulSetReplicaReadyWithPods(
-				statefulSetName,
-				map[string][]string{namespace + "/internalapi": {"10.0.0.1"}},
+				novaNames.MetadataStatefulSetName,
+				map[string][]string{novaNames.MetadataName.Namespace + "/internalapi": {"10.0.0.1"}},
 			)
 
 			th.ExpectCondition(
-				novaMetadataName,
+				novaNames.MetadataName,
 				ConditionGetterFunc(NovaMetadataConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionTrue,
 			)
 
 			Eventually(func(g Gomega) {
-				instance := GetNovaMetadata(novaMetadataName)
+				instance := GetNovaMetadata(novaNames.MetadataName)
 				g.Expect(instance.Status.NetworkAttachments).To(
-					Equal(map[string][]string{namespace + "/internalapi": {"10.0.0.1"}}))
+					Equal(map[string][]string{novaNames.MetadataName.Namespace + "/internalapi": {"10.0.0.1"}}))
 
 			}, timeout, interval).Should(Succeed())
 
 			th.ExpectCondition(
-				novaMetadataName,
+				novaNames.MetadataName,
 				ConditionGetterFunc(NovaMetadataConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionTrue,
@@ -458,7 +437,7 @@ var _ = Describe("NovaMetadata controller", func() {
 	When("NovaMetadata is created with externalEndpoints", func() {
 		BeforeEach(func() {
 			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaMetadataSecret(namespace, SecretName))
+				k8sClient.Delete, ctx, CreateNovaMetadataSecret(novaNames.MetadataName.Namespace, SecretName))
 
 			spec := GetDefaultNovaMetadataSpec()
 			var externalEndpoints []interface{}
@@ -471,31 +450,26 @@ var _ = Describe("NovaMetadata controller", func() {
 			)
 			spec["externalEndpoints"] = externalEndpoints
 
-			metadata := CreateNovaMetadata(namespace, spec)
-			novaMetadataName = types.NamespacedName{Name: metadata.GetName(), Namespace: metadata.GetNamespace()}
+			metadata := CreateNovaMetadata(novaNames.MetadataName, spec)
 			DeferCleanup(th.DeleteInstance, metadata)
 		})
 
 		It("creates MetalLB service", func() {
-			statefulSetName := types.NamespacedName{
-				Namespace: namespace,
-				Name:      novaMetadataName.Name,
-			}
-			th.SimulateStatefulSetReplicaReady(statefulSetName)
+			th.SimulateStatefulSetReplicaReady(novaNames.MetadataStatefulSetName)
 
 			// As the internal endpoint is configured in ExternalEndpoints it does not
 			// get a Route but a Service with MetalLB annotations instead
-			service := th.GetService(types.NamespacedName{Namespace: namespace, Name: "nova-metadata-internal"})
+			service := th.GetService(types.NamespacedName{Namespace: novaNames.MetadataName.Namespace, Name: "nova-metadata-internal"})
 			Expect(service.Annotations).To(
 				HaveKeyWithValue("metallb.universe.tf/address-pool", "osp-internalapi"))
 			Expect(service.Annotations).To(
 				HaveKeyWithValue("metallb.universe.tf/allow-shared-ip", "osp-internalapi"))
 			Expect(service.Annotations).To(
 				HaveKeyWithValue("metallb.universe.tf/loadBalancerIPs", "internal-lb-ip-1,internal-lb-ip-2"))
-			th.AssertRouteNotExists(types.NamespacedName{Namespace: namespace, Name: "nova-metadata-internal"})
+			th.AssertRouteNotExists(types.NamespacedName{Namespace: novaNames.MetadataName.Namespace, Name: "nova-metadata-internal"})
 
 			th.ExpectCondition(
-				novaMetadataName,
+				novaNames.MetadataName,
 				ConditionGetterFunc(NovaMetadataConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionTrue,
@@ -503,30 +477,23 @@ var _ = Describe("NovaMetadata controller", func() {
 		})
 	})
 	When("NovaMetadata is reconfigured", func() {
-		var statefulSetName types.NamespacedName
-
 		BeforeEach(func() {
 			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaMetadataSecret(namespace, SecretName))
+				k8sClient.Delete, ctx, CreateNovaMetadataSecret(novaNames.MetadataName.Namespace, SecretName))
 
-			metadata := CreateNovaMetadata(namespace, GetDefaultNovaMetadataSpec())
-			novaMetadataName = types.NamespacedName{Name: metadata.GetName(), Namespace: metadata.GetNamespace()}
+			metadata := CreateNovaMetadata(novaNames.MetadataName, GetDefaultNovaMetadataSpec())
 			DeferCleanup(th.DeleteInstance, metadata)
 
 			th.ExpectCondition(
-				novaMetadataName,
+				novaNames.MetadataName,
 				ConditionGetterFunc(NovaMetadataConditionGetter),
 				condition.ServiceConfigReadyCondition,
 				corev1.ConditionTrue,
 			)
 
-			statefulSetName = types.NamespacedName{
-				Namespace: namespace,
-				Name:      novaMetadataName.Name,
-			}
-			th.SimulateStatefulSetReplicaReady(statefulSetName)
+			th.SimulateStatefulSetReplicaReady(novaNames.MetadataStatefulSetName)
 			th.ExpectCondition(
-				novaMetadataName,
+				novaNames.MetadataName,
 				ConditionGetterFunc(NovaMetadataConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionTrue,
@@ -535,7 +502,7 @@ var _ = Describe("NovaMetadata controller", func() {
 
 		It("applies new NetworkAttachments configuration", func() {
 			Eventually(func(g Gomega) {
-				novaMetadata := GetNovaMetadata(novaMetadataName)
+				novaMetadata := GetNovaMetadata(novaNames.MetadataName)
 				novaMetadata.Spec.NetworkAttachments = append(novaMetadata.Spec.NetworkAttachments, "internalapi")
 
 				err := k8sClient.Update(ctx, novaMetadata)
@@ -543,7 +510,7 @@ var _ = Describe("NovaMetadata controller", func() {
 			}, timeout, interval).Should(Succeed())
 
 			th.ExpectConditionWithDetails(
-				novaMetadataName,
+				novaNames.MetadataName,
 				ConditionGetterFunc(NovaMetadataConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionFalse,
@@ -551,7 +518,7 @@ var _ = Describe("NovaMetadata controller", func() {
 				"NetworkAttachment resources missing: internalapi",
 			)
 			th.ExpectConditionWithDetails(
-				novaMetadataName,
+				novaNames.MetadataName,
 				ConditionGetterFunc(NovaMetadataConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionFalse,
@@ -559,11 +526,11 @@ var _ = Describe("NovaMetadata controller", func() {
 				"NetworkAttachment resources missing: internalapi",
 			)
 
-			internalAPINADName := types.NamespacedName{Namespace: namespace, Name: "internalapi"}
+			internalAPINADName := types.NamespacedName{Namespace: novaNames.MetadataName.Namespace, Name: "internalapi"}
 			DeferCleanup(th.DeleteInstance, th.CreateNetworkAttachmentDefinition(internalAPINADName))
 
 			th.ExpectConditionWithDetails(
-				novaMetadataName,
+				novaNames.MetadataName,
 				ConditionGetterFunc(NovaMetadataConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionFalse,
@@ -572,7 +539,7 @@ var _ = Describe("NovaMetadata controller", func() {
 					"not all pods have interfaces with ips as configured in NetworkAttachments: [internalapi]",
 			)
 			th.ExpectConditionWithDetails(
-				novaMetadataName,
+				novaNames.MetadataName,
 				ConditionGetterFunc(NovaMetadataConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionFalse,
@@ -582,26 +549,26 @@ var _ = Describe("NovaMetadata controller", func() {
 			)
 
 			SimulateStatefulSetReplicaReadyWithPods(
-				statefulSetName,
-				map[string][]string{namespace + "/internalapi": {"10.0.0.1"}},
+				novaNames.MetadataStatefulSetName,
+				map[string][]string{novaNames.MetadataName.Namespace + "/internalapi": {"10.0.0.1"}},
 			)
 
 			th.ExpectCondition(
-				novaMetadataName,
+				novaNames.MetadataName,
 				ConditionGetterFunc(NovaMetadataConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionTrue,
 			)
 
 			Eventually(func(g Gomega) {
-				novaMetadata := GetNovaMetadata(novaMetadataName)
+				novaMetadata := GetNovaMetadata(novaNames.MetadataName)
 				g.Expect(novaMetadata.Status.NetworkAttachments).To(
-					Equal(map[string][]string{namespace + "/internalapi": {"10.0.0.1"}}))
+					Equal(map[string][]string{novaNames.MetadataName.Namespace + "/internalapi": {"10.0.0.1"}}))
 
 			}, timeout, interval).Should(Succeed())
 
 			th.ExpectCondition(
-				novaMetadataName,
+				novaNames.MetadataName,
 				ConditionGetterFunc(NovaMetadataConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionTrue,
@@ -609,12 +576,12 @@ var _ = Describe("NovaMetadata controller", func() {
 		})
 		It("applies new RegisteredCells input to its StatefulSet to trigger Pod restart", func() {
 			originalConfigHash := GetEnvValue(
-				th.GetStatefulSet(statefulSetName).Spec.Template.Spec.Containers[0].Env, "CONFIG_HASH", "")
+				th.GetStatefulSet(novaNames.MetadataStatefulSetName).Spec.Template.Spec.Containers[0].Env, "CONFIG_HASH", "")
 
 			// Simulate that a new cell is added and Nova controller registered it and
 			// therefore a new cell is added to RegisteredCells
 			Eventually(func(g Gomega) {
-				novaMetadata := GetNovaMetadata(novaMetadataName)
+				novaMetadata := GetNovaMetadata(novaNames.MetadataName)
 				novaMetadata.Spec.RegisteredCells = map[string]string{"cell0": "cell0-config-hash"}
 				err := k8sClient.Update(ctx, novaMetadata)
 				g.Expect(err == nil || k8s_errors.IsConflict(err)).To(BeTrue())
@@ -623,7 +590,7 @@ var _ = Describe("NovaMetadata controller", func() {
 			// Assert that the CONFIG_HASH of the StateFulSet is changed due to this reconfiguration
 			Eventually(func(g Gomega) {
 				currentConfigHash := GetEnvValue(
-					th.GetStatefulSet(statefulSetName).Spec.Template.Spec.Containers[0].Env, "CONFIG_HASH", "")
+					th.GetStatefulSet(novaNames.MetadataStatefulSetName).Spec.Template.Spec.Containers[0].Env, "CONFIG_HASH", "")
 				g.Expect(originalConfigHash).NotTo(Equal(currentConfigHash))
 
 			}, timeout, interval).Should(Succeed())
@@ -631,26 +598,20 @@ var _ = Describe("NovaMetadata controller", func() {
 	})
 
 	When("starts zero replicas", func() {
-		var statefulSetName types.NamespacedName
 		BeforeEach(func() {
 			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaMetadataSecret(namespace, SecretName))
+				k8sClient.Delete, ctx, CreateNovaMetadataSecret(novaNames.MetadataName.Namespace, SecretName))
 
 			spec := GetDefaultNovaMetadataSpec()
 			spec["replicas"] = 0
-			metadata := CreateNovaMetadata(namespace, spec)
-			novaMetadataName = types.NamespacedName{Name: metadata.GetName(), Namespace: metadata.GetNamespace()}
-			statefulSetName = types.NamespacedName{
-				Namespace: namespace,
-				Name:      novaMetadataName.Name,
-			}
+			metadata := CreateNovaMetadata(novaNames.MetadataName, spec)
 			DeferCleanup(th.DeleteInstance, metadata)
 		})
 		It("and deployment is Ready", func() {
-			ss := th.GetStatefulSet(statefulSetName)
+			ss := th.GetStatefulSet(novaNames.MetadataStatefulSetName)
 			Expect(int(*ss.Spec.Replicas)).To(Equal(0))
 			th.ExpectCondition(
-				novaMetadataName,
+				novaNames.MetadataName,
 				ConditionGetterFunc(NovaMetadataConditionGetter),
 				condition.DeploymentReadyCondition,
 				corev1.ConditionTrue,

--- a/test/functional/nova_reconfiguration_test.go
+++ b/test/functional/nova_reconfiguration_test.go
@@ -18,7 +18,6 @@ package functional_test
 import (
 	"fmt"
 
-	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/openstack-k8s-operators/lib-common/modules/test/helpers"
@@ -31,58 +30,50 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func CreateNovaWith3CellsAndEnsureReady(namespace string) NovaNames {
-	var novaName types.NamespacedName
-	var novaNames NovaNames
-	var cell0 CellNames
-	var cell1 CellNames
-	var cell2 CellNames
+func CreateNovaWith3CellsAndEnsureReady(novaNames NovaNames) {
+	cell0 := novaNames.Cells["cell0"]
+	cell1 := novaNames.Cells["cell1"]
+	cell2 := novaNames.Cells["cell2"]
 
-	novaName = types.NamespacedName{
-		Namespace: namespace,
-		Name:      uuid.New().String(),
-	}
-	novaNames = GetNovaNames(novaName, []string{"cell0", "cell1", "cell2"})
-	cell0 = novaNames.Cells["cell0"]
-	cell1 = novaNames.Cells["cell1"]
-	cell2 = novaNames.Cells["cell2"]
-
-	DeferCleanup(k8sClient.Delete, ctx, CreateNovaSecret(namespace, SecretName))
+	DeferCleanup(k8sClient.Delete, ctx, CreateNovaSecret(novaNames.NovaName.Namespace, SecretName))
 	DeferCleanup(
 		k8sClient.Delete,
 		ctx,
-		CreateNovaMessageBusSecret(namespace, "mq-for-api-secret"),
+		CreateNovaMessageBusSecret(cell0.CellName.Namespace, fmt.Sprintf("%s-secret", cell0.TransportURLName.Name)),
 	)
 	DeferCleanup(
 		k8sClient.Delete,
 		ctx,
-		CreateNovaMessageBusSecret(namespace, "mq-for-cell1-secret"),
+		CreateNovaMessageBusSecret(cell1.CellName.Namespace, fmt.Sprintf("%s-secret", cell1.TransportURLName.Name)),
 	)
 	DeferCleanup(
 		k8sClient.Delete,
 		ctx,
-		CreateNovaMessageBusSecret(namespace, "mq-for-cell2-secret"),
+		CreateNovaMessageBusSecret(cell2.CellName.Namespace, fmt.Sprintf("%s-secret", cell2.TransportURLName.Name)),
 	)
 
 	serviceSpec := corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 3306}}}
-	DeferCleanup(th.DeleteDBService, th.CreateDBService(namespace, "db-for-api", serviceSpec))
-	DeferCleanup(th.DeleteDBService, th.CreateDBService(namespace, "db-for-cell1", serviceSpec))
-	DeferCleanup(th.DeleteDBService, th.CreateDBService(namespace, "db-for-cell2", serviceSpec))
+	DeferCleanup(
+		th.DeleteDBService,
+		th.CreateDBService(novaNames.APIMariaDBDatabaseName.Namespace, novaNames.APIMariaDBDatabaseName.Name, serviceSpec))
+	DeferCleanup(th.DeleteDBService, th.CreateDBService(cell0.MariaDBDatabaseName.Namespace, cell0.MariaDBDatabaseName.Name, serviceSpec))
+	DeferCleanup(th.DeleteDBService, th.CreateDBService(cell1.MariaDBDatabaseName.Namespace, cell1.MariaDBDatabaseName.Name, serviceSpec))
+	DeferCleanup(th.DeleteDBService, th.CreateDBService(cell2.MariaDBDatabaseName.Namespace, cell2.MariaDBDatabaseName.Name, serviceSpec))
 
 	spec := GetDefaultNovaSpec()
 	cell0Template := GetDefaultNovaCellTemplate()
-	cell0Template["cellDatabaseInstance"] = "db-for-api"
+	cell0Template["cellDatabaseInstance"] = cell0.MariaDBDatabaseName.Name
 	cell0Template["cellDatabaseUser"] = "nova_cell0"
 
 	cell1Template := GetDefaultNovaCellTemplate()
-	cell1Template["cellDatabaseInstance"] = "db-for-cell1"
+	cell1Template["cellDatabaseInstance"] = cell1.MariaDBDatabaseName.Name
 	cell1Template["cellDatabaseUser"] = "nova_cell1"
-	cell1Template["cellMessageBusInstance"] = "mq-for-cell1"
+	cell1Template["cellMessageBusInstance"] = cell1.TransportURLName.Name
 
 	cell2Template := GetDefaultNovaCellTemplate()
-	cell2Template["cellDatabaseInstance"] = "db-for-cell2"
+	cell2Template["cellDatabaseInstance"] = cell2.MariaDBDatabaseName.Name
 	cell2Template["cellDatabaseUser"] = "nova_cell2"
-	cell2Template["cellMessageBusInstance"] = "mq-for-cell2"
+	cell2Template["cellMessageBusInstance"] = cell2.TransportURLName.Name
 	cell2Template["hasAPIAccess"] = false
 
 	spec["cellTemplates"] = map[string]interface{}{
@@ -90,11 +81,11 @@ func CreateNovaWith3CellsAndEnsureReady(namespace string) NovaNames {
 		"cell1": cell1Template,
 		"cell2": cell2Template,
 	}
-	spec["apiDatabaseInstance"] = "db-for-api"
-	spec["apiMessageBusInstance"] = "mq-for-api"
+	spec["apiDatabaseInstance"] = novaNames.APIMariaDBDatabaseName.Name
+	spec["apiMessageBusInstance"] = cell0.TransportURLName.Name
 
-	DeferCleanup(th.DeleteInstance, CreateNova(novaName, spec))
-	keystoneAPIName := th.CreateKeystoneAPI(namespace)
+	DeferCleanup(th.DeleteInstance, CreateNova(novaNames.NovaName, spec))
+	keystoneAPIName := th.CreateKeystoneAPI(novaNames.NovaName.Namespace)
 	DeferCleanup(th.DeleteKeystoneAPI, keystoneAPIName)
 	keystoneAPI := th.GetKeystoneAPI(keystoneAPIName)
 	keystoneAPI.Status.APIEndpoints["internal"] = "http://keystone-internal-openstack.testing"
@@ -103,6 +94,7 @@ func CreateNovaWith3CellsAndEnsureReady(namespace string) NovaNames {
 	}, timeout, interval).Should(Succeed())
 
 	th.SimulateKeystoneServiceReady(novaNames.KeystoneServiceName)
+	// END of common logic with Nova multicell test
 
 	th.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
 	th.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
@@ -127,37 +119,33 @@ func CreateNovaWith3CellsAndEnsureReady(namespace string) NovaNames {
 	th.SimulateJobSuccess(cell2.CellDBSyncJobName)
 	th.SimulateStatefulSetReplicaReady(cell2.ConductorStatefulSetName)
 	th.SimulateJobSuccess(cell2.CellMappingJobName)
-	th.SimulateStatefulSetReplicaReady(novaSchedulerStatefulSetName)
-	th.SimulateStatefulSetReplicaReady(novaMetadataStatefulSetName)
+	th.SimulateStatefulSetReplicaReady(novaNames.SchedulerStatefulSetName)
+	th.SimulateStatefulSetReplicaReady(novaNames.MetadataStatefulSetName)
 	th.ExpectCondition(
-		novaName,
+		novaNames.NovaName,
 		ConditionGetterFunc(NovaConditionGetter),
 		novav1.NovaAllCellsReadyCondition,
 		corev1.ConditionTrue,
 	)
 	th.ExpectCondition(
-		novaName,
+		novaNames.NovaName,
 		ConditionGetterFunc(NovaConditionGetter),
 		condition.ReadyCondition,
 		corev1.ConditionTrue,
 	)
-	return novaNames
 }
 
 var _ = Describe("Nova reconfiguration", func() {
-	var novaNames NovaNames
-
 	BeforeEach(func() {
 		// Uncomment this if you need the full output in the logs from gomega
 		// matchers
 		// format.MaxLength = 0
 
-		novaNames = CreateNovaWith3CellsAndEnsureReady(namespace)
-
+		CreateNovaWith3CellsAndEnsureReady(novaNames)
 	})
 	When("cell0 conductor replicas is set to 0", func() {
 		It("sets the deployment replicas to 0", func() {
-			cell0DeploymentName := novaNames.Cells["cell0"].ConductorStatefulSetName
+			cell0DeploymentName := cell0.ConductorStatefulSetName
 
 			deployment := th.GetStatefulSet(cell0DeploymentName)
 			one := int32(1)
@@ -185,12 +173,10 @@ var _ = Describe("Nova reconfiguration", func() {
 			}, timeout, interval).Should(Succeed())
 		})
 	})
-	When("networkAttachment is added to a conductor while the definition is missing", func() {
+	When("networkAttachemnt is added to a conductor while the definition is missing", func() {
 		It("applies new NetworkAttachments configuration to that Conductor", func() {
-			cell1Names := NewCell(novaName, "cell1")
-
 			Eventually(func(g Gomega) {
-				nova := GetNova(novaName)
+				nova := GetNova(novaNames.NovaName)
 
 				cell1 := nova.Spec.CellTemplates["cell1"]
 				attachments := cell1.ConductorServiceTemplate.NetworkAttachments
@@ -203,7 +189,7 @@ var _ = Describe("Nova reconfiguration", func() {
 			}, timeout, interval).Should(Succeed())
 
 			th.ExpectConditionWithDetails(
-				cell1Names.CellConductorName,
+				cell1.CellConductorName,
 				ConditionGetterFunc(NovaConductorConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionFalse,
@@ -211,7 +197,7 @@ var _ = Describe("Nova reconfiguration", func() {
 				"NetworkAttachment resources missing: internalapi",
 			)
 			th.ExpectConditionWithDetails(
-				cell1Names.CellConductorName,
+				cell1.CellConductorName,
 				ConditionGetterFunc(NovaConductorConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionFalse,
@@ -220,7 +206,7 @@ var _ = Describe("Nova reconfiguration", func() {
 			)
 
 			th.ExpectConditionWithDetails(
-				cell1Names.CellName,
+				cell1.CellName,
 				ConditionGetterFunc(NovaCellConditionGetter),
 				novav1.NovaConductorReadyCondition,
 				corev1.ConditionFalse,
@@ -228,7 +214,7 @@ var _ = Describe("Nova reconfiguration", func() {
 				"NetworkAttachment resources missing: internalapi",
 			)
 			th.ExpectConditionWithDetails(
-				cell1Names.CellName,
+				cell1.CellName,
 				ConditionGetterFunc(NovaCellConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionFalse,
@@ -237,7 +223,7 @@ var _ = Describe("Nova reconfiguration", func() {
 			)
 
 			th.ExpectConditionWithDetails(
-				novaName,
+				novaNames.NovaName,
 				ConditionGetterFunc(NovaConditionGetter),
 				novav1.NovaAllCellsReadyCondition,
 				corev1.ConditionFalse,
@@ -245,7 +231,7 @@ var _ = Describe("Nova reconfiguration", func() {
 				"NovaCell cell1 is not Ready",
 			)
 			th.ExpectConditionWithDetails(
-				novaName,
+				novaNames.NovaName,
 				ConditionGetterFunc(NovaConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionFalse,
@@ -253,11 +239,11 @@ var _ = Describe("Nova reconfiguration", func() {
 				"NovaCell cell1 is not Ready",
 			)
 
-			internalAPINADName := types.NamespacedName{Namespace: namespace, Name: "internalapi"}
+			internalAPINADName := types.NamespacedName{Namespace: novaNames.NovaName.Namespace, Name: "internalapi"}
 			DeferCleanup(th.DeleteInstance, th.CreateNetworkAttachmentDefinition(internalAPINADName))
 
 			th.ExpectConditionWithDetails(
-				novaName,
+				novaNames.NovaName,
 				ConditionGetterFunc(NovaConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionFalse,
@@ -266,12 +252,12 @@ var _ = Describe("Nova reconfiguration", func() {
 			)
 
 			SimulateStatefulSetReplicaReadyWithPods(
-				cell1Names.ConductorStatefulSetName,
-				map[string][]string{namespace + "/internalapi": {"10.0.0.1"}},
+				cell1.ConductorStatefulSetName,
+				map[string][]string{novaNames.NovaName.Namespace + "/internalapi": {"10.0.0.1"}},
 			)
 
 			th.ExpectCondition(
-				novaName,
+				novaNames.NovaName,
 				ConditionGetterFunc(NovaConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionTrue,
@@ -285,7 +271,7 @@ var _ = Describe("Nova reconfiguration", func() {
 			// return a Conflict and then we have to retry by re-reading Nova,
 			// and updating it again.
 			Eventually(func(g Gomega) {
-				nova := GetNova(novaName)
+				nova := GetNova(novaNames.NovaName)
 
 				newSelector := map[string]string{"foo": "bar"}
 				nova.Spec.NodeSelector = newSelector
@@ -301,7 +287,7 @@ var _ = Describe("Nova reconfiguration", func() {
 
 			// Now reset it back to empty and see that it is propagates too
 			Eventually(func(g Gomega) {
-				nova := GetNova(novaName)
+				nova := GetNova(novaNames.NovaName)
 
 				newSelector := map[string]string{}
 				nova.Spec.NodeSelector = newSelector
@@ -316,31 +302,22 @@ var _ = Describe("Nova reconfiguration", func() {
 		},
 			Entry("the nova api pods",
 				func() types.NamespacedName {
-					return types.NamespacedName{
-						Namespace: namespace,
-						Name:      novaName.Name + "-api",
-					}
+					return novaNames.APIName
 				}),
 			Entry("the nova scheduler pods", func() types.NamespacedName {
-				return types.NamespacedName{
-					Namespace: namespace,
-					Name:      novaName.Name + "-scheduler",
-				}
+				return novaNames.SchedulerName
 			}),
 			Entry("the nova metadata pods", func() types.NamespacedName {
-				return types.NamespacedName{
-					Namespace: namespace,
-					Name:      novaName.Name + "-metadata",
-				}
+				return novaNames.MetadataName
 			}),
 			Entry("the nova cell0 conductor", func() types.NamespacedName {
-				return NewCell(novaName, "cell0").ConductorStatefulSetName
+				return cell0.ConductorStatefulSetName
 			}),
 			Entry("the nova cell1 conductor", func() types.NamespacedName {
-				return NewCell(novaName, "cell1").ConductorStatefulSetName
+				return cell1.ConductorStatefulSetName
 			}),
 			Entry("the nova cell2 conductor", func() types.NamespacedName {
-				return NewCell(novaName, "cell2").ConductorStatefulSetName
+				return cell2.ConductorStatefulSetName
 			}),
 		)
 
@@ -348,22 +325,10 @@ var _ = Describe("Nova reconfiguration", func() {
 			serviceSelector := map[string]string{"foo": "api"}
 			conductorSelector := map[string]string{"foo": "conductor"}
 			globalSelector := map[string]string{"foo": "global"}
-			novaAPIdeploymentName := types.NamespacedName{
-				Namespace: namespace,
-				Name:      novaName.Name + "-api",
-			}
-			novaSchedulerDeploymentName := types.NamespacedName{
-				Namespace: namespace,
-				Name:      novaName.Name + "-scheduler",
-			}
-			novaMetadataDeploymentName := types.NamespacedName{
-				Namespace: namespace,
-				Name:      novaName.Name + "-metadata",
-			}
 
 			// Set the service specific NodeSelector first
 			Eventually(func(g Gomega) {
-				nova := GetNova(novaName)
+				nova := GetNova(novaNames.NovaName)
 
 				nova.Spec.APIServiceTemplate.NodeSelector = serviceSelector
 				nova.Spec.MetadataServiceTemplate.NodeSelector = serviceSelector
@@ -376,58 +341,58 @@ var _ = Describe("Nova reconfiguration", func() {
 				err := k8sClient.Update(ctx, nova)
 				g.Expect(err == nil || k8s_errors.IsConflict(err)).To(BeTrue())
 
-				apiDeployment := th.GetStatefulSet(novaAPIdeploymentName)
+				apiDeployment := th.GetStatefulSet(novaNames.APIDeploymentName)
 				g.Expect(apiDeployment.Spec.Template.Spec.NodeSelector).To(Equal(serviceSelector))
-				schedulerDeployment := th.GetStatefulSet(novaSchedulerDeploymentName)
+				schedulerDeployment := th.GetStatefulSet(novaNames.SchedulerStatefulSetName)
 				g.Expect(schedulerDeployment.Spec.Template.Spec.NodeSelector).To(Equal(serviceSelector))
-				metadataDeployment := th.GetStatefulSet(novaMetadataDeploymentName)
+				metadataDeployment := th.GetStatefulSet(novaNames.MetadataStatefulSetName)
 				g.Expect(metadataDeployment.Spec.Template.Spec.NodeSelector).To(Equal(serviceSelector))
 
-				for _, cell := range []string{"cell0", "cell1", "cell2"} {
-					conductorDeploymentName := NewCell(novaName, cell).ConductorStatefulSetName
-					conductorDeployment := th.GetStatefulSet(conductorDeploymentName)
-					g.Expect(conductorDeployment.Spec.Template.Spec.NodeSelector).To(Equal(conductorSelector))
-				}
-
+				conductorDeployment := th.GetStatefulSet(cell0.ConductorStatefulSetName)
+				g.Expect(conductorDeployment.Spec.Template.Spec.NodeSelector).To(Equal(conductorSelector))
+				conductorDeployment = th.GetStatefulSet(cell1.ConductorStatefulSetName)
+				g.Expect(conductorDeployment.Spec.Template.Spec.NodeSelector).To(Equal(conductorSelector))
+				conductorDeployment = th.GetStatefulSet(cell2.ConductorStatefulSetName)
+				g.Expect(conductorDeployment.Spec.Template.Spec.NodeSelector).To(Equal(conductorSelector))
 			}, timeout, interval).Should(Succeed())
 
 			// Set the global NodeSelector and assert that it is propagated
 			// except to the NovaService's
 			Eventually(func(g Gomega) {
-				nova := GetNova(novaName)
+				nova := GetNova(novaNames.NovaName)
 				nova.Spec.NodeSelector = globalSelector
 
 				err := k8sClient.Update(ctx, nova)
 				g.Expect(err == nil || k8s_errors.IsConflict(err)).To(BeTrue())
 
 				// NovaService's deployment keeps it own selector
-				apiDeployment := th.GetStatefulSet(novaAPIdeploymentName)
+				apiDeployment := th.GetStatefulSet(novaNames.APIDeploymentName)
 				g.Expect(apiDeployment.Spec.Template.Spec.NodeSelector).To(Equal(serviceSelector))
-				schedulerDeployment := th.GetStatefulSet(novaSchedulerDeploymentName)
+				schedulerDeployment := th.GetStatefulSet(novaNames.SchedulerStatefulSetName)
 				g.Expect(schedulerDeployment.Spec.Template.Spec.NodeSelector).To(Equal(serviceSelector))
-				metadataDeployment := th.GetStatefulSet(novaMetadataDeploymentName)
+				metadataDeployment := th.GetStatefulSet(novaNames.MetadataStatefulSetName)
 				g.Expect(metadataDeployment.Spec.Template.Spec.NodeSelector).To(Equal(serviceSelector))
 
 				// and cell conductors keep their own selector
-				for _, cell := range []string{"cell0", "cell1", "cell2"} {
-					conductorDeploymentName := NewCell(novaName, cell).ConductorStatefulSetName
-					conductorDeployment := th.GetStatefulSet(conductorDeploymentName)
-					g.Expect(conductorDeployment.Spec.Template.Spec.NodeSelector).To(Equal(conductorSelector))
-				}
+				conductorDeployment := th.GetStatefulSet(cell0.ConductorStatefulSetName)
+				g.Expect(conductorDeployment.Spec.Template.Spec.NodeSelector).To(Equal(conductorSelector))
+				conductorDeployment = th.GetStatefulSet(cell1.ConductorStatefulSetName)
+				g.Expect(conductorDeployment.Spec.Template.Spec.NodeSelector).To(Equal(conductorSelector))
+				conductorDeployment = th.GetStatefulSet(cell2.ConductorStatefulSetName)
+				g.Expect(conductorDeployment.Spec.Template.Spec.NodeSelector).To(Equal(conductorSelector))
 			}, timeout, interval).Should(Succeed())
 		})
 	})
 	When("CellMessageBusInstance is reconfigured for a cell", func() {
 		It("re-runs the cell mapping job and updates the cell hash", func() {
-			cell1Names := NewCell(novaName, "cell1")
-			mappingJob := th.GetJob(cell1Names.CellMappingJobName)
+			mappingJob := th.GetJob(cell1.CellMappingJobName)
 			oldJobInputHash := GetEnvValue(
 				mappingJob.Spec.Template.Spec.Containers[0].Env, "INPUT_HASH", "")
 
-			oldCell1Hash := GetNova(novaName).Status.RegisteredCells[cell1Names.CellName.Name]
+			oldCell1Hash := GetNova(novaNames.NovaName).Status.RegisteredCells[cell1.CellName.Name]
 
 			Eventually(func(g Gomega) {
-				nova := GetNova(novaName)
+				nova := GetNova(novaNames.NovaName)
 
 				cell1 := nova.Spec.CellTemplates["cell1"]
 				cell1.CellMessageBusInstance = "alternate-mq-for-cell1"
@@ -442,24 +407,24 @@ var _ = Describe("Nova reconfiguration", func() {
 			DeferCleanup(
 				k8sClient.Delete,
 				ctx,
-				CreateNovaMessageBusSecret(namespace, "alternate-mq-for-cell1-secret"),
+				CreateNovaMessageBusSecret(cell1.CellName.Namespace, "alternate-mq-for-cell1-secret"),
 			)
 
 			// Expect that nova controller updates the TransportURL to point to
 			// the new rabbit cluster
 			Eventually(func(g Gomega) {
-				transport := th.GetTransportURL(cell1Names.TransportURLName)
+				transport := th.GetTransportURL(cell1.TransportURLName)
 				g.Expect(transport.Spec.RabbitmqClusterName).To(Equal("alternate-mq-for-cell1"))
 			}, timeout, interval).Should(Succeed())
 
-			th.SimulateTransportURLReady(cell1Names.TransportURLName)
+			th.SimulateTransportURLReady(cell1.TransportURLName)
 
 			// Expect that the NovaConductor config is updated with the new transport URL
 			Eventually(func(g Gomega) {
 				configDataMap := th.GetConfigMap(
 					types.NamespacedName{
-						Namespace: namespace,
-						Name:      fmt.Sprintf("%s-config-data", cell1Names.CellConductorName.Name),
+						Namespace: cell1.CellName.Namespace,
+						Name:      fmt.Sprintf("%s-config-data", cell1.CellConductorName.Name),
 					},
 				)
 				g.Expect(configDataMap).ShouldNot(BeNil())
@@ -471,17 +436,17 @@ var _ = Describe("Nova reconfiguration", func() {
 			// Expect that nova controller updates the mapping Job to re-run that
 			// to update the CellMapping table in the nova_api DB.
 			Eventually(func(g Gomega) {
-				mappingJob := th.GetJob(cell1Names.CellMappingJobName)
+				mappingJob := th.GetJob(cell1.CellMappingJobName)
 				newJobInputHash := GetEnvValue(
 					mappingJob.Spec.Template.Spec.Containers[0].Env, "INPUT_HASH", "")
 				g.Expect(newJobInputHash).NotTo(Equal(oldJobInputHash))
 			}, timeout, interval).Should(Succeed())
 
-			th.SimulateJobSuccess(cell1Names.CellMappingJobName)
+			th.SimulateJobSuccess(cell1.CellMappingJobName)
 
 			// Expect that the new config results in a new cell1 hash
 			Eventually(func(g Gomega) {
-				newCell1Hash := GetNova(novaName).Status.RegisteredCells[cell1Names.CellName.Name]
+				newCell1Hash := GetNova(novaNames.NovaName).Status.RegisteredCells[cell1.CellName.Name]
 				g.Expect(newCell1Hash).NotTo(Equal(oldCell1Hash))
 			}, timeout, interval).Should(Succeed())
 		})

--- a/test/functional/nova_scheduler_test.go
+++ b/test/functional/nova_scheduler_test.go
@@ -30,26 +30,22 @@ import (
 )
 
 var _ = Describe("NovaScheduler controller", func() {
-	var novaSchedulerName types.NamespacedName
-
 	BeforeEach(func() {
 		// Uncomment this if you need the full output in the logs from gomega
 		// matchers
 		// format.MaxLength = 0
 		DeferCleanup(
-			k8sClient.Delete, ctx, CreateNovaMessageBusSecret(namespace, MessageBusSecretName))
+			k8sClient.Delete, ctx, CreateNovaMessageBusSecret(novaNames.SchedulerName.Namespace, MessageBusSecretName))
+
 		spec := GetDefaultNovaSchedulerSpec()
 		spec["customServiceConfig"] = "foo=bar"
-		instance := CreateNovaScheduler(namespace, spec)
-		novaSchedulerName = types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
-		DeferCleanup(th.DeleteInstance, instance)
-
+		DeferCleanup(th.DeleteInstance, CreateNovaScheduler(novaNames.SchedulerName, spec))
 	})
 
 	When("a NovaScheduler CR is created pointing to a non existent Secret", func() {
 		It("is not Ready", func() {
 			th.ExpectCondition(
-				novaSchedulerName,
+				novaNames.SchedulerName,
 				ConditionGetterFunc(NovaSchedulerConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionFalse,
@@ -57,7 +53,7 @@ var _ = Describe("NovaScheduler controller", func() {
 		})
 
 		It("has empty Status fields", func() {
-			instance := GetNovaScheduler(novaSchedulerName)
+			instance := GetNovaScheduler(novaNames.SchedulerName)
 			// NOTE(gibi): Hash and Endpoints have `omitempty` tags so while
 			// they are initialized to {} that value is omitted from the output
 			// when sent to the client. So we see nils here.
@@ -67,7 +63,7 @@ var _ = Describe("NovaScheduler controller", func() {
 
 		It("is missing the secret", func() {
 			th.ExpectCondition(
-				novaSchedulerName,
+				novaNames.SchedulerName,
 				ConditionGetterFunc(NovaSchedulerConditionGetter),
 				condition.InputReadyCondition,
 				corev1.ConditionFalse,
@@ -81,7 +77,7 @@ var _ = Describe("NovaScheduler controller", func() {
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "not-relevant-secret",
-					Namespace: namespace,
+					Namespace: novaNames.SchedulerName.Namespace,
 				},
 			}
 			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
@@ -90,7 +86,7 @@ var _ = Describe("NovaScheduler controller", func() {
 
 		It("is not Ready", func() {
 			th.ExpectCondition(
-				novaSchedulerName,
+				novaNames.SchedulerName,
 				ConditionGetterFunc(NovaSchedulerConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionFalse,
@@ -99,7 +95,7 @@ var _ = Describe("NovaScheduler controller", func() {
 
 		It("is missing the secret", func() {
 			th.ExpectCondition(
-				novaSchedulerName,
+				novaNames.SchedulerName,
 				ConditionGetterFunc(NovaSchedulerConditionGetter),
 				condition.InputReadyCondition,
 				corev1.ConditionFalse,
@@ -113,7 +109,7 @@ var _ = Describe("NovaScheduler controller", func() {
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      SecretName,
-					Namespace: namespace,
+					Namespace: novaNames.SchedulerName.Namespace,
 				},
 				Data: map[string][]byte{
 					"NovaPassword": []byte("12345678"),
@@ -125,7 +121,7 @@ var _ = Describe("NovaScheduler controller", func() {
 
 		It("is not Ready", func() {
 			th.ExpectCondition(
-				novaSchedulerName,
+				novaNames.SchedulerName,
 				ConditionGetterFunc(NovaSchedulerConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionFalse,
@@ -134,7 +130,7 @@ var _ = Describe("NovaScheduler controller", func() {
 
 		It("reports that the inputs are not ready", func() {
 			th.ExpectCondition(
-				novaSchedulerName,
+				novaNames.SchedulerName,
 				ConditionGetterFunc(NovaSchedulerConditionGetter),
 				condition.InputReadyCondition,
 				corev1.ConditionFalse,
@@ -145,12 +141,12 @@ var _ = Describe("NovaScheduler controller", func() {
 	When("the Secret is created with all the expected fields", func() {
 		BeforeEach(func() {
 			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaAPISecret(namespace, SecretName))
+				k8sClient.Delete, ctx, CreateNovaAPISecret(novaNames.SchedulerName.Namespace, SecretName))
 		})
 
 		It("reports that input is ready", func() {
 			th.ExpectCondition(
-				novaSchedulerName,
+				novaNames.SchedulerName,
 				ConditionGetterFunc(NovaSchedulerConditionGetter),
 				condition.InputReadyCondition,
 				corev1.ConditionTrue,
@@ -161,7 +157,7 @@ var _ = Describe("NovaScheduler controller", func() {
 			// NOTE(gibi): NovaScheduler has no external dependency right now to
 			// generate the configs.
 			th.ExpectCondition(
-				novaSchedulerName,
+				novaNames.SchedulerName,
 				ConditionGetterFunc(NovaSchedulerConditionGetter),
 				condition.ServiceConfigReadyCondition,
 				corev1.ConditionTrue,
@@ -169,8 +165,8 @@ var _ = Describe("NovaScheduler controller", func() {
 
 			configDataMap := th.GetConfigMap(
 				types.NamespacedName{
-					Namespace: namespace,
-					Name:      fmt.Sprintf("%s-config-data", novaSchedulerName.Name),
+					Namespace: novaNames.SchedulerName.Namespace,
+					Name:      fmt.Sprintf("%s-config-data", novaNames.SchedulerName.Name),
 				},
 			)
 			Expect(configDataMap).ShouldNot(BeNil())
@@ -184,7 +180,7 @@ var _ = Describe("NovaScheduler controller", func() {
 
 		It("stored the input hash in the Status", func() {
 			Eventually(func(g Gomega) {
-				novaScheduler := GetNovaScheduler(novaSchedulerName)
+				novaScheduler := GetNovaScheduler(novaNames.SchedulerName)
 				g.Expect(novaScheduler.Status.Hash).Should(HaveKeyWithValue("input", Not(BeEmpty())))
 			}, timeout, interval).Should(Succeed())
 
@@ -194,39 +190,34 @@ var _ = Describe("NovaScheduler controller", func() {
 	When("the NovaScheduler is deleted", func() {
 		BeforeEach(func() {
 			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaAPISecret(namespace, SecretName))
+				k8sClient.Delete, ctx, CreateNovaAPISecret(novaNames.SchedulerName.Namespace, SecretName))
 		})
 		It("deletes the generated ConfigMaps", func() {
 			th.ExpectCondition(
-				novaSchedulerName,
+				novaNames.SchedulerName,
 				ConditionGetterFunc(NovaSchedulerConditionGetter),
 				condition.ServiceConfigReadyCondition,
 				corev1.ConditionTrue,
 			)
 
-			th.DeleteInstance(GetNovaScheduler(novaSchedulerName))
+			th.DeleteInstance(GetNovaScheduler(novaNames.SchedulerName))
 
 			Eventually(func() []corev1.ConfigMap {
-				return th.ListConfigMaps(novaSchedulerName.Name).Items
+				return th.ListConfigMaps(novaNames.SchedulerName.Name).Items
 			}, timeout, interval).Should(BeEmpty())
 		})
 	})
 
 	When("the NovaScheduler is created with a proper Secret", func() {
-		var statefulSetName types.NamespacedName
 
 		BeforeEach(func() {
 			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaAPISecret(namespace, SecretName))
-			statefulSetName = types.NamespacedName{
-				Namespace: namespace,
-				Name:      novaSchedulerName.Name,
-			}
+				k8sClient.Delete, ctx, CreateNovaAPISecret(novaNames.SchedulerName.Namespace, SecretName))
 		})
 
 		It(" reports input ready", func() {
 			th.ExpectCondition(
-				novaSchedulerName,
+				novaNames.SchedulerName,
 				ConditionGetterFunc(NovaSchedulerConditionGetter),
 				condition.InputReadyCondition,
 				corev1.ConditionTrue,
@@ -235,7 +226,7 @@ var _ = Describe("NovaScheduler controller", func() {
 
 		It("creates a StatefulSet for the nova-scheduler service", func() {
 			th.ExpectConditionWithDetails(
-				novaSchedulerName,
+				novaNames.SchedulerName,
 				ConditionGetterFunc(NovaSchedulerConditionGetter),
 				condition.DeploymentReadyCondition,
 				corev1.ConditionFalse,
@@ -243,7 +234,7 @@ var _ = Describe("NovaScheduler controller", func() {
 				condition.DeploymentReadyRunningMessage,
 			)
 
-			ss := th.GetStatefulSet(statefulSetName)
+			ss := th.GetStatefulSet(novaNames.SchedulerStatefulSetName)
 			Expect(int(*ss.Spec.Replicas)).To(Equal(1))
 			Expect(ss.Spec.Template.Spec.Volumes).To(HaveLen(1))
 			Expect(ss.Spec.Template.Spec.Containers).To(HaveLen(1))
@@ -256,33 +247,33 @@ var _ = Describe("NovaScheduler controller", func() {
 		When("the StatefulSet has at least one Replica ready", func() {
 			BeforeEach(func() {
 				th.ExpectConditionWithDetails(
-					novaSchedulerName,
+					novaNames.SchedulerName,
 					ConditionGetterFunc(NovaSchedulerConditionGetter),
 					condition.DeploymentReadyCondition,
 					corev1.ConditionFalse,
 					condition.RequestedReason,
 					condition.DeploymentReadyRunningMessage,
 				)
-				th.SimulateStatefulSetReplicaReady(statefulSetName)
+				th.SimulateStatefulSetReplicaReady(novaNames.SchedulerStatefulSetName)
 			})
 
 			It("reports that the StatefulSet is ready", func() {
 				th.ExpectCondition(
-					novaSchedulerName,
+					novaNames.SchedulerName,
 					ConditionGetterFunc(NovaSchedulerConditionGetter),
 					condition.DeploymentReadyCondition,
 					corev1.ConditionTrue,
 				)
 
-				novaScheduler := GetNovaScheduler(novaSchedulerName)
+				novaScheduler := GetNovaScheduler(novaNames.SchedulerName)
 				Expect(novaScheduler.Status.ReadyCount).To(BeNumerically(">", 0))
 			})
 		})
 
 		It("is Ready", func() {
-			th.SimulateStatefulSetReplicaReady(statefulSetName)
+			th.SimulateStatefulSetReplicaReady(novaNames.SchedulerStatefulSetName)
 			th.ExpectCondition(
-				novaSchedulerName,
+				novaNames.SchedulerName,
 				ConditionGetterFunc(NovaSchedulerConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionTrue,
@@ -292,27 +283,24 @@ var _ = Describe("NovaScheduler controller", func() {
 })
 
 var _ = Describe("NovaScheduler controller", func() {
-	var novaSchedulerName types.NamespacedName
 	BeforeEach(func() {
 		DeferCleanup(
-			k8sClient.Delete, ctx, CreateNovaMessageBusSecret(namespace, MessageBusSecretName))
+			k8sClient.Delete, ctx, CreateNovaMessageBusSecret(novaNames.SchedulerName.Namespace, MessageBusSecretName))
 	})
 
 	When("NovaScheduler is created with networkAttachments", func() {
 		BeforeEach(func() {
 			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaAPISecret(namespace, SecretName))
+				k8sClient.Delete, ctx, CreateNovaAPISecret(novaNames.SchedulerName.Namespace, SecretName))
 
 			spec := GetDefaultNovaSchedulerSpec()
 			spec["networkAttachments"] = []string{"internalapi"}
-			instance := CreateNovaScheduler(namespace, spec)
-			novaSchedulerName = types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
-			DeferCleanup(th.DeleteInstance, instance)
+			DeferCleanup(th.DeleteInstance, CreateNovaScheduler(novaNames.SchedulerName, spec))
 		})
 
 		It("reports that the definition is missing", func() {
 			th.ExpectConditionWithDetails(
-				novaSchedulerName,
+				novaNames.SchedulerName,
 				ConditionGetterFunc(NovaSchedulerConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionFalse,
@@ -320,28 +308,24 @@ var _ = Describe("NovaScheduler controller", func() {
 				"NetworkAttachment resources missing: internalapi",
 			)
 			th.ExpectCondition(
-				novaSchedulerName,
+				novaNames.SchedulerName,
 				ConditionGetterFunc(NovaSchedulerConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionFalse,
 			)
 		})
 		It("reports that network attachment is missing", func() {
-			internalAPINADName := types.NamespacedName{Namespace: namespace, Name: "internalapi"}
+			internalAPINADName := types.NamespacedName{Namespace: novaNames.SchedulerName.Namespace, Name: "internalapi"}
 			nad := th.CreateNetworkAttachmentDefinition(internalAPINADName)
 			DeferCleanup(th.DeleteInstance, nad)
 
-			statefulSetName := types.NamespacedName{
-				Namespace: namespace,
-				Name:      novaSchedulerName.Name,
-			}
-			ss := th.GetStatefulSet(statefulSetName)
+			ss := th.GetStatefulSet(novaNames.SchedulerStatefulSetName)
 
 			expectedAnnotation, err := json.Marshal(
 				[]networkv1.NetworkSelectionElement{
 					{
 						Name:             "internalapi",
-						Namespace:        namespace,
+						Namespace:        novaNames.SchedulerName.Namespace,
 						InterfaceRequest: "internalapi",
 					}})
 			Expect(err).ShouldNot(HaveOccurred())
@@ -351,10 +335,10 @@ var _ = Describe("NovaScheduler controller", func() {
 
 			// We don't add network attachment status annotations to the Pods
 			// to simulate that the network attachments are missing.
-			SimulateStatefulSetReplicaReadyWithPods(statefulSetName, map[string][]string{})
+			SimulateStatefulSetReplicaReadyWithPods(novaNames.SchedulerStatefulSetName, map[string][]string{})
 
 			th.ExpectConditionWithDetails(
-				novaSchedulerName,
+				novaNames.SchedulerName,
 				ConditionGetterFunc(NovaSchedulerConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionFalse,
@@ -364,21 +348,17 @@ var _ = Describe("NovaScheduler controller", func() {
 			)
 		})
 		It("reports that an IP is missing", func() {
-			internalAPINADName := types.NamespacedName{Namespace: namespace, Name: "internalapi"}
+			internalAPINADName := types.NamespacedName{Namespace: novaNames.SchedulerName.Namespace, Name: "internalapi"}
 			nad := th.CreateNetworkAttachmentDefinition(internalAPINADName)
 			DeferCleanup(th.DeleteInstance, nad)
 
-			statefulSetName := types.NamespacedName{
-				Namespace: namespace,
-				Name:      novaSchedulerName.Name,
-			}
-			ss := th.GetStatefulSet(statefulSetName)
+			ss := th.GetStatefulSet(novaNames.SchedulerStatefulSetName)
 
 			expectedAnnotation, err := json.Marshal(
 				[]networkv1.NetworkSelectionElement{
 					{
 						Name:             "internalapi",
-						Namespace:        namespace,
+						Namespace:        novaNames.SchedulerName.Namespace,
 						InterfaceRequest: "internalapi",
 					}})
 			Expect(err).ShouldNot(HaveOccurred())
@@ -389,12 +369,12 @@ var _ = Describe("NovaScheduler controller", func() {
 			// We simulate that there is no IP associated with the internalapi
 			// network attachment
 			SimulateStatefulSetReplicaReadyWithPods(
-				statefulSetName,
-				map[string][]string{namespace + "/internalapi": {}},
+				novaNames.SchedulerStatefulSetName,
+				map[string][]string{novaNames.SchedulerName.Namespace + "/internalapi": {}},
 			)
 
 			th.ExpectConditionWithDetails(
-				novaSchedulerName,
+				novaNames.SchedulerName,
 				ConditionGetterFunc(NovaSchedulerConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionFalse,
@@ -404,34 +384,30 @@ var _ = Describe("NovaScheduler controller", func() {
 			)
 		})
 		It("reports NetworkAttachmentsReady if the Pods got the proper annotations", func() {
-			internalAPINADName := types.NamespacedName{Namespace: namespace, Name: "internalapi"}
+			internalAPINADName := types.NamespacedName{Namespace: novaNames.SchedulerName.Namespace, Name: "internalapi"}
 			nad := th.CreateNetworkAttachmentDefinition(internalAPINADName)
 			DeferCleanup(th.DeleteInstance, nad)
 
-			statefulSetName := types.NamespacedName{
-				Namespace: namespace,
-				Name:      novaSchedulerName.Name,
-			}
 			SimulateStatefulSetReplicaReadyWithPods(
-				statefulSetName,
-				map[string][]string{namespace + "/internalapi": {"10.0.0.1"}},
+				novaNames.SchedulerStatefulSetName,
+				map[string][]string{novaNames.SchedulerName.Namespace + "/internalapi": {"10.0.0.1"}},
 			)
 
 			th.ExpectCondition(
-				novaSchedulerName,
+				novaNames.SchedulerName,
 				ConditionGetterFunc(NovaSchedulerConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionTrue,
 			)
 
 			Eventually(func(g Gomega) {
-				novaScheduler := GetNovaScheduler(novaSchedulerName)
+				novaScheduler := GetNovaScheduler(novaNames.SchedulerName)
 				g.Expect(novaScheduler.Status.NetworkAttachments).To(
-					Equal(map[string][]string{namespace + "/internalapi": {"10.0.0.1"}}))
+					Equal(map[string][]string{novaNames.SchedulerName.Namespace + "/internalapi": {"10.0.0.1"}}))
 			}, timeout, interval).Should(Succeed())
 
 			th.ExpectCondition(
-				novaSchedulerName,
+				novaNames.SchedulerName,
 				ConditionGetterFunc(NovaSchedulerConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionTrue,
@@ -439,30 +415,21 @@ var _ = Describe("NovaScheduler controller", func() {
 		})
 	})
 	When("NovaScheduler is reconfigured", func() {
-		var statefulSetName types.NamespacedName
-
 		BeforeEach(func() {
 			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaAPISecret(namespace, SecretName))
-
-			instance := CreateNovaScheduler(namespace, GetDefaultNovaSchedulerSpec())
-			novaSchedulerName = types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
-			DeferCleanup(th.DeleteInstance, instance)
+				k8sClient.Delete, ctx, CreateNovaAPISecret(novaNames.SchedulerName.Namespace, SecretName))
+			DeferCleanup(th.DeleteInstance, CreateNovaScheduler(novaNames.SchedulerName, GetDefaultNovaSchedulerSpec()))
 
 			th.ExpectCondition(
-				novaSchedulerName,
+				novaNames.SchedulerName,
 				ConditionGetterFunc(NovaSchedulerConditionGetter),
 				condition.ServiceConfigReadyCondition,
 				corev1.ConditionTrue,
 			)
 
-			statefulSetName = types.NamespacedName{
-				Namespace: namespace,
-				Name:      novaSchedulerName.Name,
-			}
-			th.SimulateStatefulSetReplicaReady(statefulSetName)
+			th.SimulateStatefulSetReplicaReady(novaNames.SchedulerStatefulSetName)
 			th.ExpectCondition(
-				novaSchedulerName,
+				novaNames.SchedulerName,
 				ConditionGetterFunc(NovaSchedulerConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionTrue,
@@ -471,7 +438,7 @@ var _ = Describe("NovaScheduler controller", func() {
 
 		It("applies new NetworkAttachments configuration", func() {
 			Eventually(func(g Gomega) {
-				novaScheduler := GetNovaScheduler(novaSchedulerName)
+				novaScheduler := GetNovaScheduler(novaNames.SchedulerName)
 				novaScheduler.Spec.NetworkAttachments = append(novaScheduler.Spec.NetworkAttachments, "internalapi")
 
 				err := k8sClient.Update(ctx, novaScheduler)
@@ -479,7 +446,7 @@ var _ = Describe("NovaScheduler controller", func() {
 			}, timeout, interval).Should(Succeed())
 
 			th.ExpectConditionWithDetails(
-				novaSchedulerName,
+				novaNames.SchedulerName,
 				ConditionGetterFunc(NovaSchedulerConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionFalse,
@@ -488,7 +455,7 @@ var _ = Describe("NovaScheduler controller", func() {
 			)
 
 			th.ExpectConditionWithDetails(
-				novaSchedulerName,
+				novaNames.SchedulerName,
 				ConditionGetterFunc(NovaSchedulerConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionFalse,
@@ -496,11 +463,11 @@ var _ = Describe("NovaScheduler controller", func() {
 				"NetworkAttachment resources missing: internalapi",
 			)
 
-			internalAPINADName := types.NamespacedName{Namespace: namespace, Name: "internalapi"}
+			internalAPINADName := types.NamespacedName{Namespace: novaNames.SchedulerName.Namespace, Name: "internalapi"}
 			DeferCleanup(th.DeleteInstance, th.CreateNetworkAttachmentDefinition(internalAPINADName))
 
 			th.ExpectConditionWithDetails(
-				novaSchedulerName,
+				novaNames.SchedulerName,
 				ConditionGetterFunc(NovaSchedulerConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionFalse,
@@ -510,7 +477,7 @@ var _ = Describe("NovaScheduler controller", func() {
 			)
 
 			th.ExpectConditionWithDetails(
-				novaSchedulerName,
+				novaNames.SchedulerName,
 				ConditionGetterFunc(NovaSchedulerConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionFalse,
@@ -520,26 +487,26 @@ var _ = Describe("NovaScheduler controller", func() {
 			)
 
 			SimulateStatefulSetReplicaReadyWithPods(
-				statefulSetName,
-				map[string][]string{namespace + "/internalapi": {"10.0.0.1"}},
+				novaNames.SchedulerStatefulSetName,
+				map[string][]string{novaNames.SchedulerName.Namespace + "/internalapi": {"10.0.0.1"}},
 			)
 
 			th.ExpectCondition(
-				novaSchedulerName,
+				novaNames.SchedulerName,
 				ConditionGetterFunc(NovaSchedulerConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionTrue,
 			)
 
 			Eventually(func(g Gomega) {
-				novaScheduler := GetNovaScheduler(novaSchedulerName)
+				novaScheduler := GetNovaScheduler(novaNames.SchedulerName)
 				g.Expect(novaScheduler.Status.NetworkAttachments).To(
-					Equal(map[string][]string{namespace + "/internalapi": {"10.0.0.1"}}))
+					Equal(map[string][]string{novaNames.SchedulerName.Namespace + "/internalapi": {"10.0.0.1"}}))
 
 			}, timeout, interval).Should(Succeed())
 
 			th.ExpectCondition(
-				novaSchedulerName,
+				novaNames.SchedulerName,
 				ConditionGetterFunc(NovaSchedulerConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionTrue,
@@ -547,12 +514,12 @@ var _ = Describe("NovaScheduler controller", func() {
 		})
 		It("applies new RegisteredCells input to its StatefulSet to trigger Pod restart", func() {
 			originalConfigHash := GetEnvValue(
-				th.GetStatefulSet(statefulSetName).Spec.Template.Spec.Containers[0].Env, "CONFIG_HASH", "")
+				th.GetStatefulSet(novaNames.SchedulerStatefulSetName).Spec.Template.Spec.Containers[0].Env, "CONFIG_HASH", "")
 
 			// Simulate that a new cell is added and Nova controller registered it and
 			// therefore a new cell is added to RegisteredCells
 			Eventually(func(g Gomega) {
-				novaAPI := GetNovaScheduler(novaSchedulerName)
+				novaAPI := GetNovaScheduler(novaNames.SchedulerName)
 				novaAPI.Spec.RegisteredCells = map[string]string{"cell0": "cell0-config-hash"}
 				err := k8sClient.Update(ctx, novaAPI)
 				g.Expect(err == nil || k8s_errors.IsConflict(err)).To(BeTrue())
@@ -561,7 +528,7 @@ var _ = Describe("NovaScheduler controller", func() {
 			// Assert that the CONFIG_HASH of the StateFulSet is changed due to this reconfiguration
 			Eventually(func(g Gomega) {
 				currentConfigHash := GetEnvValue(
-					th.GetStatefulSet(statefulSetName).Spec.Template.Spec.Containers[0].Env, "CONFIG_HASH", "")
+					th.GetStatefulSet(novaNames.SchedulerStatefulSetName).Spec.Template.Spec.Containers[0].Env, "CONFIG_HASH", "")
 				g.Expect(originalConfigHash).NotTo(Equal(currentConfigHash))
 
 			}, timeout, interval).Should(Succeed())

--- a/test/functional/novaapi_controller_test.go
+++ b/test/functional/novaapi_controller_test.go
@@ -33,22 +33,19 @@ import (
 )
 
 var _ = Describe("NovaAPI controller", func() {
-	var novaAPIName types.NamespacedName
-
 	When("a NovaAPI CR is created pointing to a non existent Secret", func() {
 		BeforeEach(func() {
 			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaMessageBusSecret(namespace, MessageBusSecretName))
+				k8sClient.Delete, ctx, CreateNovaMessageBusSecret(novaNames.APIName.Namespace, MessageBusSecretName))
+
 			spec := GetDefaultNovaAPISpec()
 			spec["customServiceConfig"] = "foo=bar"
-			instance := CreateNovaAPI(namespace, spec)
-			novaAPIName = types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
-			DeferCleanup(th.DeleteInstance, instance)
+			DeferCleanup(th.DeleteInstance, CreateNovaAPI(novaNames.APIName, spec))
 		})
 
 		It("is not Ready", func() {
 			th.ExpectCondition(
-				novaAPIName,
+				novaNames.APIName,
 				ConditionGetterFunc(NovaAPIConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionFalse,
@@ -56,7 +53,7 @@ var _ = Describe("NovaAPI controller", func() {
 		})
 
 		It("has empty Status fields", func() {
-			instance := GetNovaAPI(novaAPIName)
+			instance := GetNovaAPI(novaNames.APIName)
 			// NOTE(gibi): Hash and Endpoints have `omitempty` tags so while
 			// they are initialized to {} that value is omitted from the output
 			// when sent to the client. So we see nils here.
@@ -68,7 +65,7 @@ var _ = Describe("NovaAPI controller", func() {
 
 		It("is missing the secret", func() {
 			th.ExpectConditionWithDetails(
-				novaAPIName,
+				novaNames.APIName,
 				ConditionGetterFunc(NovaAPIConditionGetter),
 				condition.InputReadyCondition,
 				corev1.ConditionFalse,
@@ -82,7 +79,7 @@ var _ = Describe("NovaAPI controller", func() {
 				secret := &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "not-relevant-secret",
-						Namespace: namespace,
+						Namespace: novaNames.APIName.Namespace,
 					},
 				}
 				Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
@@ -91,7 +88,7 @@ var _ = Describe("NovaAPI controller", func() {
 
 			It("is not Ready", func() {
 				th.ExpectCondition(
-					novaAPIName,
+					novaNames.APIName,
 					ConditionGetterFunc(NovaAPIConditionGetter),
 					condition.ReadyCondition,
 					corev1.ConditionFalse,
@@ -100,7 +97,7 @@ var _ = Describe("NovaAPI controller", func() {
 
 			It("is missing the secret", func() {
 				th.ExpectConditionWithDetails(
-					novaAPIName,
+					novaNames.APIName,
 					ConditionGetterFunc(NovaAPIConditionGetter),
 					condition.InputReadyCondition,
 					corev1.ConditionFalse,
@@ -115,7 +112,7 @@ var _ = Describe("NovaAPI controller", func() {
 				secret := &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      SecretName,
-						Namespace: namespace,
+						Namespace: novaNames.APIName.Namespace,
 					},
 					Data: map[string][]byte{
 						"NovaPassword": []byte("12345678"),
@@ -127,7 +124,7 @@ var _ = Describe("NovaAPI controller", func() {
 
 			It("is not Ready", func() {
 				th.ExpectCondition(
-					novaAPIName,
+					novaNames.APIName,
 					ConditionGetterFunc(NovaAPIConditionGetter),
 					condition.ReadyCondition,
 					corev1.ConditionFalse,
@@ -136,7 +133,7 @@ var _ = Describe("NovaAPI controller", func() {
 
 			It("reports that the inputs are not ready", func() {
 				th.ExpectCondition(
-					novaAPIName,
+					novaNames.APIName,
 					ConditionGetterFunc(NovaAPIConditionGetter),
 					condition.InputReadyCondition,
 					corev1.ConditionFalse,
@@ -147,12 +144,12 @@ var _ = Describe("NovaAPI controller", func() {
 		When("the Secret is created with all the expected fields", func() {
 			BeforeEach(func() {
 				DeferCleanup(
-					k8sClient.Delete, ctx, CreateNovaAPISecret(namespace, SecretName))
+					k8sClient.Delete, ctx, CreateNovaAPISecret(novaNames.APIName.Namespace, SecretName))
 			})
 
 			It("reports that input is ready", func() {
 				th.ExpectCondition(
-					novaAPIName,
+					novaNames.APIName,
 					ConditionGetterFunc(NovaAPIConditionGetter),
 					condition.InputReadyCondition,
 					corev1.ConditionTrue,
@@ -163,7 +160,7 @@ var _ = Describe("NovaAPI controller", func() {
 				// NOTE(gibi): NovaAPI has no external dependency right now to
 				// generate the configs.
 				th.ExpectCondition(
-					novaAPIName,
+					novaNames.APIName,
 					ConditionGetterFunc(NovaAPIConditionGetter),
 					condition.ServiceConfigReadyCondition,
 					corev1.ConditionTrue,
@@ -171,8 +168,8 @@ var _ = Describe("NovaAPI controller", func() {
 
 				configDataMap := th.GetConfigMap(
 					types.NamespacedName{
-						Namespace: namespace,
-						Name:      fmt.Sprintf("%s-config-data", novaAPIName.Name),
+						Namespace: novaNames.APIName.Namespace,
+						Name:      fmt.Sprintf("%s-config-data", novaNames.APIName.Name),
 					},
 				)
 				Expect(configDataMap).ShouldNot(BeNil())
@@ -186,7 +183,7 @@ var _ = Describe("NovaAPI controller", func() {
 
 			It("stored the input hash in the Status", func() {
 				Eventually(func(g Gomega) {
-					novaAPI := GetNovaAPI(novaAPIName)
+					novaAPI := GetNovaAPI(novaNames.APIName)
 					g.Expect(novaAPI.Status.Hash).Should(HaveKeyWithValue("input", Not(BeEmpty())))
 				}, timeout, interval).Should(Succeed())
 
@@ -195,16 +192,16 @@ var _ = Describe("NovaAPI controller", func() {
 			When("the NovaAPI is deleted", func() {
 				It("deletes the generated ConfigMaps", func() {
 					th.ExpectCondition(
-						novaAPIName,
+						novaNames.APIName,
 						ConditionGetterFunc(NovaAPIConditionGetter),
 						condition.ServiceConfigReadyCondition,
 						corev1.ConditionTrue,
 					)
 
-					th.DeleteInstance(GetNovaAPI(novaAPIName))
+					th.DeleteInstance(GetNovaAPI(novaNames.APIName))
 
 					Eventually(func() []corev1.ConfigMap {
-						return th.ListConfigMaps(novaAPIName.Name).Items
+						return th.ListConfigMaps(novaNames.APIName.Name).Items
 					}, timeout, interval).Should(BeEmpty())
 				})
 			})
@@ -214,18 +211,15 @@ var _ = Describe("NovaAPI controller", func() {
 	When("NovAPI is created with a proper Secret", func() {
 		BeforeEach(func() {
 			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaAPISecret(namespace, SecretName))
+				k8sClient.Delete, ctx, CreateNovaAPISecret(novaNames.APIName.Namespace, SecretName))
 			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaMessageBusSecret(namespace, MessageBusSecretName))
-
-			instance := CreateNovaAPI(namespace, GetDefaultNovaAPISpec())
-			novaAPIName = types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
-			DeferCleanup(th.DeleteInstance, instance)
+				k8sClient.Delete, ctx, CreateNovaMessageBusSecret(novaNames.APIName.Namespace, MessageBusSecretName))
+			DeferCleanup(th.DeleteInstance, CreateNovaAPI(novaNames.APIName, GetDefaultNovaAPISpec()))
 		})
 
 		It(" reports input ready", func() {
 			th.ExpectCondition(
-				novaAPIName,
+				novaNames.APIName,
 				ConditionGetterFunc(NovaAPIConditionGetter),
 				condition.InputReadyCondition,
 				corev1.ConditionTrue,
@@ -234,34 +228,24 @@ var _ = Describe("NovaAPI controller", func() {
 	})
 
 	When("NovAPI is created", func() {
-		var statefulSetName types.NamespacedName
-
 		BeforeEach(func() {
 			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaAPISecret(namespace, SecretName))
+				k8sClient.Delete, ctx, CreateNovaAPISecret(novaNames.APIName.Namespace, SecretName))
 			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaMessageBusSecret(namespace, MessageBusSecretName))
-
-			instance := CreateNovaAPI(namespace, GetDefaultNovaAPISpec())
-			novaAPIName = types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
-			DeferCleanup(th.DeleteInstance, instance)
+				k8sClient.Delete, ctx, CreateNovaMessageBusSecret(novaNames.APIName.Namespace, MessageBusSecretName))
+			DeferCleanup(th.DeleteInstance, CreateNovaAPI(novaNames.APIName, GetDefaultNovaAPISpec()))
 
 			th.ExpectCondition(
-				novaAPIName,
+				novaNames.APIName,
 				ConditionGetterFunc(NovaAPIConditionGetter),
 				condition.ServiceConfigReadyCondition,
 				corev1.ConditionTrue,
 			)
-
-			statefulSetName = types.NamespacedName{
-				Namespace: namespace,
-				Name:      novaAPIName.Name,
-			}
 		})
 
 		It("creates a StatefulSet for the nova-api service", func() {
 			th.ExpectConditionWithDetails(
-				novaAPIName,
+				novaNames.APIName,
 				ConditionGetterFunc(NovaAPIConditionGetter),
 				condition.DeploymentReadyCondition,
 				corev1.ConditionFalse,
@@ -269,7 +253,7 @@ var _ = Describe("NovaAPI controller", func() {
 				condition.DeploymentReadyRunningMessage,
 			)
 
-			ss := th.GetStatefulSet(statefulSetName)
+			ss := th.GetStatefulSet(novaNames.APIStatefulSetName)
 			Expect(int(*ss.Spec.Replicas)).To(Equal(1))
 			Expect(ss.Spec.Template.Spec.Volumes).To(HaveLen(2))
 			Expect(ss.Spec.Template.Spec.Containers).To(HaveLen(2))
@@ -291,55 +275,55 @@ var _ = Describe("NovaAPI controller", func() {
 		When("the StatefulSet has at least one Replica ready", func() {
 			BeforeEach(func() {
 				th.ExpectConditionWithDetails(
-					novaAPIName,
+					novaNames.APIName,
 					ConditionGetterFunc(NovaAPIConditionGetter),
 					condition.DeploymentReadyCondition,
 					corev1.ConditionFalse,
 					condition.RequestedReason,
 					condition.DeploymentReadyRunningMessage,
 				)
-				th.SimulateStatefulSetReplicaReady(statefulSetName)
+				th.SimulateStatefulSetReplicaReady(novaNames.APIStatefulSetName)
 			})
 
 			It("reports that the StatefulSet is ready", func() {
 				th.ExpectCondition(
-					novaAPIName,
+					novaNames.APIName,
 					ConditionGetterFunc(NovaAPIConditionGetter),
 					condition.DeploymentReadyCondition,
 					corev1.ConditionTrue,
 				)
 
-				novaAPI := GetNovaAPI(novaAPIName)
+				novaAPI := GetNovaAPI(novaNames.APIName)
 				Expect(novaAPI.Status.ReadyCount).To(BeNumerically(">", 0))
 			})
 		})
 
 		It("exposes the service", func() {
-			th.SimulateStatefulSetReplicaReady(statefulSetName)
+			th.SimulateStatefulSetReplicaReady(novaNames.APIStatefulSetName)
 			th.ExpectCondition(
-				novaAPIName,
+				novaNames.APIName,
 				ConditionGetterFunc(NovaAPIConditionGetter),
 				condition.ExposeServiceReadyCondition,
 				corev1.ConditionTrue,
 			)
-			public := th.GetService(types.NamespacedName{Namespace: namespace, Name: "nova-public"})
+			public := th.GetService(types.NamespacedName{Namespace: novaNames.APIName.Namespace, Name: "nova-public"})
 			Expect(public.Labels["service"]).To(Equal("nova-api"))
-			internal := th.GetService(types.NamespacedName{Namespace: namespace, Name: "nova-internal"})
+			internal := th.GetService(types.NamespacedName{Namespace: novaNames.APIName.Namespace, Name: "nova-internal"})
 			Expect(internal.Labels["service"]).To(Equal("nova-api"))
-			th.AssertRouteExists(types.NamespacedName{Namespace: namespace, Name: "nova-public"})
+			th.AssertRouteExists(types.NamespacedName{Namespace: novaNames.APIName.Namespace, Name: "nova-public"})
 		})
 
 		It("creates KeystoneEndpoint", func() {
-			th.SimulateStatefulSetReplicaReady(statefulSetName)
-			th.SimulateKeystoneEndpointReady(types.NamespacedName{Namespace: namespace, Name: "nova"})
+			th.SimulateStatefulSetReplicaReady(novaNames.APIStatefulSetName)
+			th.SimulateKeystoneEndpointReady(types.NamespacedName{Namespace: novaNames.APIName.Namespace, Name: "nova"})
 
-			keystoneEndpoint := th.GetKeystoneEndpoint(types.NamespacedName{Namespace: namespace, Name: "nova"})
+			keystoneEndpoint := th.GetKeystoneEndpoint(types.NamespacedName{Namespace: novaNames.APIName.Namespace, Name: "nova"})
 			endpoints := keystoneEndpoint.Spec.Endpoints
 			Expect(endpoints).To(HaveKeyWithValue("public", "http:/v2.1"))
-			Expect(endpoints).To(HaveKeyWithValue("internal", "http://nova-internal."+namespace+".svc:8774/v2.1"))
+			Expect(endpoints).To(HaveKeyWithValue("internal", "http://nova-internal."+novaNames.APIName.Namespace+".svc:8774/v2.1"))
 
 			th.ExpectCondition(
-				novaAPIName,
+				novaNames.APIName,
 				ConditionGetterFunc(NovaAPIConditionGetter),
 				condition.KeystoneEndpointReadyCondition,
 				corev1.ConditionTrue,
@@ -347,11 +331,11 @@ var _ = Describe("NovaAPI controller", func() {
 		})
 
 		It("is Ready", func() {
-			th.SimulateStatefulSetReplicaReady(statefulSetName)
-			th.SimulateKeystoneEndpointReady(types.NamespacedName{Namespace: namespace, Name: "nova"})
+			th.SimulateStatefulSetReplicaReady(novaNames.APIStatefulSetName)
+			th.SimulateKeystoneEndpointReady(types.NamespacedName{Namespace: novaNames.APIName.Namespace, Name: "nova"})
 
 			th.ExpectCondition(
-				novaAPIName,
+				novaNames.APIName,
 				ConditionGetterFunc(NovaAPIConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionTrue,
@@ -359,56 +343,53 @@ var _ = Describe("NovaAPI controller", func() {
 		})
 	})
 	When("NovaAPI CR instance is deleted", func() {
-		var statefulSetName types.NamespacedName
-		var keystoneEndpointName types.NamespacedName
 		BeforeEach(func() {
 			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaAPISecret(namespace, SecretName))
+				k8sClient.Delete, ctx, CreateNovaAPISecret(novaNames.APIName.Namespace, SecretName))
 			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaMessageBusSecret(namespace, MessageBusSecretName))
-
-			instance := CreateNovaAPI(namespace, GetDefaultNovaAPISpec())
-			novaAPIName = types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
-			DeferCleanup(th.DeleteInstance, instance)
-			statefulSetName = types.NamespacedName{Namespace: namespace, Name: novaAPIName.Name}
-			keystoneEndpointName = types.NamespacedName{Namespace: namespace, Name: "nova"}
+				k8sClient.Delete, ctx, CreateNovaMessageBusSecret(novaNames.APIName.Namespace, MessageBusSecretName))
+			DeferCleanup(th.DeleteInstance, CreateNovaAPI(novaNames.APIName, GetDefaultNovaAPISpec()))
 		})
 
 		It("removes the finalizer from KeystoneEndpoint", func() {
-			th.SimulateStatefulSetReplicaReady(statefulSetName)
-			th.SimulateKeystoneEndpointReady(keystoneEndpointName)
+			th.SimulateStatefulSetReplicaReady(novaNames.APIStatefulSetName)
+			th.SimulateKeystoneEndpointReady(novaNames.APIKeystoneEndpointName)
 			th.ExpectCondition(
-				novaAPIName,
+				novaNames.APIName,
 				ConditionGetterFunc(NovaAPIConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionTrue,
 			)
 
-			endpoint := th.GetKeystoneEndpoint(keystoneEndpointName)
+			endpoint := th.GetKeystoneEndpoint(novaNames.APIKeystoneEndpointName)
 			Expect(endpoint.Finalizers).To(ContainElement("NovaAPI"))
 
-			th.DeleteInstance(GetNovaAPI(novaAPIName))
-			endpoint = th.GetKeystoneEndpoint(keystoneEndpointName)
+			th.DeleteInstance(GetNovaAPI(novaNames.APIName))
+			endpoint = th.GetKeystoneEndpoint(novaNames.APIKeystoneEndpointName)
 			Expect(endpoint.Finalizers).NotTo(ContainElement("NovaAPI"))
 		})
 	})
+})
+
+var _ = Describe("NovaAPI controller", func() {
+	BeforeEach(func() {
+		DeferCleanup(
+			k8sClient.Delete, ctx, CreateNovaMessageBusSecret(novaNames.APIName.Namespace, MessageBusSecretName))
+	})
+
 	When("NovaAPI is created with networkAttachments", func() {
 		BeforeEach(func() {
 			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaAPISecret(namespace, SecretName))
-			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaMessageBusSecret(namespace, MessageBusSecretName))
+				k8sClient.Delete, ctx, CreateNovaAPISecret(novaNames.APIName.Namespace, SecretName))
 
 			spec := GetDefaultNovaAPISpec()
 			spec["networkAttachments"] = []string{"internalapi"}
-			instance := CreateNovaAPI(namespace, spec)
-			novaAPIName = types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
-			DeferCleanup(th.DeleteInstance, instance)
+			DeferCleanup(th.DeleteInstance, CreateNovaAPI(novaNames.APIName, spec))
 		})
 
 		It("reports that the definition is missing", func() {
 			th.ExpectConditionWithDetails(
-				novaAPIName,
+				novaNames.APIName,
 				ConditionGetterFunc(NovaAPIConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionFalse,
@@ -416,28 +397,24 @@ var _ = Describe("NovaAPI controller", func() {
 				"NetworkAttachment resources missing: internalapi",
 			)
 			th.ExpectCondition(
-				novaAPIName,
+				novaNames.APIName,
 				ConditionGetterFunc(NovaAPIConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionFalse,
 			)
 		})
 		It("reports that network attachment is missing", func() {
-			internalAPINADName := types.NamespacedName{Namespace: namespace, Name: "internalapi"}
+			internalAPINADName := types.NamespacedName{Namespace: novaNames.APIName.Namespace, Name: "internalapi"}
 			nad := th.CreateNetworkAttachmentDefinition(internalAPINADName)
 			DeferCleanup(th.DeleteInstance, nad)
 
-			statefulSetName := types.NamespacedName{
-				Namespace: namespace,
-				Name:      novaAPIName.Name,
-			}
-			ss := th.GetStatefulSet(statefulSetName)
+			ss := th.GetStatefulSet(novaNames.APIStatefulSetName)
 
 			expectedAnnotation, err := json.Marshal(
 				[]networkv1.NetworkSelectionElement{
 					{
 						Name:             "internalapi",
-						Namespace:        namespace,
+						Namespace:        novaNames.APIName.Namespace,
 						InterfaceRequest: "internalapi",
 					}})
 			Expect(err).ShouldNot(HaveOccurred())
@@ -447,10 +424,10 @@ var _ = Describe("NovaAPI controller", func() {
 
 			// We don't add network attachment status annotations to the Pods
 			// to simulate that the network attachments are missing.
-			SimulateStatefulSetReplicaReadyWithPods(statefulSetName, map[string][]string{})
+			SimulateStatefulSetReplicaReadyWithPods(novaNames.APIStatefulSetName, map[string][]string{})
 
 			th.ExpectConditionWithDetails(
-				novaAPIName,
+				novaNames.APIName,
 				ConditionGetterFunc(NovaAPIConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionFalse,
@@ -460,21 +437,17 @@ var _ = Describe("NovaAPI controller", func() {
 			)
 		})
 		It("reports that an IP is missing", func() {
-			internalAPINADName := types.NamespacedName{Namespace: namespace, Name: "internalapi"}
+			internalAPINADName := types.NamespacedName{Namespace: novaNames.APIName.Namespace, Name: "internalapi"}
 			nad := th.CreateNetworkAttachmentDefinition(internalAPINADName)
 			DeferCleanup(th.DeleteInstance, nad)
 
-			statefulSetName := types.NamespacedName{
-				Namespace: namespace,
-				Name:      novaAPIName.Name,
-			}
-			ss := th.GetStatefulSet(statefulSetName)
+			ss := th.GetStatefulSet(novaNames.APIStatefulSetName)
 
 			expectedAnnotation, err := json.Marshal(
 				[]networkv1.NetworkSelectionElement{
 					{
 						Name:             "internalapi",
-						Namespace:        namespace,
+						Namespace:        novaNames.APIName.Namespace,
 						InterfaceRequest: "internalapi",
 					}})
 			Expect(err).ShouldNot(HaveOccurred())
@@ -485,12 +458,12 @@ var _ = Describe("NovaAPI controller", func() {
 			// We simulate that there is no IP associated with the internalapi
 			// network attachment
 			SimulateStatefulSetReplicaReadyWithPods(
-				statefulSetName,
-				map[string][]string{namespace + "/internalapi": {}},
+				novaNames.APIStatefulSetName,
+				map[string][]string{novaNames.APIName.Namespace + "/internalapi": {}},
 			)
 
 			th.ExpectConditionWithDetails(
-				novaAPIName,
+				novaNames.APIName,
 				ConditionGetterFunc(NovaAPIConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionFalse,
@@ -500,38 +473,33 @@ var _ = Describe("NovaAPI controller", func() {
 			)
 		})
 		It("reports NetworkAttachmentsReady if the Pods got the proper annotations", func() {
-			internalAPINADName := types.NamespacedName{Namespace: namespace, Name: "internalapi"}
+			internalAPINADName := types.NamespacedName{Namespace: novaNames.APIName.Namespace, Name: "internalapi"}
 			nad := th.CreateNetworkAttachmentDefinition(internalAPINADName)
 			DeferCleanup(th.DeleteInstance, nad)
 
-			statefulSetName := types.NamespacedName{
-				Namespace: namespace,
-				Name:      novaAPIName.Name,
-			}
 			SimulateStatefulSetReplicaReadyWithPods(
-				statefulSetName,
-				map[string][]string{namespace + "/internalapi": {"10.0.0.1"}},
+				novaNames.APIStatefulSetName,
+				map[string][]string{novaNames.APIName.Namespace + "/internalapi": {"10.0.0.1"}},
 			)
 
 			th.ExpectCondition(
-				novaAPIName,
+				novaNames.APIName,
 				ConditionGetterFunc(NovaAPIConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionTrue,
 			)
 
 			Eventually(func(g Gomega) {
-				novaAPI := GetNovaAPI(novaAPIName)
+				novaAPI := GetNovaAPI(novaNames.APIName)
 				g.Expect(novaAPI.Status.NetworkAttachments).To(
-					Equal(map[string][]string{namespace + "/internalapi": {"10.0.0.1"}}))
+					Equal(map[string][]string{novaNames.APIName.Namespace + "/internalapi": {"10.0.0.1"}}))
 
 			}, timeout, interval).Should(Succeed())
 
-			keystoneEndpointName := types.NamespacedName{Namespace: namespace, Name: "nova"}
-			th.SimulateKeystoneEndpointReady(keystoneEndpointName)
+			th.SimulateKeystoneEndpointReady(novaNames.APIKeystoneEndpointName)
 
 			th.ExpectCondition(
-				novaAPIName,
+				novaNames.APIName,
 				ConditionGetterFunc(NovaAPIConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionTrue,
@@ -541,11 +509,6 @@ var _ = Describe("NovaAPI controller", func() {
 
 	When("NovaAPI is created with externalEndpoints", func() {
 		BeforeEach(func() {
-			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaAPISecret(namespace, SecretName))
-			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaMessageBusSecret(namespace, MessageBusSecretName))
-
 			spec := GetDefaultNovaAPISpec()
 			// NOTE(gibi): We need to create the data as raw list of maps
 			// to allow defaulting to happen according to the kubebuilder
@@ -560,42 +523,37 @@ var _ = Describe("NovaAPI controller", func() {
 			)
 			spec["externalEndpoints"] = externalEndpoints
 
-			instance := CreateNovaAPI(namespace, spec)
-			novaAPIName = types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
-			DeferCleanup(th.DeleteInstance, instance)
+			DeferCleanup(
+				k8sClient.Delete, ctx, CreateNovaAPISecret(novaNames.APIName.Namespace, SecretName))
+			DeferCleanup(th.DeleteInstance, CreateNovaAPI(novaNames.APIName, spec))
 		})
 
 		It("creates MetalLB service", func() {
-			statefulSetName := types.NamespacedName{
-				Namespace: namespace,
-				Name:      novaAPIName.Name,
-			}
-			th.SimulateStatefulSetReplicaReady(statefulSetName)
+			th.SimulateStatefulSetReplicaReady(novaNames.APIStatefulSetName)
 
-			keystoneEndpointName := types.NamespacedName{Namespace: namespace, Name: "nova"}
-			th.SimulateKeystoneEndpointReady(keystoneEndpointName)
+			th.SimulateKeystoneEndpointReady(novaNames.APIKeystoneEndpointName)
 
 			// As the internal endpoint is configured in ExternalEndpoints it does not
 			// get a Route but a Service with MetalLB annotations instead
-			service := th.GetService(types.NamespacedName{Namespace: namespace, Name: "nova-internal"})
+			service := th.GetService(types.NamespacedName{Namespace: novaNames.APIName.Namespace, Name: "nova-internal"})
 			Expect(service.Annotations).To(
 				HaveKeyWithValue("metallb.universe.tf/address-pool", "osp-internalapi"))
 			Expect(service.Annotations).To(
 				HaveKeyWithValue("metallb.universe.tf/allow-shared-ip", "osp-internalapi"))
 			Expect(service.Annotations).To(
 				HaveKeyWithValue("metallb.universe.tf/loadBalancerIPs", "internal-lb-ip-1,internal-lb-ip-2"))
-			th.AssertRouteNotExists(types.NamespacedName{Namespace: namespace, Name: "nova-internal"})
+			th.AssertRouteNotExists(types.NamespacedName{Namespace: novaNames.APIName.Namespace, Name: "nova-internal"})
 
 			// As the public endpoint is not mentioned in the ExternalEndpoints a generic Service and
 			// a Route is created
-			service = th.GetService(types.NamespacedName{Namespace: namespace, Name: "nova-public"})
+			service = th.GetService(types.NamespacedName{Namespace: novaNames.APIName.Namespace, Name: "nova-public"})
 			Expect(service.Annotations).NotTo(HaveKey("metallb.universe.tf/address-pool"))
 			Expect(service.Annotations).NotTo(HaveKey("metallb.universe.tf/allow-shared-ip"))
 			Expect(service.Annotations).NotTo(HaveKey("metallb.universe.tf/loadBalancerIPs"))
-			th.AssertRouteExists(types.NamespacedName{Namespace: namespace, Name: "nova-public"})
+			th.AssertRouteExists(types.NamespacedName{Namespace: novaNames.APIName.Namespace, Name: "nova-public"})
 
 			th.ExpectCondition(
-				novaAPIName,
+				novaNames.APIName,
 				ConditionGetterFunc(NovaAPIConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionTrue,
@@ -604,33 +562,22 @@ var _ = Describe("NovaAPI controller", func() {
 	})
 
 	When("NovAPI is reconfigured", func() {
-		var statefulSetName types.NamespacedName
-
 		BeforeEach(func() {
 			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaAPISecret(namespace, SecretName))
-			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaMessageBusSecret(namespace, MessageBusSecretName))
-
-			api := CreateNovaAPI(namespace, GetDefaultNovaAPISpec())
-			novaAPIName = types.NamespacedName{Name: api.GetName(), Namespace: api.GetNamespace()}
-			DeferCleanup(th.DeleteInstance, api)
+				k8sClient.Delete, ctx, CreateNovaAPISecret(novaNames.APIName.Namespace, SecretName))
+			DeferCleanup(th.DeleteInstance, CreateNovaAPI(novaNames.APIName, GetDefaultNovaAPISpec()))
 
 			th.ExpectCondition(
-				novaAPIName,
+				novaNames.APIName,
 				ConditionGetterFunc(NovaAPIConditionGetter),
 				condition.ServiceConfigReadyCondition,
 				corev1.ConditionTrue,
 			)
 
-			statefulSetName = types.NamespacedName{
-				Namespace: namespace,
-				Name:      novaAPIName.Name,
-			}
-			th.SimulateStatefulSetReplicaReady(statefulSetName)
-			th.SimulateKeystoneEndpointReady(types.NamespacedName{Namespace: namespace, Name: "nova"})
+			th.SimulateStatefulSetReplicaReady(novaNames.APIStatefulSetName)
+			th.SimulateKeystoneEndpointReady(novaNames.APIKeystoneEndpointName)
 			th.ExpectCondition(
-				novaAPIName,
+				novaNames.APIName,
 				ConditionGetterFunc(NovaAPIConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionTrue,
@@ -639,7 +586,7 @@ var _ = Describe("NovaAPI controller", func() {
 
 		It("applies new NetworkAttachments configuration", func() {
 			Eventually(func(g Gomega) {
-				novaAPI := GetNovaAPI(novaAPIName)
+				novaAPI := GetNovaAPI(novaNames.APIName)
 				novaAPI.Spec.NetworkAttachments = append(novaAPI.Spec.NetworkAttachments, "internalapi")
 
 				err := k8sClient.Update(ctx, novaAPI)
@@ -647,7 +594,7 @@ var _ = Describe("NovaAPI controller", func() {
 			}, timeout, interval).Should(Succeed())
 
 			th.ExpectConditionWithDetails(
-				novaAPIName,
+				novaNames.APIName,
 				ConditionGetterFunc(NovaAPIConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionFalse,
@@ -655,7 +602,7 @@ var _ = Describe("NovaAPI controller", func() {
 				"NetworkAttachment resources missing: internalapi",
 			)
 			th.ExpectConditionWithDetails(
-				novaAPIName,
+				novaNames.APIName,
 				ConditionGetterFunc(NovaAPIConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionFalse,
@@ -663,11 +610,11 @@ var _ = Describe("NovaAPI controller", func() {
 				"NetworkAttachment resources missing: internalapi",
 			)
 
-			internalAPINADName := types.NamespacedName{Namespace: namespace, Name: "internalapi"}
+			internalAPINADName := types.NamespacedName{Namespace: novaNames.APIName.Namespace, Name: "internalapi"}
 			DeferCleanup(th.DeleteInstance, th.CreateNetworkAttachmentDefinition(internalAPINADName))
 
 			th.ExpectConditionWithDetails(
-				novaAPIName,
+				novaNames.APIName,
 				ConditionGetterFunc(NovaAPIConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionFalse,
@@ -676,7 +623,7 @@ var _ = Describe("NovaAPI controller", func() {
 					"not all pods have interfaces with ips as configured in NetworkAttachments: [internalapi]",
 			)
 			th.ExpectConditionWithDetails(
-				novaAPIName,
+				novaNames.APIName,
 				ConditionGetterFunc(NovaAPIConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionFalse,
@@ -686,26 +633,26 @@ var _ = Describe("NovaAPI controller", func() {
 			)
 
 			SimulateStatefulSetReplicaReadyWithPods(
-				statefulSetName,
-				map[string][]string{namespace + "/internalapi": {"10.0.0.1"}},
+				novaNames.APIStatefulSetName,
+				map[string][]string{novaNames.APIName.Namespace + "/internalapi": {"10.0.0.1"}},
 			)
 
 			th.ExpectCondition(
-				novaAPIName,
+				novaNames.APIName,
 				ConditionGetterFunc(NovaAPIConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionTrue,
 			)
 
 			Eventually(func(g Gomega) {
-				novaAPI := GetNovaAPI(novaAPIName)
+				novaAPI := GetNovaAPI(novaNames.APIName)
 				g.Expect(novaAPI.Status.NetworkAttachments).To(
-					Equal(map[string][]string{namespace + "/internalapi": {"10.0.0.1"}}))
+					Equal(map[string][]string{novaNames.APIName.Namespace + "/internalapi": {"10.0.0.1"}}))
 
 			}, timeout, interval).Should(Succeed())
 
 			th.ExpectCondition(
-				novaAPIName,
+				novaNames.APIName,
 				ConditionGetterFunc(NovaAPIConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionTrue,
@@ -714,12 +661,12 @@ var _ = Describe("NovaAPI controller", func() {
 
 		It("applies new RegisteredCells input to its StatefulSet to trigger Pod restart", func() {
 			originalConfigHash := GetEnvValue(
-				th.GetStatefulSet(statefulSetName).Spec.Template.Spec.Containers[0].Env, "CONFIG_HASH", "")
+				th.GetStatefulSet(novaNames.APIStatefulSetName).Spec.Template.Spec.Containers[0].Env, "CONFIG_HASH", "")
 
 			// Simulate that a new cell is added and Nova controller registered it and
 			// therefore a new cell is added to RegisteredCells
 			Eventually(func(g Gomega) {
-				novaAPI := GetNovaAPI(novaAPIName)
+				novaAPI := GetNovaAPI(novaNames.APIName)
 				novaAPI.Spec.RegisteredCells = map[string]string{"cell0": "cell0-config-hash"}
 				err := k8sClient.Update(ctx, novaAPI)
 				g.Expect(err == nil || k8s_errors.IsConflict(err)).To(BeTrue())
@@ -728,7 +675,7 @@ var _ = Describe("NovaAPI controller", func() {
 			// Assert that the CONFIG_HASH of the StateFulSet is changed due to this reconfiguration
 			Eventually(func(g Gomega) {
 				currentConfigHash := GetEnvValue(
-					th.GetStatefulSet(statefulSetName).Spec.Template.Spec.Containers[0].Env, "CONFIG_HASH", "")
+					th.GetStatefulSet(novaNames.APIStatefulSetName).Spec.Template.Spec.Containers[0].Env, "CONFIG_HASH", "")
 				g.Expect(originalConfigHash).NotTo(Equal(currentConfigHash))
 
 			}, timeout, interval).Should(Succeed())

--- a/test/functional/novaconductor_controller_test.go
+++ b/test/functional/novaconductor_controller_test.go
@@ -32,26 +32,14 @@ import (
 )
 
 var _ = Describe("NovaConductor controller", func() {
-	var novaConductorName types.NamespacedName
-
-	BeforeEach(func() {
-		// Uncomment this if you need the full output in the logs from gomega
-		// matchers
-		// format.MaxLength = 0
-
-	})
-
 	When("a NovaConductor CR is created pointing to a non existent Secret", func() {
 		BeforeEach(func() {
-			spec := GetDefaultNovaConductorSpec()
-			instance := CreateNovaConductor(namespace, spec)
-			novaConductorName = types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
-			DeferCleanup(th.DeleteInstance, instance)
+			DeferCleanup(th.DeleteInstance, CreateNovaConductor(novaNames.ConductorName, GetDefaultNovaConductorSpec()))
 		})
 
 		It("is not Ready", func() {
 			th.ExpectCondition(
-				novaConductorName,
+				novaNames.ConductorName,
 				ConditionGetterFunc(NovaConductorConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionFalse,
@@ -59,7 +47,7 @@ var _ = Describe("NovaConductor controller", func() {
 		})
 
 		It("has empty Status fields", func() {
-			instance := GetNovaConductor(novaConductorName)
+			instance := GetNovaConductor(novaNames.ConductorName)
 			// NOTE(gibi): Hash has `omitempty` tags so while
 			// they are initialized to an empty map that value is omitted from
 			// the output when sent to the client. So we see nils here.
@@ -69,7 +57,7 @@ var _ = Describe("NovaConductor controller", func() {
 
 		It("is missing the secret", func() {
 			th.ExpectCondition(
-				novaConductorName,
+				novaNames.ConductorName,
 				ConditionGetterFunc(NovaConductorConditionGetter),
 				condition.InputReadyCondition,
 				corev1.ConditionFalse,
@@ -81,7 +69,7 @@ var _ = Describe("NovaConductor controller", func() {
 				secret := &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "not-relevant-secret",
-						Namespace: namespace,
+						Namespace: novaNames.ConductorName.Namespace,
 					},
 				}
 				Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
@@ -90,7 +78,7 @@ var _ = Describe("NovaConductor controller", func() {
 
 			It("is not Ready", func() {
 				th.ExpectCondition(
-					novaConductorName,
+					novaNames.ConductorName,
 					ConditionGetterFunc(NovaConductorConditionGetter),
 					condition.ReadyCondition,
 					corev1.ConditionFalse,
@@ -99,7 +87,7 @@ var _ = Describe("NovaConductor controller", func() {
 
 			It("is missing the secret", func() {
 				th.ExpectCondition(
-					novaConductorName,
+					novaNames.ConductorName,
 					ConditionGetterFunc(NovaConductorConditionGetter),
 					condition.InputReadyCondition,
 					corev1.ConditionFalse,
@@ -113,7 +101,7 @@ var _ = Describe("NovaConductor controller", func() {
 				secret := &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      SecretName,
-						Namespace: namespace,
+						Namespace: novaNames.ConductorName.Namespace,
 					},
 					Data: map[string][]byte{
 						"NovaPassword": []byte("12345678"),
@@ -125,7 +113,7 @@ var _ = Describe("NovaConductor controller", func() {
 
 			It("is not Ready", func() {
 				th.ExpectCondition(
-					novaConductorName,
+					novaNames.ConductorName,
 					ConditionGetterFunc(NovaConductorConditionGetter),
 					condition.ReadyCondition,
 					corev1.ConditionFalse,
@@ -134,7 +122,7 @@ var _ = Describe("NovaConductor controller", func() {
 
 			It("reports that the inputs are not ready", func() {
 				th.ExpectCondition(
-					novaConductorName,
+					novaNames.ConductorName,
 					ConditionGetterFunc(NovaConductorConditionGetter),
 					condition.InputReadyCondition,
 					corev1.ConditionFalse,
@@ -147,17 +135,17 @@ var _ = Describe("NovaConductor controller", func() {
 				DeferCleanup(
 					k8sClient.Delete,
 					ctx,
-					CreateNovaConductorSecret(namespace, SecretName),
+					CreateNovaConductorSecret(novaNames.ConductorName.Namespace, SecretName),
 				)
 				DeferCleanup(
 					k8sClient.Delete, ctx,
-					CreateNovaMessageBusSecret(namespace, MessageBusSecretName),
+					CreateNovaMessageBusSecret(novaNames.ConductorName.Namespace, MessageBusSecretName),
 				)
 			})
 
 			It("reports that input is ready", func() {
 				th.ExpectCondition(
-					novaConductorName,
+					novaNames.ConductorName,
 					ConditionGetterFunc(NovaConductorConditionGetter),
 					condition.InputReadyCondition,
 					corev1.ConditionTrue,
@@ -167,7 +155,7 @@ var _ = Describe("NovaConductor controller", func() {
 				// NOTE(gibi): NovaConductor has no external dependency right now to
 				// generate the configs.
 				th.ExpectCondition(
-					novaConductorName,
+					novaNames.ConductorName,
 					ConditionGetterFunc(NovaConductorConditionGetter),
 					condition.ServiceConfigReadyCondition,
 					corev1.ConditionTrue,
@@ -175,16 +163,16 @@ var _ = Describe("NovaConductor controller", func() {
 
 				configDataMap := th.GetConfigMap(
 					types.NamespacedName{
-						Namespace: namespace,
-						Name:      fmt.Sprintf("%s-config-data", novaConductorName.Name),
+						Namespace: novaNames.ConductorName.Namespace,
+						Name:      fmt.Sprintf("%s-config-data", novaNames.ConductorName.Name),
 					},
 				)
 				Expect(configDataMap.Data).Should(HaveKeyWithValue("nova-blank.conf", ""))
 
 				scriptMap := th.GetConfigMap(
 					types.NamespacedName{
-						Namespace: namespace,
-						Name:      fmt.Sprintf("%s-scripts", novaConductorName.Name),
+						Namespace: novaNames.ConductorName.Namespace,
+						Name:      fmt.Sprintf("%s-scripts", novaNames.ConductorName.Name),
 					},
 				)
 				// Everything under templates/novaconductor are added automatically by
@@ -193,11 +181,14 @@ var _ = Describe("NovaConductor controller", func() {
 					"dbsync.sh", ContainSubstring("nova-manage db sync")))
 				Expect(scriptMap.Data).Should(HaveKeyWithValue(
 					"dbsync.sh", ContainSubstring("nova-manage api_db sync")))
+				// FIXME(bogdando): have I lost this change upon rebasing?
+				//Expect(scriptMap.Data).Should(HaveKeyWithValue(
+				//	"dbsync.sh", ContainSubstring("nova-manage cell_v2 map_cell0")))
 			})
 
 			It("stored the input hash in the Status", func() {
 				Eventually(func(g Gomega) {
-					novaConductor := GetNovaConductor(novaConductorName)
+					novaConductor := GetNovaConductor(novaNames.ConductorName)
 					g.Expect(novaConductor.Status.Hash).Should(HaveKeyWithValue("input", Not(BeEmpty())))
 				}, timeout, interval).Should(Succeed())
 
@@ -206,15 +197,15 @@ var _ = Describe("NovaConductor controller", func() {
 			When("the NovaConductor is deleted", func() {
 				It("deletes the generated ConfigMaps", func() {
 					th.ExpectCondition(
-						novaConductorName,
+						novaNames.ConductorName,
 						ConditionGetterFunc(NovaConductorConditionGetter),
 						condition.ServiceConfigReadyCondition,
 						corev1.ConditionTrue,
 					)
 
-					th.DeleteInstance(GetNovaConductor(novaConductorName))
+					th.DeleteInstance(GetNovaConductor(novaNames.ConductorName))
 					Eventually(func() []corev1.ConfigMap {
-						return th.ListConfigMaps(novaConductorName.Name).Items
+						return th.ListConfigMaps(novaNames.ConductorName.Name).Items
 					}, timeout, interval).Should(BeEmpty())
 				})
 			})
@@ -222,36 +213,21 @@ var _ = Describe("NovaConductor controller", func() {
 	})
 
 	When("NovConductor is created with a proper Secret", func() {
-		var jobName types.NamespacedName
-		var statefulSetName types.NamespacedName
-
 		BeforeEach(func() {
 			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaConductorSecret(namespace, SecretName))
+				k8sClient.Delete, ctx, CreateNovaConductorSecret(novaNames.ConductorName.Namespace, SecretName))
 			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaMessageBusSecret(namespace, MessageBusSecretName))
+				k8sClient.Delete, ctx, CreateNovaMessageBusSecret(novaNames.ConductorName.Namespace, MessageBusSecretName))
 
 			spec := GetDefaultNovaConductorSpec()
-			instance := CreateNovaConductor(namespace, spec)
-			novaConductorName = types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
-			DeferCleanup(th.DeleteInstance, instance)
+			DeferCleanup(th.DeleteInstance, CreateNovaConductor(novaNames.ConductorName, spec))
 
 			th.ExpectCondition(
-				novaConductorName,
+				novaNames.ConductorName,
 				ConditionGetterFunc(NovaConductorConditionGetter),
 				condition.InputReadyCondition,
 				corev1.ConditionTrue,
 			)
-
-			jobName = types.NamespacedName{
-				Namespace: namespace,
-				Name:      novaConductorName.Name + "-db-sync",
-			}
-			statefulSetName = types.NamespacedName{
-				Namespace: namespace,
-				Name:      novaConductorName.Name,
-			}
-
 		})
 
 		// NOTE(gibi): This could be racy when run against a real cluster
@@ -260,14 +236,14 @@ var _ = Describe("NovaConductor controller", func() {
 		// this actually passes.
 		It("started the dbsync job and it reports waiting for that job to finish", func() {
 			th.ExpectConditionWithDetails(
-				novaConductorName,
+				novaNames.ConductorName,
 				ConditionGetterFunc(NovaConductorConditionGetter),
 				condition.DBSyncReadyCondition,
 				corev1.ConditionFalse,
 				condition.RequestedReason,
 				condition.DBSyncReadyRunningMessage,
 			)
-			job := th.GetJob(jobName)
+			job := th.GetJob(novaNames.ConductorDBSyncJobName)
 			Expect(job.Spec.Template.Spec.Volumes).To(HaveLen(2))
 			Expect(job.Spec.Template.Spec.InitContainers).To(HaveLen(0))
 			Expect(job.Spec.Template.Spec.Containers).To(HaveLen(1))
@@ -279,13 +255,13 @@ var _ = Describe("NovaConductor controller", func() {
 
 		When("DB sync fails", func() {
 			BeforeEach(func() {
-				th.SimulateJobFailure(jobName)
+				th.SimulateJobFailure(novaNames.ConductorDBSyncJobName)
 			})
 
 			// NOTE(gibi): lib-common only deletes the job if the job succeeds
 			It("reports that DB sync is failed and the job is not deleted", func() {
 				th.ExpectConditionWithDetails(
-					novaConductorName,
+					novaNames.ConductorName,
 					ConditionGetterFunc(NovaConductorConditionGetter),
 					condition.DBSyncReadyCondition,
 					corev1.ConditionFalse,
@@ -293,10 +269,10 @@ var _ = Describe("NovaConductor controller", func() {
 					"DBsync job error occurred Internal error occurred: Job Failed. Check job logs",
 				)
 				// This would fail the test case if the job does not exists
-				th.GetJob(jobName)
+				th.GetJob(novaNames.ConductorDBSyncJobName)
 
 				// We don't store the failed job's hash.
-				novaConductor := GetNovaConductor(novaConductorName)
+				novaConductor := GetNovaConductor(novaNames.ConductorName)
 				Expect(novaConductor.Status.Hash).ShouldNot(HaveKey("dbsync"))
 
 			})
@@ -304,7 +280,7 @@ var _ = Describe("NovaConductor controller", func() {
 			When("NovaConductor is deleted", func() {
 				It("deletes the failed job", func() {
 					th.ExpectConditionWithDetails(
-						novaConductorName,
+						novaNames.ConductorName,
 						ConditionGetterFunc(NovaConductorConditionGetter),
 						condition.DBSyncReadyCondition,
 						corev1.ConditionFalse,
@@ -312,10 +288,10 @@ var _ = Describe("NovaConductor controller", func() {
 						"DBsync job error occurred Internal error occurred: Job Failed. Check job logs",
 					)
 
-					th.DeleteInstance(GetNovaConductor(novaConductorName))
+					th.DeleteInstance(GetNovaConductor(novaNames.ConductorName))
 
 					Eventually(func() []batchv1.Job {
-						return th.ListJobs(novaConductorName.Name).Items
+						return th.ListJobs(novaNames.ConductorName.Name).Items
 					}, timeout, interval).Should(BeEmpty())
 				})
 			})
@@ -323,23 +299,23 @@ var _ = Describe("NovaConductor controller", func() {
 
 		When("DB sync job finishes successfully", func() {
 			BeforeEach(func() {
-				th.SimulateJobSuccess(jobName)
+				th.SimulateJobSuccess(novaNames.ConductorDBSyncJobName)
 			})
 
 			It("reports that DB sync is ready and the job is configured to be deleted", func() {
 				th.ExpectCondition(
-					novaConductorName,
+					novaNames.ConductorName,
 					ConditionGetterFunc(NovaConductorConditionGetter),
 					condition.DBSyncReadyCondition,
 					corev1.ConditionTrue,
 				)
-				job := th.GetJob(jobName)
+				job := th.GetJob(novaNames.ConductorDBSyncJobName)
 				Expect(job.Spec.TTLSecondsAfterFinished).NotTo(BeNil())
 			})
 
 			It("stores the hash of the Job in the Status", func() {
 				Eventually(func(g Gomega) {
-					novaConductor := GetNovaConductor(novaConductorName)
+					novaConductor := GetNovaConductor(novaNames.ConductorName)
 					g.Expect(novaConductor.Status.Hash).Should(HaveKeyWithValue("dbsync", Not(BeEmpty())))
 				}, timeout, interval).Should(Succeed())
 
@@ -347,12 +323,12 @@ var _ = Describe("NovaConductor controller", func() {
 
 			It("creates a StatefulSet for the nova-conductor service", func() {
 				th.ExpectCondition(
-					novaConductorName,
+					novaNames.ConductorName,
 					ConditionGetterFunc(NovaConductorConditionGetter),
 					condition.DeploymentReadyCondition,
 					corev1.ConditionFalse,
 				)
-				ss := th.GetStatefulSet(statefulSetName)
+				ss := th.GetStatefulSet(novaNames.ConductorStatefulSetName)
 				Expect(ss.Spec.Template.Spec.Containers).To(HaveLen(1))
 				container := ss.Spec.Template.Spec.Containers[0]
 				Expect(container.LivenessProbe.Exec.Command).To(
@@ -360,116 +336,100 @@ var _ = Describe("NovaConductor controller", func() {
 				Expect(container.ReadinessProbe.Exec.Command).To(
 					Equal([]string{"/usr/bin/pgrep", "-r", "DRST", "nova-conductor"}))
 
-				th.SimulateStatefulSetReplicaReady(statefulSetName)
+				th.SimulateStatefulSetReplicaReady(novaNames.ConductorStatefulSetName)
 				th.ExpectCondition(
-					novaConductorName,
+					novaNames.ConductorName,
 					ConditionGetterFunc(NovaConductorConditionGetter),
 					condition.DeploymentReadyCondition,
 					corev1.ConditionTrue,
 				)
 				th.ExpectCondition(
-					novaConductorName,
+					novaNames.ConductorName,
 					ConditionGetterFunc(NovaConductorConditionGetter),
 					condition.ReadyCondition,
 					corev1.ConditionTrue,
 				)
-				conductor := GetNovaConductor(novaConductorName)
+				conductor := GetNovaConductor(novaNames.ConductorName)
 				Expect(conductor.Status.ReadyCount).To(BeNumerically(">", 0))
 			})
 		})
 	})
 
 	When("NovaConductor is configured to preserve jobs", func() {
-		var jobName types.NamespacedName
-
 		BeforeEach(func() {
 			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaConductorSecret(namespace, SecretName))
+				k8sClient.Delete, ctx, CreateNovaConductorSecret(novaNames.ConductorName.Namespace, SecretName))
 			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaMessageBusSecret(namespace, MessageBusSecretName))
+				k8sClient.Delete, ctx, CreateNovaMessageBusSecret(novaNames.ConductorName.Namespace, MessageBusSecretName))
 
 			spec := GetDefaultNovaConductorSpec()
 			spec["debug"] = map[string]interface{}{
 				"preserveJobs": true,
 			}
-			instance := CreateNovaConductor(namespace, spec)
-			novaConductorName = types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
+			DeferCleanup(th.DeleteInstance, CreateNovaConductor(novaNames.ConductorName, spec))
 
 			th.ExpectCondition(
-				novaConductorName,
+				novaNames.ConductorName,
 				ConditionGetterFunc(NovaConductorConditionGetter),
 				condition.DBSyncReadyCondition,
 				corev1.ConditionFalse,
 			)
-
-			jobName = types.NamespacedName{
-				Namespace: namespace,
-				Name:      novaConductorName.Name + "-db-sync",
-			}
 		})
 
 		It("does not configure DB sync job to be deleted after it finished", func() {
-			th.SimulateJobSuccess(jobName)
+			th.SimulateJobSuccess(novaNames.ConductorDBSyncJobName)
 
 			th.ExpectCondition(
-				novaConductorName,
+				novaNames.ConductorName,
 				ConditionGetterFunc(NovaConductorConditionGetter),
 				condition.DBSyncReadyCondition,
 				corev1.ConditionTrue,
 			)
-			Expect(th.GetJob(jobName).Spec.TTLSecondsAfterFinished).To(BeNil())
+			Expect(th.GetJob(novaNames.ConductorDBSyncJobName).Spec.TTLSecondsAfterFinished).To(BeNil())
 		})
 
 		It("does not configure DB sync job to be deleted after it failed", func() {
-			th.SimulateJobFailure(jobName)
+			th.SimulateJobFailure(novaNames.ConductorDBSyncJobName)
 
 			th.ExpectConditionWithDetails(
-				novaConductorName,
+				novaNames.ConductorName,
 				ConditionGetterFunc(NovaConductorConditionGetter),
 				condition.DBSyncReadyCondition,
 				corev1.ConditionFalse,
 				condition.ErrorReason,
 				"DBsync job error occurred Internal error occurred: Job Failed. Check job logs",
 			)
-			Expect(th.GetJob(jobName).Spec.TTLSecondsAfterFinished).To(BeNil())
+			Expect(th.GetJob(novaNames.ConductorDBSyncJobName).Spec.TTLSecondsAfterFinished).To(BeNil())
 		})
 	})
 
 	When("PreserveJobs changed from true to false", func() {
-		var jobName types.NamespacedName
-
 		BeforeEach(func() {
 			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaConductorSecret(namespace, SecretName))
+				k8sClient.Delete, ctx, CreateNovaConductorSecret(novaNames.ConductorName.Namespace, SecretName))
 			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaMessageBusSecret(namespace, MessageBusSecretName))
+				k8sClient.Delete, ctx, CreateNovaMessageBusSecret(novaNames.ConductorName.Namespace, MessageBusSecretName))
 
 			spec := GetDefaultNovaConductorSpec()
 			spec["debug"] = map[string]interface{}{
 				"preserveJobs": true,
 			}
-			instance := CreateNovaConductor(namespace, spec)
-			novaConductorName = types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
+			DeferCleanup(th.DeleteInstance, CreateNovaConductor(novaNames.ConductorName, spec))
 
-			jobName = types.NamespacedName{
-				Namespace: namespace,
-				Name:      novaConductorName.Name + "-db-sync",
-			}
-
-			th.SimulateJobSuccess(jobName)
+			th.SimulateJobSuccess(novaNames.ConductorDBSyncJobName)
 			th.ExpectCondition(
-				novaConductorName,
+				novaNames.ConductorName,
 				ConditionGetterFunc(NovaConductorConditionGetter),
 				condition.DBSyncReadyCondition,
 				corev1.ConditionTrue,
 			)
 
-			Expect(th.GetJob(jobName).Spec.TTLSecondsAfterFinished).To(BeNil())
+			Expect(th.GetJob(novaNames.ConductorDBSyncJobName).Spec.TTLSecondsAfterFinished).To(BeNil())
 
 			// Update the NovaConductor to not preserve Jobs
 			// Eventually is needed here to retry if the update returns conflict
 			Eventually(func(g Gomega) {
-				conductor := GetNovaConductor(novaConductorName)
+				conductor := GetNovaConductor(novaNames.ConductorName)
 				conductor.Spec.Debug.PreserveJobs = false
 				g.Expect(k8sClient.Update(ctx, conductor)).Should(Succeed())
 			}, timeout, interval).Should(Succeed())
@@ -477,33 +437,32 @@ var _ = Describe("NovaConductor controller", func() {
 
 		It("marks the job to be deleted", func() {
 			Eventually(func(g Gomega) {
-				g.Expect(th.GetJob(jobName).Spec.TTLSecondsAfterFinished).NotTo(BeNil())
+				g.Expect(th.GetJob(novaNames.ConductorDBSyncJobName).Spec.TTLSecondsAfterFinished).NotTo(BeNil())
 			}, timeout, interval).Should(Succeed())
 		})
 	})
 
+})
+
+var _ = Describe("NovaConductor controller", func() {
+	BeforeEach(func() {
+		DeferCleanup(
+			k8sClient.Delete, ctx, CreateNovaMessageBusSecret(novaNames.ConductorName.Namespace, MessageBusSecretName))
+	})
+
 	When("NovaConductor is created with networkAttachments", func() {
-		var jobName types.NamespacedName
 		BeforeEach(func() {
 			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaConductorSecret(namespace, SecretName))
-			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaMessageBusSecret(namespace, MessageBusSecretName))
+				k8sClient.Delete, ctx, CreateNovaConductorSecret(novaNames.ConductorName.Namespace, SecretName))
 
 			spec := GetDefaultNovaConductorSpec()
 			spec["networkAttachments"] = []string{"internalapi"}
-			instance := CreateNovaConductor(namespace, spec)
-			novaConductorName = types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
-			jobName = types.NamespacedName{
-				Namespace: namespace,
-				Name:      novaConductorName.Name + "-db-sync",
-			}
-
+			DeferCleanup(th.DeleteInstance, CreateNovaConductor(novaNames.ConductorName, spec))
 		})
 
 		It("reports that the definition is missing", func() {
 			th.ExpectConditionWithDetails(
-				novaConductorName,
+				novaNames.ConductorName,
 				ConditionGetterFunc(NovaConductorConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionFalse,
@@ -511,29 +470,25 @@ var _ = Describe("NovaConductor controller", func() {
 				"NetworkAttachment resources missing: internalapi",
 			)
 			th.ExpectCondition(
-				novaConductorName,
+				novaNames.ConductorName,
 				ConditionGetterFunc(NovaConductorConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionFalse,
 			)
 		})
 		It("reports that network attachment is missing", func() {
-			internalAPINADName := types.NamespacedName{Namespace: namespace, Name: "internalapi"}
+			internalAPINADName := types.NamespacedName{Namespace: novaNames.ConductorName.Namespace, Name: "internalapi"}
 			nad := th.CreateNetworkAttachmentDefinition(internalAPINADName)
 			DeferCleanup(th.DeleteInstance, nad)
-			th.SimulateJobSuccess(jobName)
+			th.SimulateJobSuccess(novaNames.ConductorDBSyncJobName)
 
-			statefulSetName := types.NamespacedName{
-				Namespace: namespace,
-				Name:      novaConductorName.Name,
-			}
-			ss := th.GetStatefulSet(statefulSetName)
+			ss := th.GetStatefulSet(novaNames.ConductorStatefulSetName)
 
 			expectedAnnotation, err := json.Marshal(
 				[]networkv1.NetworkSelectionElement{
 					{
 						Name:             "internalapi",
-						Namespace:        namespace,
+						Namespace:        novaNames.ConductorName.Namespace,
 						InterfaceRequest: "internalapi",
 					}})
 			Expect(err).ShouldNot(HaveOccurred())
@@ -543,10 +498,10 @@ var _ = Describe("NovaConductor controller", func() {
 
 			// We don't add network attachment status annotations to the Pods
 			// to simulate that the network attachments are missing.
-			SimulateStatefulSetReplicaReadyWithPods(statefulSetName, map[string][]string{})
+			SimulateStatefulSetReplicaReadyWithPods(novaNames.ConductorStatefulSetName, map[string][]string{})
 
 			th.ExpectConditionWithDetails(
-				novaConductorName,
+				novaNames.ConductorName,
 				ConditionGetterFunc(NovaConductorConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionFalse,
@@ -556,22 +511,18 @@ var _ = Describe("NovaConductor controller", func() {
 			)
 		})
 		It("reports that an IP is missing", func() {
-			internalAPINADName := types.NamespacedName{Namespace: namespace, Name: "internalapi"}
+			internalAPINADName := types.NamespacedName{Namespace: novaNames.ConductorName.Namespace, Name: "internalapi"}
 			nad := th.CreateNetworkAttachmentDefinition(internalAPINADName)
 			DeferCleanup(th.DeleteInstance, nad)
-			th.SimulateJobSuccess(jobName)
+			th.SimulateJobSuccess(novaNames.ConductorDBSyncJobName)
 
-			statefulSetName := types.NamespacedName{
-				Namespace: namespace,
-				Name:      novaConductorName.Name,
-			}
-			ss := th.GetStatefulSet(statefulSetName)
+			ss := th.GetStatefulSet(novaNames.ConductorStatefulSetName)
 
 			expectedAnnotation, err := json.Marshal(
 				[]networkv1.NetworkSelectionElement{
 					{
 						Name:             "internalapi",
-						Namespace:        namespace,
+						Namespace:        novaNames.ConductorName.Namespace,
 						InterfaceRequest: "internalapi",
 					}})
 			Expect(err).ShouldNot(HaveOccurred())
@@ -582,12 +533,12 @@ var _ = Describe("NovaConductor controller", func() {
 			// We simulate that there is no IP associated with the internalapi
 			// network attachment
 			SimulateStatefulSetReplicaReadyWithPods(
-				statefulSetName,
-				map[string][]string{namespace + "/internalapi": {}},
+				novaNames.ConductorStatefulSetName,
+				map[string][]string{novaNames.ConductorName.Namespace + "/internalapi": {}},
 			)
 
 			th.ExpectConditionWithDetails(
-				novaConductorName,
+				novaNames.ConductorName,
 				ConditionGetterFunc(NovaConductorConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionFalse,
@@ -597,35 +548,31 @@ var _ = Describe("NovaConductor controller", func() {
 			)
 		})
 		It("reports NetworkAttachmentsReady if the Pods got the proper annotations", func() {
-			internalAPINADName := types.NamespacedName{Namespace: namespace, Name: "internalapi"}
+			internalAPINADName := types.NamespacedName{Namespace: novaNames.ConductorName.Namespace, Name: "internalapi"}
 			nad := th.CreateNetworkAttachmentDefinition(internalAPINADName)
 			DeferCleanup(th.DeleteInstance, nad)
-			th.SimulateJobSuccess(jobName)
+			th.SimulateJobSuccess(novaNames.ConductorDBSyncJobName)
 
-			statefulSetName := types.NamespacedName{
-				Namespace: namespace,
-				Name:      novaConductorName.Name,
-			}
 			SimulateStatefulSetReplicaReadyWithPods(
-				statefulSetName,
-				map[string][]string{namespace + "/internalapi": {"10.0.0.1"}},
+				novaNames.ConductorStatefulSetName,
+				map[string][]string{novaNames.ConductorName.Namespace + "/internalapi": {"10.0.0.1"}},
 			)
 
 			th.ExpectCondition(
-				novaConductorName,
+				novaNames.ConductorName,
 				ConditionGetterFunc(NovaConductorConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionTrue,
 			)
 
 			Eventually(func(g Gomega) {
-				novaConductor := GetNovaConductor(novaConductorName)
+				novaConductor := GetNovaConductor(novaNames.ConductorName)
 				g.Expect(novaConductor.Status.NetworkAttachments).To(
-					Equal(map[string][]string{namespace + "/internalapi": {"10.0.0.1"}}))
+					Equal(map[string][]string{novaNames.ConductorName.Namespace + "/internalapi": {"10.0.0.1"}}))
 			}, timeout, interval).Should(Succeed())
 
 			th.ExpectCondition(
-				novaConductorName,
+				novaNames.ConductorName,
 				ConditionGetterFunc(NovaConductorConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionTrue,
@@ -633,38 +580,22 @@ var _ = Describe("NovaConductor controller", func() {
 		})
 	})
 	When("NovaConductor is reconfigured", func() {
-		var statefulSetName types.NamespacedName
-		var jobName types.NamespacedName
-
 		BeforeEach(func() {
 			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaConductorSecret(namespace, SecretName))
-			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaMessageBusSecret(namespace, MessageBusSecretName))
-
-			conductor := CreateNovaConductor(namespace, GetDefaultNovaConductorSpec())
-			novaConductorName = types.NamespacedName{Name: conductor.GetName(), Namespace: conductor.GetNamespace()}
-			DeferCleanup(th.DeleteInstance, conductor)
+				k8sClient.Delete, ctx, CreateNovaConductorSecret(novaNames.ConductorName.Namespace, SecretName))
+			DeferCleanup(th.DeleteInstance, CreateNovaConductor(novaNames.ConductorName, GetDefaultNovaConductorSpec()))
 
 			th.ExpectCondition(
-				novaConductorName,
+				novaNames.ConductorName,
 				ConditionGetterFunc(NovaConductorConditionGetter),
 				condition.ServiceConfigReadyCondition,
 				corev1.ConditionTrue,
 			)
 
-			jobName = types.NamespacedName{
-				Namespace: namespace,
-				Name:      novaConductorName.Name + "-db-sync",
-			}
-			th.SimulateJobSuccess(jobName)
-			statefulSetName = types.NamespacedName{
-				Namespace: namespace,
-				Name:      novaConductorName.Name,
-			}
-			th.SimulateStatefulSetReplicaReady(statefulSetName)
+			th.SimulateJobSuccess(novaNames.ConductorDBSyncJobName)
+			th.SimulateStatefulSetReplicaReady(novaNames.ConductorStatefulSetName)
 			th.ExpectCondition(
-				novaConductorName,
+				novaNames.ConductorName,
 				ConditionGetterFunc(NovaConductorConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionTrue,
@@ -673,7 +604,7 @@ var _ = Describe("NovaConductor controller", func() {
 
 		It("applies new NetworkAttachments configuration", func() {
 			Eventually(func(g Gomega) {
-				novaConductor := GetNovaConductor(novaConductorName)
+				novaConductor := GetNovaConductor(novaNames.ConductorName)
 				novaConductor.Spec.NetworkAttachments = append(novaConductor.Spec.NetworkAttachments, "internalapi")
 
 				err := k8sClient.Update(ctx, novaConductor)
@@ -681,7 +612,7 @@ var _ = Describe("NovaConductor controller", func() {
 			}, timeout, interval).Should(Succeed())
 
 			th.ExpectConditionWithDetails(
-				novaConductorName,
+				novaNames.ConductorName,
 				ConditionGetterFunc(NovaConductorConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionFalse,
@@ -690,7 +621,7 @@ var _ = Describe("NovaConductor controller", func() {
 			)
 
 			th.ExpectConditionWithDetails(
-				novaConductorName,
+				novaNames.ConductorName,
 				ConditionGetterFunc(NovaConductorConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionFalse,
@@ -698,11 +629,11 @@ var _ = Describe("NovaConductor controller", func() {
 				"NetworkAttachment resources missing: internalapi",
 			)
 
-			internalAPINADName := types.NamespacedName{Namespace: namespace, Name: "internalapi"}
+			internalAPINADName := types.NamespacedName{Namespace: novaNames.ConductorName.Namespace, Name: "internalapi"}
 			DeferCleanup(th.DeleteInstance, th.CreateNetworkAttachmentDefinition(internalAPINADName))
 
 			th.ExpectConditionWithDetails(
-				novaConductorName,
+				novaNames.ConductorName,
 				ConditionGetterFunc(NovaConductorConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionFalse,
@@ -712,7 +643,7 @@ var _ = Describe("NovaConductor controller", func() {
 			)
 
 			th.ExpectConditionWithDetails(
-				novaConductorName,
+				novaNames.ConductorName,
 				ConditionGetterFunc(NovaConductorConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionFalse,
@@ -722,26 +653,26 @@ var _ = Describe("NovaConductor controller", func() {
 			)
 
 			SimulateStatefulSetReplicaReadyWithPods(
-				statefulSetName,
-				map[string][]string{namespace + "/internalapi": {"10.0.0.1"}},
+				novaNames.ConductorStatefulSetName,
+				map[string][]string{novaNames.ConductorName.Namespace + "/internalapi": {"10.0.0.1"}},
 			)
 
 			th.ExpectCondition(
-				novaConductorName,
+				novaNames.ConductorName,
 				ConditionGetterFunc(NovaConductorConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionTrue,
 			)
 
 			Eventually(func(g Gomega) {
-				novaConductor := GetNovaConductor(novaConductorName)
+				novaConductor := GetNovaConductor(novaNames.ConductorName)
 				g.Expect(novaConductor.Status.NetworkAttachments).To(
-					Equal(map[string][]string{namespace + "/internalapi": {"10.0.0.1"}}))
+					Equal(map[string][]string{novaNames.ConductorName.Namespace + "/internalapi": {"10.0.0.1"}}))
 
 			}, timeout, interval).Should(Succeed())
 
 			th.ExpectCondition(
-				novaConductorName,
+				novaNames.ConductorName,
 				ConditionGetterFunc(NovaConductorConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionTrue,

--- a/test/functional/novaexternalcompute_controller_test.go
+++ b/test/functional/novaexternalcompute_controller_test.go
@@ -17,7 +17,6 @@ package functional_test
 import (
 	"fmt"
 
-	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
@@ -30,96 +29,62 @@ import (
 	novav1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
 )
 
-func CreateNovaCellAndEnsureReady(namespace string, novaCellName types.NamespacedName) {
+func CreateNovaCellAndEnsureReady(cell CellNames) {
 	DeferCleanup(
-		k8sClient.Delete, ctx, CreateNovaConductorSecret(namespace, SecretName))
+		k8sClient.Delete, ctx, CreateNovaConductorSecret(cell.CellName.Namespace, SecretName))
 	DeferCleanup(
-		k8sClient.Delete, ctx, CreateNovaMessageBusSecret(namespace, MessageBusSecretName))
+		k8sClient.Delete, ctx, CreateNovaMessageBusSecret(cell.CellName.Namespace, MessageBusSecretName))
 
 	spec := GetDefaultNovaCellSpec()
-	spec["cellName"] = "cell1"
-	instance := CreateNovaCell(novaCellName, spec)
-	DeferCleanup(th.DeleteInstance, instance)
-	cellName := types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
+	spec["cellName"] = cell.CellName.Name
+	DeferCleanup(th.DeleteInstance, CreateNovaCell(cell.CellName, spec))
 
-	novaConductorName := types.NamespacedName{
-		Namespace: namespace,
-		Name:      cellName.Name + "-conductor",
-	}
-	novaConductorDBSyncJobName := types.NamespacedName{
-		Namespace: namespace,
-		Name:      novaConductorName.Name + "-db-sync",
-	}
-	th.SimulateJobSuccess(novaConductorDBSyncJobName)
-
-	conductorStatefulSetName := types.NamespacedName{
-		Namespace: namespace,
-		Name:      novaConductorName.Name,
-	}
-	th.SimulateStatefulSetReplicaReady(conductorStatefulSetName)
+	th.SimulateJobSuccess(cell.CellDBSyncJobName)
+	th.SimulateStatefulSetReplicaReady(cell.ConductorStatefulSetName)
 
 	th.ExpectCondition(
-		cellName,
+		cell.CellName,
 		ConditionGetterFunc(NovaCellConditionGetter),
 		condition.ReadyCondition,
 		corev1.ConditionTrue,
 	)
-
 }
 
 var _ = Describe("NovaExternalCompute", func() {
-	var computeName types.NamespacedName
-	var novaName types.NamespacedName
-	var novaCellName types.NamespacedName
-
-	BeforeEach(func() {
-		// Uncomment this if you need the full output in the logs from gomega
-		// matchers
-		// format.MaxLength = 0
-
-		computeName = types.NamespacedName{
-			Namespace: namespace,
-			Name:      uuid.New().String(),
-		}
-		novaName = types.NamespacedName{
-			Namespace: namespace,
-			Name:      uuid.New().String(),
-		}
-		novaCellName = types.NamespacedName{
-			Namespace: namespace,
-			Name:      novaName.Name + "-" + "cell1",
-		}
-	})
-
 	When("created", func() {
 
 		BeforeEach(func() {
 			// Create the NovaCell the compute will belong to
-			CreateNovaCellAndEnsureReady(namespace, novaCellName)
-			// Create the compute
-			instance := CreateNovaExternalCompute(computeName, GetDefaultNovaExternalComputeSpec(novaName.Name, computeName.Name))
-			DeferCleanup(th.DeleteInstance, instance)
-			compute := GetNovaExternalCompute(computeName)
+			CreateNovaCellAndEnsureReady(cell1)
+			// Create the external compute
+			DeferCleanup(
+				th.DeleteInstance,
+				CreateNovaExternalCompute(
+					novaNames.ComputeName,
+					GetDefaultNovaExternalComputeSpec(novaNames.NovaName.Name, novaNames.ComputeName.Name)))
+
+			compute := GetNovaExternalCompute(novaNames.ComputeName)
+			// TODO(bogdando): move to novaNames.Compute*
 			inventoryName := types.NamespacedName{
-				Namespace: namespace,
+				Namespace: novaNames.ComputeName.Namespace,
 				Name:      compute.Spec.InventoryConfigMapName,
 			}
 			CreateNovaExternalComputeInventoryConfigMap(inventoryName)
 			DeferCleanup(th.DeleteConfigMap, inventoryName)
 
 			sshSecretName := types.NamespacedName{
-				Namespace: namespace,
+				Namespace: novaNames.ComputeName.Namespace,
 				Name:      compute.Spec.SSHKeySecretName,
 			}
 			CreateNovaExternalComputeSSHSecret(sshSecretName)
 			DeferCleanup(th.DeleteSecret, sshSecretName)
 			libvirtAEEName := types.NamespacedName{
-				Namespace: namespace,
+				Namespace: novaNames.ComputeName.Namespace,
 				Name:      fmt.Sprintf("%s-%s-deploy-libvirt", compute.Spec.NovaInstance, compute.Name),
 			}
 			SimulateAEESucceeded(libvirtAEEName)
 			novaAEEName := types.NamespacedName{
-				Namespace: namespace,
+				Namespace: novaNames.ComputeName.Namespace,
 				Name:      fmt.Sprintf("%s-%s-deploy-nova", compute.Spec.NovaInstance, compute.Name),
 			}
 			SimulateAEESucceeded(novaAEEName)
@@ -128,7 +93,7 @@ var _ = Describe("NovaExternalCompute", func() {
 
 		It("adds Finalizer to itself", func() {
 			Eventually(func(g Gomega) {
-				compute := GetNovaExternalCompute(computeName)
+				compute := GetNovaExternalCompute(novaNames.ComputeName)
 				g.Expect(compute.Finalizers).To(ContainElement("NovaExternalCompute"))
 
 			}, timeout, interval).Should(Succeed())
@@ -136,7 +101,7 @@ var _ = Describe("NovaExternalCompute", func() {
 
 		It("initializes Status", func() {
 			Eventually(func(g Gomega) {
-				compute := GetNovaExternalCompute(computeName)
+				compute := GetNovaExternalCompute(novaNames.ComputeName)
 				g.Expect(compute.Status.Conditions).NotTo(BeEmpty())
 				g.Expect(compute.Status.Hash).NotTo(BeNil())
 
@@ -145,18 +110,18 @@ var _ = Describe("NovaExternalCompute", func() {
 
 		It("reports InputReady and stores that input hash", func() {
 			th.ExpectCondition(
-				computeName,
+				novaNames.ComputeName,
 				ConditionGetterFunc(NovaExternalComputeConditionGetter),
 				condition.InputReadyCondition,
 				corev1.ConditionTrue,
 			)
-			compute := GetNovaExternalCompute(computeName)
+			compute := GetNovaExternalCompute(novaNames.ComputeName)
 			Expect(compute.Status.Hash["input"]).NotTo(BeEmpty())
 		})
 
 		It("is Ready", func() {
 			th.ExpectCondition(
-				computeName,
+				novaNames.ComputeName,
 				ConditionGetterFunc(NovaExternalComputeConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionTrue,
@@ -164,7 +129,7 @@ var _ = Describe("NovaExternalCompute", func() {
 		})
 		It("can be deleted as the finalizer is automatically removed", func() {
 			th.ExpectCondition(
-				computeName,
+				novaNames.ComputeName,
 				ConditionGetterFunc(NovaExternalComputeConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionTrue,
@@ -174,78 +139,81 @@ var _ = Describe("NovaExternalCompute", func() {
 			// after the timeout. So if this passes then we know the the CR is
 			// removed and that can only happen if the finalizer is removed from
 			// it first
-			compute := GetNovaExternalCompute(computeName)
+			compute := GetNovaExternalCompute(novaNames.ComputeName)
 			th.DeleteInstance(compute)
 		})
 	})
 	When("created but Secrets are missing or fields missing", func() {
 		BeforeEach(func() {
-			compute := CreateNovaExternalCompute(computeName, GetDefaultNovaExternalComputeSpec(novaName.Name, computeName.Name))
-			DeferCleanup(th.DeleteInstance, compute)
+			DeferCleanup(
+				th.DeleteInstance,
+				CreateNovaExternalCompute(
+					novaNames.ComputeName,
+					GetDefaultNovaExternalComputeSpec(novaNames.NovaName.Name, novaNames.ComputeName.Name)))
 		})
 
 		It("reports missing Inventory configmap", func() {
-			compute := GetNovaExternalCompute(computeName)
+			compute := GetNovaExternalCompute(novaNames.ComputeName)
 			th.ExpectConditionWithDetails(
-				computeName,
+				novaNames.ComputeName,
 				ConditionGetterFunc(NovaExternalComputeConditionGetter),
 				condition.InputReadyCondition,
 				corev1.ConditionFalse,
 				condition.RequestedReason,
 				"Input data resources missing: configmap/"+compute.Spec.InventoryConfigMapName,
 			)
-			compute = GetNovaExternalCompute(computeName)
+			compute = GetNovaExternalCompute(novaNames.ComputeName)
 			Expect(compute.Status.Hash["input"]).To(BeEmpty())
 		})
 
 		It("reports missing field from Inventory configmap", func() {
-			compute := GetNovaExternalCompute(computeName)
+			compute := GetNovaExternalCompute(novaNames.ComputeName)
 			CreateEmptyConfigMap(
-				types.NamespacedName{Namespace: namespace, Name: compute.Spec.InventoryConfigMapName})
+				types.NamespacedName{Namespace: novaNames.ComputeName.Namespace, Name: compute.Spec.InventoryConfigMapName})
 			th.ExpectConditionWithDetails(
-				computeName,
+				novaNames.ComputeName,
 				ConditionGetterFunc(NovaExternalComputeConditionGetter),
 				condition.InputReadyCondition,
 				corev1.ConditionFalse,
 				condition.ErrorReason,
 				"Input data error occurred field 'inventory' not found in configmap/"+compute.Spec.InventoryConfigMapName,
 			)
-			compute = GetNovaExternalCompute(computeName)
+			compute = GetNovaExternalCompute(novaNames.ComputeName)
 			Expect(compute.Status.Hash["input"]).To(BeEmpty())
 		})
 
 		It("reports missing SSH key secret", func() {
-			compute := GetNovaExternalCompute(computeName)
-			inventoryName := types.NamespacedName{Namespace: namespace, Name: compute.Spec.InventoryConfigMapName}
+			compute := GetNovaExternalCompute(novaNames.ComputeName)
+			inventoryName := types.NamespacedName{Namespace: novaNames.ComputeName.Namespace, Name: compute.Spec.InventoryConfigMapName}
 			CreateNovaExternalComputeInventoryConfigMap(inventoryName)
 			DeferCleanup(th.DeleteConfigMap, inventoryName)
 			th.ExpectConditionWithDetails(
-				computeName,
+				novaNames.ComputeName,
 				ConditionGetterFunc(NovaExternalComputeConditionGetter),
 				condition.InputReadyCondition,
 				corev1.ConditionFalse,
 				condition.RequestedReason,
 				"Input data resources missing: secret/"+compute.Spec.SSHKeySecretName,
 			)
-			compute = GetNovaExternalCompute(computeName)
+			compute = GetNovaExternalCompute(novaNames.ComputeName)
 			Expect(compute.Status.Hash["input"]).To(BeEmpty())
 		})
 
 		It("reports missing field from SSH key secret", func() {
-			compute := GetNovaExternalCompute(computeName)
+			compute := GetNovaExternalCompute(novaNames.ComputeName)
 			CreateNovaExternalComputeInventoryConfigMap(
-				types.NamespacedName{Namespace: namespace, Name: compute.Spec.InventoryConfigMapName})
+				types.NamespacedName{Namespace: novaNames.ComputeName.Namespace, Name: compute.Spec.InventoryConfigMapName})
 			th.CreateEmptySecret(
-				types.NamespacedName{Namespace: namespace, Name: compute.Spec.SSHKeySecretName})
+				types.NamespacedName{Namespace: novaNames.ComputeName.Namespace, Name: compute.Spec.SSHKeySecretName})
 			th.ExpectConditionWithDetails(
-				computeName,
+				novaNames.ComputeName,
 				ConditionGetterFunc(NovaExternalComputeConditionGetter),
 				condition.InputReadyCondition,
 				corev1.ConditionFalse,
 				condition.ErrorReason,
 				"Input data error occurred field 'ssh-privatekey' not found in secret/"+compute.Spec.SSHKeySecretName,
 			)
-			compute = GetNovaExternalCompute(computeName)
+			compute = GetNovaExternalCompute(novaNames.ComputeName)
 			Expect(compute.Status.Hash["input"]).To(BeEmpty())
 		})
 	})
@@ -253,18 +221,21 @@ var _ = Describe("NovaExternalCompute", func() {
 	When("created but NovaCell is not Ready", func() {
 		BeforeEach(func() {
 			// Create the compute
-			instance := CreateNovaExternalCompute(computeName, GetDefaultNovaExternalComputeSpec(novaName.Name, computeName.Name))
-			DeferCleanup(th.DeleteInstance, instance)
-			compute := GetNovaExternalCompute(computeName)
+			DeferCleanup(
+				th.DeleteInstance,
+				CreateNovaExternalCompute(
+					novaNames.ComputeName,
+					GetDefaultNovaExternalComputeSpec(novaNames.NovaName.Name, novaNames.ComputeName.Name)))
+			compute := GetNovaExternalCompute(novaNames.ComputeName)
 			inventoryName := types.NamespacedName{
-				Namespace: namespace,
+				Namespace: novaNames.ComputeName.Namespace,
 				Name:      compute.Spec.InventoryConfigMapName,
 			}
 			CreateNovaExternalComputeInventoryConfigMap(inventoryName)
 			DeferCleanup(th.DeleteSecret, inventoryName)
 
 			sshSecretName := types.NamespacedName{
-				Namespace: namespace,
+				Namespace: novaNames.ComputeName.Namespace,
 				Name:      compute.Spec.SSHKeySecretName,
 			}
 			CreateNovaExternalComputeSSHSecret(sshSecretName)
@@ -273,12 +244,12 @@ var _ = Describe("NovaExternalCompute", func() {
 
 		It("reports if NovaCell is missing", func() {
 			th.ExpectConditionWithDetails(
-				computeName,
+				novaNames.ComputeName,
 				ConditionGetterFunc(NovaExternalComputeConditionGetter),
 				novav1.NovaCellReadyCondition,
 				corev1.ConditionFalse,
 				condition.RequestedReason,
-				"Waiting for NovaCell "+novaCellName.Name+" to exists",
+				"Waiting for NovaCell "+cell1.CellName.Name+" to exists",
 			)
 		})
 
@@ -287,55 +258,59 @@ var _ = Describe("NovaExternalCompute", func() {
 			// deployment success
 			spec := GetDefaultNovaCellSpec()
 			spec["cellName"] = "cell1"
-			instance := CreateNovaCell(novaCellName, spec)
+			instance := CreateNovaCell(cell1.CellName, spec)
 
 			DeferCleanup(th.DeleteInstance, instance)
 
 			th.ExpectConditionWithDetails(
-				computeName,
+				novaNames.ComputeName,
 				ConditionGetterFunc(NovaExternalComputeConditionGetter),
 				novav1.NovaCellReadyCondition,
 				corev1.ConditionFalse,
 				condition.RequestedReason,
-				"Waiting for NovaCell "+novaCellName.Name+" to become Ready",
+				"Waiting for NovaCell "+cell1.CellName.Name+" to become Ready",
 			)
 		})
 	})
 	When("inventory is reconfigured to a non existing ConfigMap", func() {
 		BeforeEach(func() {
 			// Create the NovaCell the compute will belong to
-			CreateNovaCellAndEnsureReady(namespace, novaCellName)
+			CreateNovaCellAndEnsureReady(cell1)
 			// Create the compute
-			instance := CreateNovaExternalCompute(computeName, GetDefaultNovaExternalComputeSpec(novaName.Name, computeName.Name))
-			DeferCleanup(th.DeleteInstance, instance)
-			compute := GetNovaExternalCompute(computeName)
+			DeferCleanup(
+				th.DeleteInstance,
+				CreateNovaExternalCompute(
+					novaNames.ComputeName,
+					GetDefaultNovaExternalComputeSpec(novaNames.NovaName.Name, novaNames.ComputeName.Name)))
+
+			compute := GetNovaExternalCompute(novaNames.ComputeName)
 			inventoryName := types.NamespacedName{
-				Namespace: namespace,
+				Namespace: novaNames.ComputeName.Namespace,
 				Name:      compute.Spec.InventoryConfigMapName,
 			}
 			CreateNovaExternalComputeInventoryConfigMap(inventoryName)
 			DeferCleanup(th.DeleteConfigMap, inventoryName)
 
 			sshSecretName := types.NamespacedName{
-				Namespace: namespace,
+				Namespace: novaNames.ComputeName.Namespace,
 				Name:      compute.Spec.SSHKeySecretName,
 			}
 			CreateNovaExternalComputeSSHSecret(sshSecretName)
 			DeferCleanup(th.DeleteSecret, sshSecretName)
 
 			libvirtAEEName := types.NamespacedName{
-				Namespace: namespace,
+				Namespace: novaNames.ComputeName.Namespace,
 				Name:      fmt.Sprintf("%s-%s-deploy-libvirt", compute.Spec.NovaInstance, compute.Name),
 			}
 			SimulateAEESucceeded(libvirtAEEName)
 			novaAEEName := types.NamespacedName{
-				Namespace: namespace,
+				Namespace: novaNames.ComputeName.Namespace,
 				Name:      fmt.Sprintf("%s-%s-deploy-nova", compute.Spec.NovaInstance, compute.Name),
 			}
 			SimulateAEESucceeded(novaAEEName)
 
 			th.ExpectCondition(
-				computeName,
+				novaNames.ComputeName,
 				ConditionGetterFunc(NovaExternalComputeConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionTrue,
@@ -344,14 +319,14 @@ var _ = Describe("NovaExternalCompute", func() {
 
 		It("reports that the inventory is missing", func() {
 			Eventually(func(g Gomega) {
-				compute := GetNovaExternalCompute(computeName)
+				compute := GetNovaExternalCompute(novaNames.ComputeName)
 				compute.Spec.InventoryConfigMapName = "non-existent"
 				err := k8sClient.Update(ctx, compute)
 				g.Expect(err == nil || k8s_errors.IsConflict(err)).To(BeTrue())
 			}, timeout, interval).Should(Succeed())
 
 			th.ExpectConditionWithDetails(
-				computeName,
+				novaNames.ComputeName,
 				ConditionGetterFunc(NovaExternalComputeConditionGetter),
 				condition.InputReadyCondition,
 				corev1.ConditionFalse,
@@ -359,7 +334,7 @@ var _ = Describe("NovaExternalCompute", func() {
 				"Input data resources missing: configmap/non-existent",
 			)
 			th.ExpectCondition(
-				computeName,
+				novaNames.ComputeName,
 				ConditionGetterFunc(NovaExternalComputeConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionFalse,
@@ -368,8 +343,8 @@ var _ = Describe("NovaExternalCompute", func() {
 	})
 	When("created as unstructured and created from golang", func() {
 		It("has the same defaults", func() {
-			computeNameUnstructured := types.NamespacedName{Namespace: computeName.Namespace, Name: "compute-default-unstructured"}
-			computeNameGolang := types.NamespacedName{Namespace: computeName.Namespace, Name: "compute-default-golang"}
+			computeNameUnstructured := types.NamespacedName{Namespace: novaNames.ComputeName.Namespace, Name: "compute-default-unstructured"}
+			computeNameGolang := types.NamespacedName{Namespace: novaNames.ComputeName.Namespace, Name: "compute-default-golang"}
 			CreateNovaExternalCompute(
 				computeNameUnstructured,
 				map[string]interface{}{

--- a/test/functional/sample_test.go
+++ b/test/functional/sample_test.go
@@ -19,7 +19,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"gopkg.in/yaml.v3"
@@ -38,53 +37,42 @@ func ReadSample(sampleFileName string) map[string]interface{} {
 	return rawSample
 }
 
-func CreateNovaFromSample(sampleFileName string, namespace string) types.NamespacedName {
-	novaName := types.NamespacedName{
-		Namespace: namespace,
-		Name:      uuid.New().String(),
-	}
-
+func CreateNovaFromSample(sampleFileName string, name types.NamespacedName) types.NamespacedName {
 	raw := ReadSample(sampleFileName)
-	DeferCleanup(th.DeleteInstance, CreateNova(novaName, raw["spec"].(map[string]interface{})))
-	return novaName
-}
-
-func CreateNovaAPIFromSample(sampleFileName string, namespace string) types.NamespacedName {
-	raw := ReadSample(sampleFileName)
-	instance := CreateNovaAPI(namespace, raw["spec"].(map[string]interface{}))
-	name := types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
+	instance := CreateNova(name, raw["spec"].(map[string]interface{}))
 	DeferCleanup(th.DeleteInstance, instance)
-	return name
+	return types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
 }
 
-func CreateNovaCellFromSample(sampleFileName string, namespace string) types.NamespacedName {
+func CreateNovaAPIFromSample(sampleFileName string, name types.NamespacedName) types.NamespacedName {
+	raw := ReadSample(sampleFileName)
+	instance := CreateNovaAPI(name, raw["spec"].(map[string]interface{}))
+	DeferCleanup(th.DeleteInstance, instance)
+	return types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
+}
+
+func CreateNovaCellFromSample(sampleFileName string, name types.NamespacedName) types.NamespacedName {
 	raw := ReadSample(sampleFileName)
 	instance := CreateNovaCell(
-		types.NamespacedName{Namespace: namespace, Name: uuid.NewString()},
+		name,
 		raw["spec"].(map[string]interface{}),
 	)
 	DeferCleanup(th.DeleteInstance, instance)
 	return types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
 }
 
-func CreateNovaConductorFromSample(sampleFileName string, namespace string) types.NamespacedName {
+func CreateNovaConductorFromSample(sampleFileName string, name types.NamespacedName) types.NamespacedName {
 	raw := ReadSample(sampleFileName)
-	instance := CreateNovaConductor(namespace, raw["spec"].(map[string]interface{}))
-	name := types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
+	instance := CreateNovaConductor(name, raw["spec"].(map[string]interface{}))
 	DeferCleanup(th.DeleteInstance, instance)
-	return name
+	return types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
 }
 
-func CreateNovaExternalComputeFromSample(sampleFileName string, namespace string) types.NamespacedName {
+func CreateNovaExternalComputeFromSample(sampleFileName string, name types.NamespacedName) types.NamespacedName {
 	raw := ReadSample(sampleFileName)
-	computeName := types.NamespacedName{
-		Namespace: namespace,
-		Name:      uuid.New().String(),
-	}
-
-	compute := CreateNovaExternalCompute(computeName, raw["spec"].(map[string]interface{}))
+	compute := CreateNovaExternalCompute(name, raw["spec"].(map[string]interface{}))
 	DeferCleanup(th.DeleteInstance, compute)
-	return computeName
+	return types.NamespacedName{Name: compute.GetName(), Namespace: compute.GetNamespace()}
 }
 
 // This is a set of test for our samples. It only validates that the sample
@@ -97,61 +85,61 @@ var _ = Describe("Samples", func() {
 
 	When("nova_v1beta1_nova.yaml sample is applied", func() {
 		It("Nova is created", func() {
-			name := CreateNovaFromSample("nova_v1beta1_nova.yaml", namespace)
+			name := CreateNovaFromSample("nova_v1beta1_nova.yaml", novaNames.NovaName)
 			GetNova(name)
 		})
 	})
 	When("nova_v1beta1_nova-multi-cell.yaml sample is applied", func() {
 		It("Nova is created", func() {
-			name := CreateNovaFromSample("nova_v1beta1_nova-multi-cell.yaml", namespace)
+			name := CreateNovaFromSample("nova_v1beta1_nova-multi-cell.yaml", novaNames.NovaName)
 			GetNova(name)
 		})
 	})
 	When("nova_v1beta1_nova_collapsed_cell.yaml sample is applied", func() {
 		It("Nova is created", func() {
-			name := CreateNovaFromSample("nova_v1beta1_nova_collapsed_cell.yaml", namespace)
+			name := CreateNovaFromSample("nova_v1beta1_nova_collapsed_cell.yaml", novaNames.NovaName)
 			GetNova(name)
 		})
 	})
 	When("nova_v1beta1_novaapi.yaml sample is applied", func() {
 		It("NovaAPI is created", func() {
-			name := CreateNovaAPIFromSample("nova_v1beta1_novaapi.yaml", namespace)
+			name := CreateNovaAPIFromSample("nova_v1beta1_novaapi.yaml", novaNames.APIName)
 			GetNovaAPI(name)
 		})
 	})
 	When("nova_v1beta1_novacell0.yaml sample is applied", func() {
 		It("NovaCell is created", func() {
-			name := CreateNovaCellFromSample("nova_v1beta1_novacell0.yaml", namespace)
+			name := CreateNovaCellFromSample("nova_v1beta1_novacell0.yaml", cell0.CellName)
 			GetNovaCell(name)
 		})
 	})
 	When("nova_v1beta1_novacell1-upcall.yaml sample is applied", func() {
 		It("NovaCell is created", func() {
-			name := CreateNovaCellFromSample("nova_v1beta1_novacell1-upcall.yaml", namespace)
+			name := CreateNovaCellFromSample("nova_v1beta1_novacell1-upcall.yaml", cell1.CellName)
 			GetNovaCell(name)
 		})
 	})
 	When("nova_v1beta1_novacell2-without-upcall.yaml sample is applied", func() {
 		It("NovaCell is created", func() {
-			name := CreateNovaCellFromSample("nova_v1beta1_novacell2-without-upcall.yaml", namespace)
+			name := CreateNovaCellFromSample("nova_v1beta1_novacell2-without-upcall.yaml", cell2.CellName)
 			GetNovaCell(name)
 		})
 	})
 	When("nova_v1beta1_novaconductor-super.yaml sample is applied", func() {
 		It("NovaConductor is created", func() {
-			name := CreateNovaConductorFromSample("nova_v1beta1_novaconductor-super.yaml", namespace)
+			name := CreateNovaConductorFromSample("nova_v1beta1_novaconductor-super.yaml", novaNames.ConductorName)
 			GetNovaConductor(name)
 		})
 	})
 	When("nova_v1beta1_novaconductor-cell.yaml sample is applied", func() {
 		It("NovaConductor is created", func() {
-			name := CreateNovaConductorFromSample("nova_v1beta1_novaconductor-cell.yaml", namespace)
+			name := CreateNovaConductorFromSample("nova_v1beta1_novaconductor-cell.yaml", novaNames.ConductorName)
 			GetNovaConductor(name)
 		})
 	})
 	When("nova_v1beta1_novaexternalcompute.yaml sample is applied", func() {
 		It("NovaExternalCompute is created", func() {
-			name := CreateNovaExternalComputeFromSample("nova_v1beta1_novaexternalcompute.yaml", namespace)
+			name := CreateNovaExternalComputeFromSample("nova_v1beta1_novaexternalcompute.yaml", novaNames.ComputeName)
 			GetNovaExternalCompute(name)
 		})
 	})

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -37,6 +37,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -70,7 +71,10 @@ var (
 	cancel    context.CancelFunc
 	logger    logr.Logger
 	th        *TestHelper
-	namespace string
+	novaNames NovaNames
+	cell0     CellNames
+	cell1     CellNames
+	cell2     CellNames
 )
 
 func TestAPIs(t *testing.T) {
@@ -238,9 +242,19 @@ var _ = BeforeEach(func() {
 	// NOTE(gibi): We need to create a unique namespace for each test run
 	// as namespaces cannot be deleted in a locally running envtest. See
 	// https://book.kubebuilder.io/reference/envtest.html#namespace-usage-limitation
-	namespace = uuid.New().String()
+	namespace := uuid.New().String()
 	th.CreateNamespace(namespace)
 	// We still request the delete of the Namespace to properly cleanup if
 	// we run the test in an existing cluster.
 	DeferCleanup(th.DeleteNamespace, namespace)
+
+	novaName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      uuid.New().String(),
+	}
+
+	novaNames = GetNovaNames(novaName, []string{"cell0", "cell1", "cell2"})
+	cell0 = novaNames.Cells["cell0"]
+	cell1 = novaNames.Cells["cell1"]
+	cell2 = novaNames.Cells["cell2"]
 })


### PR DESCRIPTION
Resubmitted https://github.com/openstack-k8s-operators/nova-operator/pull/203 after rebase and extending factoring out for the new things added

The transport URL related change to be dropped as have been extracted https://github.com/openstack-k8s-operators/nova-operator/pull/338

There is clear pattern how the nova-operator names the resources it
creates but we repeating the same naming logic all over our test code.
So this patch moves the naming logic to a single place in the test.

Continue factoring out nova/cell test names
    
Rebase and extend the original factoring out change to the newly
added services and features.
    
Move novaName(s) with a 3 cells names initialization from a generated
namespace uuid into the shared BeforeEach() for all tests.
    
Align individual names prefixes for NovaName/CellName with the internal
Nova controllers logic.
    
Remove no longer needed instance getters as using predictable names,
when instantiating things.
    
Change the common tests initialization of secrets, keystoneAPI etc.
to BecomeAll(), that saves testing time a lot.
    
Extends: Remove duplicated NovaScheduler instance
The NovaScheduler controller test created a NovaScheduler instance
before each test. However there are test cases later in the file that
also creates its own NovaScheduler instance with specific configuration.
So in those tests there are two NovaScheduler instances being
reconciled. This makes troubleshooting the test complex. So this patch
separates the tests with the global NovaScheduler to a deparate Describe
section. So that the rest of the tests can  create its own NovaScheduler
with the needed configuration.
    
Split other Nova services' NADs tests into separate sections as well
(TODO: better naming for the describe sections)
