### PR TITLE
Set metadata_proxy_shared_secret from secret

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -102,7 +102,7 @@ type PasswordSelector struct {
 	// the Secret
 	CellDatabase string `json:"cellDatabase"`
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="NovaMetadataSecret"
+	// +kubebuilder:default="MetadataSecret"
 	// MetadataSecret - the name of the field to get the metadata secret from the
 	// Secret
 	MetadataSecret string `json:"metadataSecret"`

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -101,6 +101,11 @@ type PasswordSelector struct {
 	// CellDatabase - the name of the field to get the Cell DB password from
 	// the Secret
 	CellDatabase string `json:"cellDatabase"`
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default="NovaMetadataSecret"
+	// MetadataSecret - the name of the field to get the metadata secret from the
+	// Secret
+	MetadataSecret string `json:"metadataSecret"`
 }
 
 // MetalLBConfig to configure the MetalLB loadbalancer service

--- a/config/crd/bases/nova.openstack.org_nova.yaml
+++ b/config/crd/bases/nova.openstack.org_nova.yaml
@@ -745,6 +745,11 @@ spec:
                     description: CellDatabase - the name of the field to get the Cell
                       DB password from the Secret
                     type: string
+                  metadataSecret:
+                    default: NovaMetadataSecret
+                    description: MetadataSecret - the name of the field to get the
+                      metadata secret from the Secret
+                    type: string
                   service:
                     default: NovaPassword
                     description: Service - Selector to get the keystone service user

--- a/config/crd/bases/nova.openstack.org_nova.yaml
+++ b/config/crd/bases/nova.openstack.org_nova.yaml
@@ -746,7 +746,7 @@ spec:
                       DB password from the Secret
                     type: string
                   metadataSecret:
-                    default: NovaMetadataSecret
+                    default: MetadataSecret
                     description: MetadataSecret - the name of the field to get the
                       metadata secret from the Secret
                     type: string

--- a/config/crd/bases/nova.openstack.org_novaapis.yaml
+++ b/config/crd/bases/nova.openstack.org_novaapis.yaml
@@ -188,6 +188,11 @@ spec:
                     description: CellDatabase - the name of the field to get the Cell
                       DB password from the Secret
                     type: string
+                  metadataSecret:
+                    default: NovaMetadataSecret
+                    description: MetadataSecret - the name of the field to get the
+                      metadata secret from the Secret
+                    type: string
                   service:
                     default: NovaPassword
                     description: Service - Selector to get the keystone service user

--- a/config/crd/bases/nova.openstack.org_novaapis.yaml
+++ b/config/crd/bases/nova.openstack.org_novaapis.yaml
@@ -189,7 +189,7 @@ spec:
                       DB password from the Secret
                     type: string
                   metadataSecret:
-                    default: NovaMetadataSecret
+                    default: MetadataSecret
                     description: MetadataSecret - the name of the field to get the
                       metadata secret from the Secret
                     type: string

--- a/config/crd/bases/nova.openstack.org_novacells.yaml
+++ b/config/crd/bases/nova.openstack.org_novacells.yaml
@@ -433,7 +433,7 @@ spec:
                       DB password from the Secret
                     type: string
                   metadataSecret:
-                    default: NovaMetadataSecret
+                    default: MetadataSecret
                     description: MetadataSecret - the name of the field to get the
                       metadata secret from the Secret
                     type: string

--- a/config/crd/bases/nova.openstack.org_novacells.yaml
+++ b/config/crd/bases/nova.openstack.org_novacells.yaml
@@ -432,6 +432,11 @@ spec:
                     description: CellDatabase - the name of the field to get the Cell
                       DB password from the Secret
                     type: string
+                  metadataSecret:
+                    default: NovaMetadataSecret
+                    description: MetadataSecret - the name of the field to get the
+                      metadata secret from the Secret
+                    type: string
                   service:
                     default: NovaPassword
                     description: Service - Selector to get the keystone service user

--- a/config/crd/bases/nova.openstack.org_novaconductors.yaml
+++ b/config/crd/bases/nova.openstack.org_novaconductors.yaml
@@ -154,6 +154,11 @@ spec:
                     description: CellDatabase - the name of the field to get the Cell
                       DB password from the Secret
                     type: string
+                  metadataSecret:
+                    default: NovaMetadataSecret
+                    description: MetadataSecret - the name of the field to get the
+                      metadata secret from the Secret
+                    type: string
                   service:
                     default: NovaPassword
                     description: Service - Selector to get the keystone service user

--- a/config/crd/bases/nova.openstack.org_novaconductors.yaml
+++ b/config/crd/bases/nova.openstack.org_novaconductors.yaml
@@ -155,7 +155,7 @@ spec:
                       DB password from the Secret
                     type: string
                   metadataSecret:
-                    default: NovaMetadataSecret
+                    default: MetadataSecret
                     description: MetadataSecret - the name of the field to get the
                       metadata secret from the Secret
                     type: string

--- a/config/crd/bases/nova.openstack.org_novametadata.yaml
+++ b/config/crd/bases/nova.openstack.org_novametadata.yaml
@@ -205,6 +205,11 @@ spec:
                     description: CellDatabase - the name of the field to get the Cell
                       DB password from the Secret
                     type: string
+                  metadataSecret:
+                    default: NovaMetadataSecret
+                    description: MetadataSecret - the name of the field to get the
+                      metadata secret from the Secret
+                    type: string
                   service:
                     default: NovaPassword
                     description: Service - Selector to get the keystone service user

--- a/config/crd/bases/nova.openstack.org_novametadata.yaml
+++ b/config/crd/bases/nova.openstack.org_novametadata.yaml
@@ -206,7 +206,7 @@ spec:
                       DB password from the Secret
                     type: string
                   metadataSecret:
-                    default: NovaMetadataSecret
+                    default: MetadataSecret
                     description: MetadataSecret - the name of the field to get the
                       metadata secret from the Secret
                     type: string

--- a/config/crd/bases/nova.openstack.org_novanovncproxies.yaml
+++ b/config/crd/bases/nova.openstack.org_novanovncproxies.yaml
@@ -139,7 +139,7 @@ spec:
                       DB password from the Secret
                     type: string
                   metadataSecret:
-                    default: NovaMetadataSecret
+                    default: MetadataSecret
                     description: MetadataSecret - the name of the field to get the
                       metadata secret from the Secret
                     type: string

--- a/config/crd/bases/nova.openstack.org_novanovncproxies.yaml
+++ b/config/crd/bases/nova.openstack.org_novanovncproxies.yaml
@@ -138,6 +138,11 @@ spec:
                     description: CellDatabase - the name of the field to get the Cell
                       DB password from the Secret
                     type: string
+                  metadataSecret:
+                    default: NovaMetadataSecret
+                    description: MetadataSecret - the name of the field to get the
+                      metadata secret from the Secret
+                    type: string
                   service:
                     default: NovaPassword
                     description: Service - Selector to get the keystone service user

--- a/config/crd/bases/nova.openstack.org_novaschedulers.yaml
+++ b/config/crd/bases/nova.openstack.org_novaschedulers.yaml
@@ -149,7 +149,7 @@ spec:
                       DB password from the Secret
                     type: string
                   metadataSecret:
-                    default: NovaMetadataSecret
+                    default: MetadataSecret
                     description: MetadataSecret - the name of the field to get the
                       metadata secret from the Secret
                     type: string

--- a/config/crd/bases/nova.openstack.org_novaschedulers.yaml
+++ b/config/crd/bases/nova.openstack.org_novaschedulers.yaml
@@ -148,6 +148,11 @@ spec:
                     description: CellDatabase - the name of the field to get the Cell
                       DB password from the Secret
                     type: string
+                  metadataSecret:
+                    default: NovaMetadataSecret
+                    description: MetadataSecret - the name of the field to get the
+                      metadata secret from the Secret
+                    type: string
                   service:
                     default: NovaPassword
                     description: Service - Selector to get the keystone service user

--- a/controllers/novaapi_controller.go
+++ b/controllers/novaapi_controller.go
@@ -164,7 +164,6 @@ func (r *NovaAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 			instance.Spec.PasswordSelectors.APIDatabase,
 			instance.Spec.PasswordSelectors.Service,
 			instance.Spec.PasswordSelectors.CellDatabase,
-			instance.Spec.PasswordSelectors.MetadataSecret,
 		},
 		h.GetClient(),
 		&instance.Status.Conditions,
@@ -363,7 +362,6 @@ func (r *NovaAPIReconciler) generateConfigs(
 		"default_project_domain": "Default",   // fixme
 		"default_user_domain":    "Default",   // fixme
 		"transport_url":          string(apiMessageBusSecret.Data["transport_url"]),
-		"metadata_secret":        string(secret.Data[instance.Spec.PasswordSelectors.MetadataSecret]),
 		"log_file":               "/var/log/nova/nova-api.log",
 	}
 	extraData := map[string]string{}

--- a/controllers/novaapi_controller.go
+++ b/controllers/novaapi_controller.go
@@ -164,6 +164,7 @@ func (r *NovaAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 			instance.Spec.PasswordSelectors.APIDatabase,
 			instance.Spec.PasswordSelectors.Service,
 			instance.Spec.PasswordSelectors.CellDatabase,
+			instance.Spec.PasswordSelectors.MetadataSecret,
 		},
 		h.GetClient(),
 		&instance.Status.Conditions,
@@ -362,7 +363,7 @@ func (r *NovaAPIReconciler) generateConfigs(
 		"default_project_domain": "Default",   // fixme
 		"default_user_domain":    "Default",   // fixme
 		"transport_url":          string(apiMessageBusSecret.Data["transport_url"]),
-		"metadata_secret":        "42", // fixme
+		"metadata_secret":        string(secret.Data[instance.Spec.PasswordSelectors.MetadataSecret]),
 		"log_file":               "/var/log/nova/nova-api.log",
 	}
 	extraData := map[string]string{}

--- a/controllers/novametadata_controller.go
+++ b/controllers/novametadata_controller.go
@@ -140,6 +140,7 @@ func (r *NovaMetadataReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			instance.Spec.PasswordSelectors.APIDatabase,
 			instance.Spec.PasswordSelectors.Service,
 			instance.Spec.PasswordSelectors.CellDatabase,
+			instance.Spec.PasswordSelectors.MetadataSecret,
 		},
 		h.GetClient(),
 		&instance.Status.Conditions,
@@ -318,7 +319,7 @@ func (r *NovaMetadataReconciler) generateConfigs(
 		"openstack_region_name":  "regionOne", // fixme
 		"default_project_domain": "Default",   // fixme
 		"default_user_domain":    "Default",   // fixme
-		"metadata_secret":        "42",        // fixme
+		"metadata_secret":        string(secret.Data[instance.Spec.PasswordSelectors.MetadataSecret]),
 		"log_file":               "/var/log/nova/nova-metadata.log",
 		"transport_url":          string(apiMessageBusSecret.Data["transport_url"]),
 	}

--- a/templates/nova.conf
+++ b/templates/nova.conf
@@ -219,7 +219,9 @@ password = {{ .nova_keystone_password }}
 cafile = {{ .openstack_cacert }}
 region_name = {{ .openstack_region_name }}
 valid_interfaces = internal
+{{if eq .service_name "nova-metadata"}}
 metadata_proxy_shared_secret = {{ .metadata_secret }}
+{{end}}
 service_metadata_proxy = true
 
 [cinder]

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -40,8 +40,7 @@ const (
 	SecretName           = "test-secret"
 	MessageBusSecretName = "rabbitmq-secret"
 	ContainerImage       = "test://nova"
-
-	timeout = 10 * time.Second
+	timeout              = 10 * time.Second
 	// have maximum 100 retries before the timeout hits
 	interval = timeout / 100
 	// consistencyTimeout is the amount of time we use to repeatedly check
@@ -66,8 +65,7 @@ func GetDefaultNovaAPISpec() map[string]interface{} {
 		"apiMessageBusSecretName": MessageBusSecretName,
 		"cell0DatabaseHostname":   "nova-cell0-db-hostname",
 		"keystoneAuthURL":         "keystone-auth-url",
-
-		"containerImage": ContainerImage,
+		"containerImage":          ContainerImage,
 	}
 }
 
@@ -133,7 +131,6 @@ func CreateNovaAPISecret(namespace string, name string) *corev1.Secret {
 			"NovaPassword":              []byte("12345678"),
 			"NovaAPIDatabasePassword":   []byte("12345678"),
 			"NovaCell0DatabasePassword": []byte("12345678"),
-			"NovaMetadataSecret":        []byte("12345678"),
 		},
 	)
 }
