### PR TITLE
Bind all available addresses instead of 0.0.0.0

### DIFF
--- a/templates/novaapi/config/httpd.conf
+++ b/templates/novaapi/config/httpd.conf
@@ -8,7 +8,7 @@ ServerName "localhost.localdomain"
 User apache
 Group apache
 
-Listen 0.0.0.0:8774
+Listen 8774
 
 TypesConfig /etc/mime.types
 

--- a/templates/novametadata/config/httpd.conf
+++ b/templates/novametadata/config/httpd.conf
@@ -8,7 +8,7 @@ ServerName "localhost.localdomain"
 User apache
 Group apache
 
-Listen 0.0.0.0:8775
+Listen 8775
 
 TypesConfig /etc/mime.types
 


### PR DESCRIPTION
... so that api can be accessed even when IPv6 is used for pod networks.