### PR TITLE
Fix the zap config in envtest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ PROC_CMD = --procs ${PROCS}
 
 .PHONY: test
 test: manifests generate fmt vet envtest ginkgo ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) -v debug --bin-dir $(LOCALBIN) use $(ENVTEST_K8S_VERSION) -p path)" OPERATOR_TEMPLATES="$(PWD)/templates" OPERATOR_PLAYBOOKS="$(PWD)/playbooks" $(GINKGO) -v --trace --cover --coverpkg=../../pkg/nova,../../pkg/novaapi,../../pkg/novaconductor,../../controllers,../../api/v1beta1 --coverprofile cover.out --covermode=atomic --randomize-all ${PROC_CMD} $(GINKGO_ARGS) ./test/...
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) -v debug --bin-dir $(LOCALBIN) use $(ENVTEST_K8S_VERSION) -p path)" OPERATOR_TEMPLATES="$(PWD)/templates" OPERATOR_PLAYBOOKS="$(PWD)/playbooks" $(GINKGO) --trace --cover --coverpkg=../../pkg/nova,../../pkg/novaapi,../../pkg/novaconductor,../../controllers,../../api/v1beta1,../../pkg/novascheduler,../../pkg/novametadata --coverprofile cover.out --covermode=atomic --randomize-all ${PROC_CMD} $(GINKGO_ARGS) ./test/...
 
 ##@ Build
 

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -74,11 +74,10 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	opts := zap.Options{
-		Development: true,
-		TimeEncoder: zapcore.ISO8601TimeEncoder,
-	}
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true), zap.UseFlagOptions(&opts)))
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true), func(o *zap.Options) {
+		o.Development = true
+		o.TimeEncoder = zapcore.ISO8601TimeEncoder
+	}))
 
 	ctx, cancel = context.WithCancel(context.TODO())
 


### PR DESCRIPTION
The previous config forced verbose mode even if it is not requested via the command line.

Also this patch disables verbose mode in the make test target by default to limit the test output of a successfull run. It can be re-enabled with make test GINKGO_ARGS='-v'.