@@ -349,7 +346,7 @@ func CreateNovaSecret(namespace string, name string) *corev1.Secret {
 			"NovaPassword":              []byte("12345678"),
 			"NovaAPIDatabasePassword":   []byte("12345678"),
 			"NovaCell0DatabasePassword": []byte("12345678"),
-			"NovaMetadataSecret":        []byte("12345678"),
+			"MetadataSecret":            []byte("12345678"),
 		},
 	)
 }
@@ -639,7 +636,7 @@ func CreateNovaMetadataSecret(namespace string, name string) *corev1.Secret {
 			"NovaPassword":              []byte("12345678"),
 			"NovaAPIDatabasePassword":   []byte("12345678"),
 			"NovaCell0DatabasePassword": []byte("12345678"),
-			"NovaMetadataSecret":        []byte("12345678"),
+			"MetadataSecret":            []byte("12345678"),
 		},
 	}
 	Expect(k8sClient.Create(ctx, secret)).Should(Succeed())

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -66,7 +66,8 @@ func GetDefaultNovaAPISpec() map[string]interface{} {
 		"apiMessageBusSecretName": MessageBusSecretName,
 		"cell0DatabaseHostname":   "nova-cell0-db-hostname",
 		"keystoneAuthURL":         "keystone-auth-url",
-		"containerImage":          ContainerImage,
+
+		"containerImage": ContainerImage,
 	}
 }
 
