### PR TITLE
[renovate] run go mod tidy on both mod files

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -38,7 +38,7 @@
     }
   ],
   "postUpgradeTasks": {
-    "commands": ["make gowork", "go mod tidy", "make manifests generate"],
+    "commands": ["make gowork", "make tidy", "make manifests generate"],
     "fileFilters": ["**/go.mod", "**/go.sum", "**/*.go", "**/*.yaml"],
     "executionMode": "update"
   }


### PR DESCRIPTION
Renovate only run `go mod tidy` in the root of the repo and that does not update api/go.mod file. So renovate switched to run make tidy that will run go mod tidy on both mod files in the repo.