### PR TITLE
Replace TripleO images by TCIB images

### DIFF
--- a/api/v1beta1/novaapi_types.go
+++ b/api/v1beta1/novaapi_types.go
@@ -33,7 +33,7 @@ import (
 // are duplicated.
 type NovaAPITemplate struct {
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="quay.io/tripleozedcentos9/openstack-nova-api:current-tripleo"
+	// +kubebuilder:default="quay.io/podified-antelope-centos9/openstack-nova-api:current-podified"
 	// ContainerImage - The service specific Container Image URL
 	ContainerImage string `json:"containerImage"`
 

--- a/api/v1beta1/novacell_types.go
+++ b/api/v1beta1/novacell_types.go
@@ -55,7 +55,7 @@ type NovaCellTemplate struct {
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={containerImage: "quay.io/tripleozedcentos9/openstack-nova-conductor:current-tripleo"}
+	// +kubebuilder:default={containerImage: "quay.io/podified-antelope-centos9/openstack-nova-conductor:current-podified"}
 	// ConductorServiceTemplate - defines the cell conductor deployment for the cell.
 	ConductorServiceTemplate NovaConductorTemplate `json:"conductorServiceTemplate"`
 

--- a/api/v1beta1/novaconductor_types.go
+++ b/api/v1beta1/novaconductor_types.go
@@ -29,7 +29,7 @@ import (
 // create a NovaConductor via higher level CRDs.
 type NovaConductorTemplate struct {
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="quay.io/tripleozedcentos9/openstack-nova-conductor:current-tripleo"
+	// +kubebuilder:default="quay.io/podified-antelope-centos9/openstack-nova-conductor:current-podified"
 	// The service specific Container Image URL
 	ContainerImage string `json:"containerImage"`
 

--- a/api/v1beta1/novaexternalcompute_types.go
+++ b/api/v1beta1/novaexternalcompute_types.go
@@ -67,12 +67,12 @@ type NovaExternalComputeSpec struct {
 	Deploy bool `json:"deploy"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="quay.io/tripleozedcentos9/openstack-nova-compute:current-tripleo"
+	// +kubebuilder:default="quay.io/podified-antelope-centos9/openstack-nova-compute:current-podified"
 	// NovaComputeContainerImage is the Container Image URL for the nova-compute container
 	NovaComputeContainerImage string `json:"novaComputeContainerImage"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="quay.io/tripleozedcentos9/openstack-nova-libvirt:current-tripleo"
+	// +kubebuilder:default="quay.io/podified-antelope-centos9/openstack-nova-libvirt:current-podified"
 	// NovaLibvirtContainerImage is the Container Image URL for the nova-libvirt container
 	NovaLibvirtContainerImage string `json:"novaLibvirtContainerImage"`
 
@@ -149,8 +149,8 @@ func NewNovaExternalComputeSpec(inventoryConfigMapName string, sshKeySecretName 
 		InventoryConfigMapName:    inventoryConfigMapName,
 		SSHKeySecretName:          sshKeySecretName,
 		Deploy:                    true,
-		NovaComputeContainerImage: "quay.io/tripleozedcentos9/openstack-nova-compute:current-tripleo",
-		NovaLibvirtContainerImage: "quay.io/tripleozedcentos9/openstack-nova-libvirt:current-tripleo",
+		NovaComputeContainerImage: "quay.io/podified-antelope-centos9/openstack-nova-compute:current-podified",
+		NovaLibvirtContainerImage: "quay.io/podified-antelope-centos9/openstack-nova-libvirt:current-podified",
 		AnsibleEEContainerImage:   "quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest",
 		NetworkAttachments:        nil,
 	}

--- a/api/v1beta1/novametadata_types.go
+++ b/api/v1beta1/novametadata_types.go
@@ -29,7 +29,7 @@ import (
 // create a NovaMetadata via higher level CRDs.
 type NovaMetadataTemplate struct {
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="quay.io/tripleozedcentos9/openstack-nova-api:current-tripleo"
+	// +kubebuilder:default="quay.io/podified-antelope-centos9/openstack-nova-api:current-podified"
 	// The service specific Container Image URL
 	ContainerImage string `json:"containerImage"`
 

--- a/api/v1beta1/novanovncproxy_types.go
+++ b/api/v1beta1/novanovncproxy_types.go
@@ -29,7 +29,7 @@ import (
 // create a NovaNoVNCProxy via higher level CRDs.
 type NovaNoVNCProxyTemplate struct {
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="quay.io/tripleozedcentos9/openstack-nova-novncproxy:current-tripleo"
+	// +kubebuilder:default="quay.io/podified-antelope-centos9/openstack-nova-novncproxy:current-podified"
 	// The service specific Container Image URL
 	ContainerImage string `json:"containerImage"`
 

--- a/api/v1beta1/novascheduler_types.go
+++ b/api/v1beta1/novascheduler_types.go
@@ -29,7 +29,7 @@ import (
 // create a NovaScheduler via higher level CRDs.
 type NovaSchedulerTemplate struct {
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="quay.io/tripleozedcentos9/openstack-nova-scheduler:current-tripleo"
+	// +kubebuilder:default="quay.io/podified-antelope-centos9/openstack-nova-scheduler:current-podified"
 	// The service specific Container Image URL
 	ContainerImage string `json:"containerImage"`
 

--- a/config/crd/bases/nova.openstack.org_nova.yaml
+++ b/config/crd/bases/nova.openstack.org_nova.yaml
@@ -57,7 +57,7 @@ spec:
                 description: APIServiceTemplate - define the nova-api service
                 properties:
                   containerImage:
-                    default: quay.io/tripleozedcentos9/openstack-nova-api:current-tripleo
+                    default: quay.io/podified-antelope-centos9/openstack-nova-api:current-podified
                     description: ContainerImage - The service specific Container Image
                       URL
                     type: string
@@ -213,12 +213,12 @@ spec:
                       type: string
                     conductorServiceTemplate:
                       default:
-                        containerImage: quay.io/tripleozedcentos9/openstack-nova-conductor:current-tripleo
+                        containerImage: quay.io/podified-antelope-centos9/openstack-nova-conductor:current-podified
                       description: ConductorServiceTemplate - defines the cell conductor
                         deployment for the cell.
                       properties:
                         containerImage:
-                          default: quay.io/tripleozedcentos9/openstack-nova-conductor:current-tripleo
+                          default: quay.io/podified-antelope-centos9/openstack-nova-conductor:current-podified
                           description: The service specific Container Image URL
                           type: string
                         customServiceConfig:
@@ -317,7 +317,7 @@ spec:
                         service dedicated for the cell.
                       properties:
                         containerImage:
-                          default: quay.io/tripleozedcentos9/openstack-nova-api:current-tripleo
+                          default: quay.io/podified-antelope-centos9/openstack-nova-api:current-podified
                           description: The service specific Container Image URL
                           type: string
                         customServiceConfig:
@@ -455,7 +455,7 @@ spec:
                         service dedicated for the cell.
                       properties:
                         containerImage:
-                          default: quay.io/tripleozedcentos9/openstack-nova-novncproxy:current-tripleo
+                          default: quay.io/podified-antelope-centos9/openstack-nova-novncproxy:current-podified
                           description: The service specific Container Image URL
                           type: string
                         customServiceConfig:
@@ -608,7 +608,7 @@ spec:
                   that is global for the deployment serving all the cells.
                 properties:
                   containerImage:
-                    default: quay.io/tripleozedcentos9/openstack-nova-api:current-tripleo
+                    default: quay.io/podified-antelope-centos9/openstack-nova-api:current-podified
                     description: The service specific Container Image URL
                     type: string
                   customServiceConfig:
@@ -779,7 +779,7 @@ spec:
                 description: SchedulerServiceTemplate- define the nova-scheduler service
                 properties:
                   containerImage:
-                    default: quay.io/tripleozedcentos9/openstack-nova-scheduler:current-tripleo
+                    default: quay.io/podified-antelope-centos9/openstack-nova-scheduler:current-podified
                     description: The service specific Container Image URL
                     type: string
                   customServiceConfig:

--- a/config/crd/bases/nova.openstack.org_novacells.yaml
+++ b/config/crd/bases/nova.openstack.org_novacells.yaml
@@ -71,7 +71,7 @@ spec:
                   deployment for the cell
                 properties:
                   containerImage:
-                    default: quay.io/tripleozedcentos9/openstack-nova-conductor:current-tripleo
+                    default: quay.io/podified-antelope-centos9/openstack-nova-conductor:current-podified
                     description: The service specific Container Image URL
                     type: string
                   customServiceConfig:
@@ -195,7 +195,7 @@ spec:
                   dedicated for the cell.
                 properties:
                   containerImage:
-                    default: quay.io/tripleozedcentos9/openstack-nova-api:current-tripleo
+                    default: quay.io/podified-antelope-centos9/openstack-nova-api:current-podified
                     description: The service specific Container Image URL
                     type: string
                   customServiceConfig:
@@ -331,7 +331,7 @@ spec:
                   dedicated for the cell.
                 properties:
                   containerImage:
-                    default: quay.io/tripleozedcentos9/openstack-nova-novncproxy:current-tripleo
+                    default: quay.io/podified-antelope-centos9/openstack-nova-novncproxy:current-podified
                     description: The service specific Container Image URL
                     type: string
                   customServiceConfig:

--- a/config/crd/bases/nova.openstack.org_novaexternalcomputes.yaml
+++ b/config/crd/bases/nova.openstack.org_novaexternalcomputes.yaml
@@ -80,7 +80,7 @@ spec:
                   type: string
                 type: array
               novaComputeContainerImage:
-                default: quay.io/tripleozedcentos9/openstack-nova-compute:current-tripleo
+                default: quay.io/podified-antelope-centos9/openstack-nova-compute:current-podified
                 description: NovaComputeContainerImage is the Container Image URL
                   for the nova-compute container
                 type: string
@@ -90,7 +90,7 @@ spec:
                   the deployment this compute belongs to
                 type: string
               novaLibvirtContainerImage:
-                default: quay.io/tripleozedcentos9/openstack-nova-libvirt:current-tripleo
+                default: quay.io/podified-antelope-centos9/openstack-nova-libvirt:current-podified
                 description: NovaLibvirtContainerImage is the Container Image URL
                   for the nova-libvirt container
                 type: string

--- a/config/samples/nova_v1beta1_nova-multi-cell.yaml
+++ b/config/samples/nova_v1beta1_nova-multi-cell.yaml
@@ -37,7 +37,7 @@ spec:
     defaultConfigOverwrite:
       logging.conf: |
         # my custom logging configuration
-    containerImage: quay.io/tripleozedcentos9/openstack-nova-api:current-tripleo
+    containerImage: quay.io/podified-antelope-centos9/openstack-nova-api:current-podified
     replicate: 3
     nodeSelector: {}
     resources:
@@ -54,7 +54,7 @@ spec:
     defaultConfigOverwrite:
       policy.yaml: |
         # my custom policy
-    containerImage: quay.io/tripleozedcentos9/openstack-nova-scheduler:current-tripleo
+    containerImage: quay.io/podified-antelope-centos9/openstack-nova-scheduler:current-podified
     replicate: 3
     nodeSelector: {}
     resources:
@@ -76,7 +76,7 @@ spec:
     defaultConfigOverwrite:
       logging.conf: |
         # my custom logging configuration
-    containerImage: quay.io/tripleozedcentos9/openstack-nova-api:current-tripleo
+    containerImage: quay.io/podified-antelope-centos9/openstack-nova-api:current-podified
     replicate: 3
     nodeSelector: {}
     resources:
@@ -103,7 +103,7 @@ spec:
         defaultConfigOverwrite:
           logging.conf: |
           # my custom logging configuration
-        containerImage: quay.io/tripleozedcentos9/openstack-nova-conductor:current-tripleo
+        containerImage: quay.io/podified-antelope-centos9/openstack-nova-conductor:current-podified
         replicate: 3
         nodeSelector: {}
         resources:
@@ -132,7 +132,7 @@ spec:
         defaultConfigOverwrite:
           logging.conf: |
           # my custom logging configuration
-        containerImage: quay.io/tripleozedcentos9/openstack-nova-conductor:current-tripleo
+        containerImage: quay.io/podified-antelope-centos9/openstack-nova-conductor:current-podified
         replicate: 3
         nodeSelector: {}
         resources:
@@ -153,7 +153,7 @@ spec:
         defaultConfigOverwrite:
           logging.conf: |
           # my custom logging configuration
-        containerImage: quay.io/tripleozedcentos9/openstack-nova-novncproxy:current-tripleo
+        containerImage: quay.io/podified-antelope-centos9/openstack-nova-novncproxy:current-podified
         replicate: 3
         nodeSelector: {}
         resources:
@@ -177,7 +177,7 @@ spec:
         defaultConfigOverwrite:
           logging.conf: |
           # my custom logging configuration
-        containerImage: quay.io/tripleozedcentos9/openstack-nova-conductor:current-tripleo
+        containerImage: quay.io/podified-antelope-centos9/openstack-nova-conductor:current-podified
         replicate: 3
         nodeSelector: {}
         resources:
@@ -200,7 +200,7 @@ spec:
           logging.conf: |
             # my custom logging configuration
         # TODO: what is the name of the container for metadata?
-        containerImage: quay.io/tripleozedcentos9/openstack-nova-api:current-tripleo
+        containerImage: quay.io/podified-antelope-centos9/openstack-nova-api:current-podified
         replicate: 3
         nodeSelector: {}
         resources:
@@ -218,7 +218,7 @@ spec:
         defaultConfigOverwrite:
           logging.conf: |
           # my custom logging configuration
-        containerImage: quay.io/tripleozedcentos9/openstack-nova-novncproxy:current-tripleo
+        containerImage: quay.io/podified-antelope-centos9/openstack-nova-novncproxy:current-podified
         replicate: 3
         nodeSelector: {}
         resources:

--- a/config/samples/nova_v1beta1_novaapi.yaml
+++ b/config/samples/nova_v1beta1_novaapi.yaml
@@ -6,6 +6,6 @@ spec:
   apiDatabaseHostname: openstack
   apiMessageBusSecretName: rabbitmq-transport-url-nova-api-transport
   cell0DatabaseHostname: openstack
-  containerImage: quay.io/tripleozedcentos9/openstack-nova-api:current-tripleo
+  containerImage: quay.io/podified-antelope-centos9/openstack-nova-api:current-podified
   keystoneAuthURL: http://keystone-public-openstack.apps-crc.testing
   secret: osp-secret

--- a/config/samples/nova_v1beta1_novaconductor-cell.yaml
+++ b/config/samples/nova_v1beta1_novaconductor-cell.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   cellMessageBusSecretName: rabbitmq-transport-url-cell1-transport
   cellName: cell1
-  containerImage: quay.io/tripleozedcentos9/openstack-nova-conductor:current-tripleo
+  containerImage: quay.io/podified-antelope-centos9/openstack-nova-conductor:current-podified
   keystoneAuthURL: http://keystone-public-openstack.apps-crc.testing
   secret: osp-secret

--- a/config/samples/nova_v1beta1_novaconductor-super.yaml
+++ b/config/samples/nova_v1beta1_novaconductor-super.yaml
@@ -6,6 +6,6 @@ spec:
   apiDatabaseHostname: openstack
   cellMessageBusSecretName: rabbitmq-transport-url-nova-api-transport
   cellName: cell0
-  containerImage: quay.io/tripleozedcentos9/openstack-nova-conductor:current-tripleo
+  containerImage: quay.io/podified-antelope-centos9/openstack-nova-conductor:current-podified
   keystoneAuthURL: http://keystone-public-openstack.apps-crc.testing
   secret: osp-secret

--- a/config/samples/nova_v1beta1_novametadata.yaml
+++ b/config/samples/nova_v1beta1_novametadata.yaml
@@ -7,7 +7,7 @@ spec:
   apiMessageBusSecretName: rabbitmq-transport-url-nova-api-transport
   cellDatabaseHostname: openstack
   cellDatabaseUser: nova_cell0
-  containerImage: quay.io/tripleozedcentos9/openstack-nova-api:current-tripleo
+  containerImage: quay.io/podified-antelope-centos9/openstack-nova-api:current-podified
   keystoneAuthURL: http://keystone-public-openstack.apps-crc.testing
   secret: osp-secret
   apiDatabaseUser: nova_api

--- a/config/samples/nova_v1beta1_novascheduler.yaml
+++ b/config/samples/nova_v1beta1_novascheduler.yaml
@@ -7,7 +7,7 @@ spec:
   apiDatabaseHostname: openstack
   apiMessageBusSecretName: rabbitmq-transport-url-nova-api-transport
   cell0DatabaseHostname: openstack
-  containerImage: quay.io/tripleozedcentos9/openstack-nova-scheduler:current-tripleo
+  containerImage: quay.io/podified-antelope-centos9/openstack-nova-scheduler:current-podified
   keystoneAuthURL: http://keystone-public-openstack.apps-crc.testing
   customServiceConfig: |
     [DEFAULT]

--- a/tools/ansible/inventory/bootstrap-configmap.yaml
+++ b/tools/ansible/inventory/bootstrap-configmap.yaml
@@ -50,7 +50,7 @@ data:
                   edpm_ovn_dbs:
                   - 172.30.251.145
             vars:
-              edpm_ovn_controller_image: quay.io/tripleomastercentos9/openstack-ovn-controller:current-tripleo
+              edpm_ovn_controller_image: quay.io/podified-antelope-centos9/openstack-ovn-controller:current-podified
               gather_facts: false
               enable_debug: false
               # SELinux module


### PR DESCRIPTION
We imported container build tools from TripleO as TCIB[1]. Now we are retiring TripleO and should complete the migration.

[1] https://github.com/openstack-k8s-operators/tcib