### PR TITLE
Make TransportURL name depend on Nova CR name

### DIFF
--- a/controllers/nova_controller.go
+++ b/controllers/nova_controller.go
@@ -251,7 +251,7 @@ func (r *NovaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 	// message bus is always the same as the top level API message bus so
 	// we create API MQ separately first
 	apiMQSecretName, apiMQStatus, apiMQError := r.ensureMQ(
-		ctx, h, instance, "nova-api-transport", instance.Spec.APIMessageBusInstance)
+		ctx, h, instance, instance.Name+"-api-transport", instance.Spec.APIMessageBusInstance)
 	switch apiMQStatus {
 	case nova.MQFailed:
 		instance.Status.Conditions.Set(condition.FalseCondition(
@@ -272,7 +272,7 @@ func (r *NovaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 		instance.Status.Conditions.MarkTrue(
 			novav1.NovaAPIMQReadyCondition, novav1.NovaAPIMQReadyMessage)
 	default:
-		return ctrl.Result{}, fmt.Errorf("Invalid MessageBusStatus from ensureMQ for the API MQ: %d", apiMQStatus)
+		return ctrl.Result{}, fmt.Errorf("Invalid MessageBusStatus from  for the API MQ: %d", apiMQStatus)
 	}
 
 	cellMQs := map[string]*nova.MessageBus{}
@@ -291,7 +291,7 @@ func (r *NovaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 			err = apiMQError
 		} else {
 			cellMQ, status, err = r.ensureMQ(
-				ctx, h, instance, cellName+"-transport", cellTemplate.CellMessageBusInstance)
+				ctx, h, instance, instance.Name+"-"+cellName+"-transport", cellTemplate.CellMessageBusInstance)
 		}
 		switch status {
 		case nova.MQFailed:

--- a/test/functional/nova_controller_test.go
+++ b/test/functional/nova_controller_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Nova controller", func() {
 		}
 		apiTransportURLName = types.NamespacedName{
 			Namespace: namespace,
-			Name:      "nova-api-transport",
+			Name:      novaName.Name + "-api-transport",
 		}
 		novaSchedulerName = types.NamespacedName{
 			Namespace: namespace,

--- a/test/functional/nova_multicell_test.go
+++ b/test/functional/nova_multicell_test.go
@@ -63,14 +63,14 @@ func NewCell(novaName types.NamespacedName, cell string) Cell {
 		},
 		TransportURLName: types.NamespacedName{
 			Namespace: novaName.Namespace,
-			Name:      cell + "-transport",
+			Name:      novaName.Name + "-" + cell + "-transport",
 		},
 	}
 
 	if cell == "cell0" {
 		c.TransportURLName = types.NamespacedName{
 			Namespace: novaName.Namespace,
-			Name:      "nova-api-transport",
+			Name:      novaName.Name + "-api-transport",
 		}
 	}
 


### PR DESCRIPTION
So far nova-api-transport as TransportURL name was hardcoded. Also the cell TransportURL names only depended on the name of the cell but did not depend on the name of the Nova CR. Now both issue if fixed.

This was initially proposed in #203 but together with a test refactoring. Now the test refactoring is handled in #323