### PR TITLE
[envtest]Remove duplicated NovaScheduler instance

### DIFF
--- a/test/functional/nova_scheduler_test.go
+++ b/test/functional/nova_scheduler_test.go
@@ -289,6 +289,15 @@ var _ = Describe("NovaScheduler controller", func() {
 			)
 		})
 	})
+})
+
+var _ = Describe("NovaScheduler controller", func() {
+	var novaSchedulerName types.NamespacedName
+	BeforeEach(func() {
+		DeferCleanup(
+			k8sClient.Delete, ctx, CreateNovaMessageBusSecret(namespace, MessageBusSecretName))
+	})
+
 	When("NovaScheduler is created with networkAttachments", func() {
 		BeforeEach(func() {
 			DeferCleanup(


### PR DESCRIPTION
The NovaScheduler controller test created a NovaScheduler instance
before each test. However there are test cases later in the file that
also creates its own NovaScheduler instance with specific configuration.
So in those tests there are two NovaScheduler instances being
reconciled. This makes troubleshooting the test complex. So this patch
separates the tests with the global NovaScheduler to a deparate Describe
section. So that the rest of the tests can  create its own NovaScheduler
with the needed configuration.