@@ -132,6 +133,7 @@ func CreateNovaAPISecret(namespace string, name string) *corev1.Secret {
 			"NovaPassword":              []byte("12345678"),
 			"NovaAPIDatabasePassword":   []byte("12345678"),
 			"NovaCell0DatabasePassword": []byte("12345678"),
+			"NovaMetadataSecret":        []byte("12345678"),
 		},
 	)
 }
@@ -347,6 +349,7 @@ func CreateNovaSecret(namespace string, name string) *corev1.Secret {
 			"NovaPassword":              []byte("12345678"),
 			"NovaAPIDatabasePassword":   []byte("12345678"),
 			"NovaCell0DatabasePassword": []byte("12345678"),
+			"NovaMetadataSecret":        []byte("12345678"),
 		},
 	)
 }
@@ -636,6 +639,7 @@ func CreateNovaMetadataSecret(namespace string, name string) *corev1.Secret {
 			"NovaPassword":              []byte("12345678"),
 			"NovaAPIDatabasePassword":   []byte("12345678"),
 			"NovaCell0DatabasePassword": []byte("12345678"),
+			"NovaMetadataSecret":        []byte("12345678"),
 		},
 	}
 	Expect(k8sClient.Create(ctx, secret)).Should(Succeed())

--- a/test/functional/nova_metadata_controller_test.go
+++ b/test/functional/nova_metadata_controller_test.go
@@ -181,6 +181,9 @@ var _ = Describe("NovaMetadata controller", func() {
 					HaveKeyWithValue("01-nova.conf",
 						ContainSubstring("transport_url=rabbit://fake")))
 				Expect(configDataMap.Data).Should(
+					HaveKeyWithValue("01-nova.conf",
+						ContainSubstring("metadata_proxy_shared_secret = 12345678")))
+				Expect(configDataMap.Data).Should(
 					HaveKeyWithValue("02-nova-override.conf", "foo=bar"))
 			})
 


### PR DESCRIPTION
Make the metadata_proxy_shared_secret configurable and modify the nova.conf template to set the secret only for nova-metadata. This change will require a follow-up modification in the install_yamls file to set both secrets for nova-metadata and ovn-metadata https://github.com/openstack-k8s-operators/install_yamls/pull/211.