### PR TITLE
Dynamic rbac fixup

### DIFF
--- a/api/v1beta1/novaapi_types.go
+++ b/api/v1beta1/novaapi_types.go
@@ -139,7 +139,6 @@ type NovaAPISpec struct {
 
 	// +kubebuilder:validation:Required
 	// ServiceAccount - service account name used internally to provide Nova services the default SA name
-	// +kubebuilder:default="nova"
 	ServiceAccount string `json:"serviceAccount"`
 }
 

--- a/api/v1beta1/novacell_types.go
+++ b/api/v1beta1/novacell_types.go
@@ -155,7 +155,6 @@ type NovaCellSpec struct {
 
 	// +kubebuilder:validation:Required
 	// ServiceAccount - service account name used internally to provide Nova services the default SA name
-	// +kubebuilder:default=nova
 	ServiceAccount string `json:"serviceAccount"`
 }
 

--- a/api/v1beta1/novaconductor_types.go
+++ b/api/v1beta1/novaconductor_types.go
@@ -137,7 +137,6 @@ type NovaConductorSpec struct {
 
 	// +kubebuilder:validation:Required
 	// ServiceAccount - service account name used internally to provide Nova services the default SA name
-	// +kubebuilder:default=nova
 	ServiceAccount string `json:"serviceAccount"`
 }
 

--- a/api/v1beta1/novametadata_types.go
+++ b/api/v1beta1/novametadata_types.go
@@ -157,7 +157,6 @@ type NovaMetadataSpec struct {
 
 	// +kubebuilder:validation:Required
 	// ServiceAccount - service account name used internally to provide Nova services the default SA name
-	// +kubebuilder:default=nova
 	ServiceAccount string `json:"serviceAccount"`
 }
 

--- a/api/v1beta1/novascheduler_types.go
+++ b/api/v1beta1/novascheduler_types.go
@@ -129,7 +129,6 @@ type NovaSchedulerSpec struct {
 
 	// +kubebuilder:validation:Required
 	// ServiceAccount - service account name used internally to provide Nova services the default SA name
-	// +kubebuilder:default=nova
 	ServiceAccount string `json:"serviceAccount"`
 }
 

--- a/config/crd/bases/nova.openstack.org_novaapis.yaml
+++ b/config/crd/bases/nova.openstack.org_novaapis.yaml
@@ -259,7 +259,6 @@ spec:
                   password information for the nova-api service.
                 type: string
               serviceAccount:
-                default: nova
                 description: ServiceAccount - service account name used internally
                   to provide Nova services the default SA name
                 type: string

--- a/config/crd/bases/nova.openstack.org_novacells.yaml
+++ b/config/crd/bases/nova.openstack.org_novacells.yaml
@@ -456,7 +456,6 @@ spec:
                   password information for the nova cell.
                 type: string
               serviceAccount:
-                default: nova
                 description: ServiceAccount - service account name used internally
                   to provide Nova services the default SA name
                 type: string

--- a/config/crd/bases/nova.openstack.org_novaconductors.yaml
+++ b/config/crd/bases/nova.openstack.org_novaconductors.yaml
@@ -225,7 +225,6 @@ spec:
                   password information for the nova-conductor service.
                 type: string
               serviceAccount:
-                default: nova
                 description: ServiceAccount - service account name used internally
                   to provide Nova services the default SA name
                 type: string

--- a/config/crd/bases/nova.openstack.org_novametadata.yaml
+++ b/config/crd/bases/nova.openstack.org_novametadata.yaml
@@ -276,7 +276,6 @@ spec:
                   password information for the nova-conductor service.
                 type: string
               serviceAccount:
-                default: nova
                 description: ServiceAccount - service account name used internally
                   to provide Nova services the default SA name
                 type: string

--- a/config/crd/bases/nova.openstack.org_novaschedulers.yaml
+++ b/config/crd/bases/nova.openstack.org_novaschedulers.yaml
@@ -219,7 +219,6 @@ spec:
                   password information for the nova-scheduler service.
                 type: string
               serviceAccount:
-                default: nova
                 description: ServiceAccount - service account name used internally
                   to provide Nova services the default SA name
                 type: string

--- a/config/samples/nova_v1beta1_novaapi.yaml
+++ b/config/samples/nova_v1beta1_novaapi.yaml
@@ -9,3 +9,4 @@ spec:
   containerImage: quay.io/podified-antelope-centos9/openstack-nova-api:current-podified
   keystoneAuthURL: http://keystone-public-openstack.apps-crc.testing
   secret: osp-secret
+  serviceAccount: nova

--- a/config/samples/nova_v1beta1_novacell0.yaml
+++ b/config/samples/nova_v1beta1_novacell0.yaml
@@ -12,3 +12,4 @@ spec:
   keystoneAuthURL: http://keystone-public-openstack.apps-crc.testing
   noVNCProxyServiceTemplate: {}
   secret: osp-secret
+  serviceAccount: nova

--- a/config/samples/nova_v1beta1_novacell1-upcall.yaml
+++ b/config/samples/nova_v1beta1_novacell1-upcall.yaml
@@ -12,3 +12,4 @@ spec:
   keystoneAuthURL: http://keystone-public-openstack.apps-crc.testing
   noVNCProxyServiceTemplate: {}
   secret: osp-secret
+  serviceAccount: nova

--- a/config/samples/nova_v1beta1_novacell2-without-upcall.yaml
+++ b/config/samples/nova_v1beta1_novacell2-without-upcall.yaml
@@ -10,3 +10,4 @@ spec:
   keystoneAuthURL: http://keystone-public-openstack.apps-crc.testing
   noVNCProxyServiceTemplate: {}
   secret: osp-secret
+  serviceAccount: nova

--- a/config/samples/nova_v1beta1_novaconductor-cell.yaml
+++ b/config/samples/nova_v1beta1_novaconductor-cell.yaml
@@ -8,3 +8,4 @@ spec:
   containerImage: quay.io/podified-antelope-centos9/openstack-nova-conductor:current-podified
   keystoneAuthURL: http://keystone-public-openstack.apps-crc.testing
   secret: osp-secret
+  serviceAccount: nova

--- a/config/samples/nova_v1beta1_novaconductor-super.yaml
+++ b/config/samples/nova_v1beta1_novaconductor-super.yaml
@@ -9,3 +9,4 @@ spec:
   containerImage: quay.io/podified-antelope-centos9/openstack-nova-conductor:current-podified
   keystoneAuthURL: http://keystone-public-openstack.apps-crc.testing
   secret: osp-secret
+  serviceAccount: nova

--- a/config/samples/nova_v1beta1_novametadata.yaml
+++ b/config/samples/nova_v1beta1_novametadata.yaml
@@ -11,3 +11,4 @@ spec:
   keystoneAuthURL: http://keystone-public-openstack.apps-crc.testing
   secret: osp-secret
   apiDatabaseUser: nova_api
+  serviceAccount: nova

--- a/config/samples/nova_v1beta1_novascheduler.yaml
+++ b/config/samples/nova_v1beta1_novascheduler.yaml
@@ -12,3 +12,4 @@ spec:
   customServiceConfig: |
     [DEFAULT]
     debug=true
+  serviceAccount: nova

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -34,6 +34,7 @@ import (
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	novav1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
 	aee "github.com/openstack-k8s-operators/openstack-ansibleee-operator/api/v1alpha1"
+	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 const (
@@ -658,4 +659,28 @@ func GetDefaultNovaMetadataSpec() map[string]interface{} {
 		"keystoneAuthURL":         "keystone-auth-url",
 		"serviceAccount":          "nova",
 	}
+}
+
+func GetServiceAccount(name types.NamespacedName) *corev1.ServiceAccount {
+	instance := &corev1.ServiceAccount{}
+	Eventually(func(g Gomega) {
+		g.Expect(k8sClient.Get(ctx, name, instance)).Should(Succeed())
+	}, timeout, interval).Should(Succeed())
+	return instance
+}
+
+func GetRole(name types.NamespacedName) *rbacv1.Role {
+	instance := &rbacv1.Role{}
+	Eventually(func(g Gomega) {
+		g.Expect(k8sClient.Get(ctx, name, instance)).Should(Succeed())
+	}, timeout, interval).Should(Succeed())
+	return instance
+}
+
+func GetRoleBinding(name types.NamespacedName) *rbacv1.RoleBinding {
+	instance := &rbacv1.RoleBinding{}
+	Eventually(func(g Gomega) {
+		g.Expect(k8sClient.Get(ctx, name, instance)).Should(Succeed())
+	}, timeout, interval).Should(Succeed())
+	return instance
 }

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -66,6 +66,7 @@ func GetDefaultNovaAPISpec() map[string]interface{} {
 		"cell0DatabaseHostname":   "nova-cell0-db-hostname",
 		"keystoneAuthURL":         "keystone-auth-url",
 		"containerImage":          ContainerImage,
+		"serviceAccount":          "nova",
 	}
 }
 
@@ -241,6 +242,7 @@ func GetDefaultNovaConductorSpec() map[string]interface{} {
 		"cellMessageBusSecretName": MessageBusSecretName,
 		"containerImage":           ContainerImage,
 		"keystoneAuthURL":          "keystone-auth-url",
+		"serviceAccount":           "nova",
 	}
 }
 
@@ -302,6 +304,7 @@ func GetDefaultNovaCellSpec() map[string]interface{} {
 		"keystoneAuthURL":           "keystone-auth-url",
 		"conductorServiceTemplate":  map[string]interface{}{},
 		"noVNCProxyServiceTemplate": map[string]interface{}{},
+		"serviceAccount":            "nova",
 	}
 }
 
@@ -385,6 +388,7 @@ func GetDefaultNovaSchedulerSpec() map[string]interface{} {
 		"cell0DatabaseHostname":   "nova-cell0-db-hostname",
 		"keystoneAuthURL":         "keystone-auth-url",
 		"containerImage":          ContainerImage,
+		"serviceAccount":          "nova",
 	}
 }
 
@@ -652,5 +656,6 @@ func GetDefaultNovaMetadataSpec() map[string]interface{} {
 		"cellDatabaseHostname":    "nova-cell-db-hostname",
 		"containerImage":          ContainerImage,
 		"keystoneAuthURL":         "keystone-auth-url",
+		"serviceAccount":          "nova",
 	}
 }

--- a/test/functional/nova_controller_test.go
+++ b/test/functional/nova_controller_test.go
@@ -46,6 +46,7 @@ var _ = Describe("Nova controller", func() {
 	var novaSchedulerStatefulSetName types.NamespacedName
 	var novaMetadataName types.NamespacedName
 	var novaMetadataStatefulSetName types.NamespacedName
+	var novaServiceAccountName string
 
 	BeforeEach(func() {
 		// Uncomment this if you need the full output in the logs from gomega
@@ -116,6 +117,7 @@ var _ = Describe("Nova controller", func() {
 			Namespace: namespace,
 			Name:      novaMetadataName.Name,
 		}
+		novaServiceAccountName = "nova-" + novaName.Name
 	})
 
 	When("Nova CR instance is created without cell0", func() {
@@ -266,10 +268,12 @@ var _ = Describe("Nova controller", func() {
 			cell := GetNovaCell(cell0Name)
 			Expect(cell.Spec.CellMessageBusSecretName).To(Equal("rabbitmq-secret"))
 			Expect(cell.Spec.ServiceUser).To(Equal("nova"))
+			Expect(cell.Spec.ServiceAccount).To(Equal(novaServiceAccountName))
 
 			conductor := GetNovaConductor(cell0ConductorName)
 			Expect(conductor.Spec.CellMessageBusSecretName).To(Equal("rabbitmq-secret"))
 			Expect(conductor.Spec.ServiceUser).To(Equal("nova"))
+			Expect(conductor.Spec.ServiceAccount).To(Equal(novaServiceAccountName))
 
 			th.ExpectCondition(
 				cell0ConductorName,
@@ -313,6 +317,7 @@ var _ = Describe("Nova controller", func() {
 			api := GetNovaAPI(novaAPIName)
 			Expect(api.Spec.APIMessageBusSecretName).To(Equal("rabbitmq-secret"))
 			Expect(api.Spec.ServiceUser).To(Equal("nova"))
+			Expect(api.Spec.ServiceAccount).To(Equal(novaServiceAccountName))
 
 			th.SimulateStatefulSetReplicaReady(novaAPIdeploymentName)
 			th.SimulateKeystoneEndpointReady(novaAPIKeystoneEndpointName)
@@ -349,6 +354,8 @@ var _ = Describe("Nova controller", func() {
 
 			scheduler := GetNovaScheduler(novaSchedulerName)
 			Expect(scheduler.Spec.APIMessageBusSecretName).To(Equal("rabbitmq-secret"))
+			Expect(scheduler.Spec.ServiceAccount).To(Equal(novaServiceAccountName))
+
 			th.SimulateStatefulSetReplicaReady(novaSchedulerStatefulSetName)
 
 			th.ExpectCondition(
@@ -383,6 +390,8 @@ var _ = Describe("Nova controller", func() {
 
 			metadata := GetNovaMetadata(novaMetadataName)
 			Expect(metadata.Spec.APIMessageBusSecretName).To(Equal("rabbitmq-secret"))
+			Expect(metadata.Spec.ServiceAccount).To(Equal(novaServiceAccountName))
+
 			th.SimulateStatefulSetReplicaReady(novaMetadataStatefulSetName)
 
 			th.ExpectCondition(

--- a/test/functional/nova_controller_test.go
+++ b/test/functional/nova_controller_test.go
@@ -46,7 +46,9 @@ var _ = Describe("Nova controller", func() {
 	var novaSchedulerStatefulSetName types.NamespacedName
 	var novaMetadataName types.NamespacedName
 	var novaMetadataStatefulSetName types.NamespacedName
-	var novaServiceAccountName string
+	var novaServiceAccountName types.NamespacedName
+	var novaRoleName types.NamespacedName
+	var novaRoleBindingName types.NamespacedName
 
 	BeforeEach(func() {
 		// Uncomment this if you need the full output in the logs from gomega
@@ -117,7 +119,18 @@ var _ = Describe("Nova controller", func() {
 			Namespace: namespace,
 			Name:      novaMetadataName.Name,
 		}
-		novaServiceAccountName = "nova-" + novaName.Name
+		novaServiceAccountName = types.NamespacedName{
+			Namespace: namespace,
+			Name:      "nova-" + novaName.Name,
+		}
+		novaRoleName = types.NamespacedName{
+			Namespace: namespace,
+			Name:      novaServiceAccountName.Name + "-role",
+		}
+		novaRoleBindingName = types.NamespacedName{
+			Namespace: namespace,
+			Name:      novaServiceAccountName.Name + "-rolebinding",
+		}
 	})
 
 	When("Nova CR instance is created without cell0", func() {
@@ -183,6 +196,38 @@ var _ = Describe("Nova controller", func() {
 			}, timeout, interval).Should(Succeed())
 
 			DeferCleanup(DeleteInstance, CreateNovaWithCell0(novaName))
+		})
+
+		It("creates service account, role and rolebindig", func() {
+			th.ExpectCondition(
+				novaName,
+				ConditionGetterFunc(NovaConditionGetter),
+				condition.ServiceAccountReadyCondition,
+				corev1.ConditionTrue,
+			)
+			sa := GetServiceAccount(novaServiceAccountName)
+
+			th.ExpectCondition(
+				novaName,
+				ConditionGetterFunc(NovaConditionGetter),
+				condition.RoleReadyCondition,
+				corev1.ConditionTrue,
+			)
+			role := GetRole(novaRoleName)
+			Expect(role.Rules).To(HaveLen(2))
+			Expect(role.Rules[0].Resources).To(Equal([]string{"securitycontextconstraints"}))
+			Expect(role.Rules[1].Resources).To(Equal([]string{"pods"}))
+
+			th.ExpectCondition(
+				novaName,
+				ConditionGetterFunc(NovaConditionGetter),
+				condition.RoleBindingReadyCondition,
+				corev1.ConditionTrue,
+			)
+			binding := GetRoleBinding(novaRoleBindingName)
+			Expect(binding.RoleRef.Name).To(Equal(role.Name))
+			Expect(binding.Subjects).To(HaveLen(1))
+			Expect(binding.Subjects[0].Name).To(Equal(sa.Name))
 		})
 
 		It("registers nova service to keystone", func() {
@@ -268,12 +313,12 @@ var _ = Describe("Nova controller", func() {
 			cell := GetNovaCell(cell0Name)
 			Expect(cell.Spec.CellMessageBusSecretName).To(Equal("rabbitmq-secret"))
 			Expect(cell.Spec.ServiceUser).To(Equal("nova"))
-			Expect(cell.Spec.ServiceAccount).To(Equal(novaServiceAccountName))
+			Expect(cell.Spec.ServiceAccount).To(Equal(novaServiceAccountName.Name))
 
 			conductor := GetNovaConductor(cell0ConductorName)
 			Expect(conductor.Spec.CellMessageBusSecretName).To(Equal("rabbitmq-secret"))
 			Expect(conductor.Spec.ServiceUser).To(Equal("nova"))
-			Expect(conductor.Spec.ServiceAccount).To(Equal(novaServiceAccountName))
+			Expect(conductor.Spec.ServiceAccount).To(Equal(novaServiceAccountName.Name))
 
 			th.ExpectCondition(
 				cell0ConductorName,
@@ -317,7 +362,7 @@ var _ = Describe("Nova controller", func() {
 			api := GetNovaAPI(novaAPIName)
 			Expect(api.Spec.APIMessageBusSecretName).To(Equal("rabbitmq-secret"))
 			Expect(api.Spec.ServiceUser).To(Equal("nova"))
-			Expect(api.Spec.ServiceAccount).To(Equal(novaServiceAccountName))
+			Expect(api.Spec.ServiceAccount).To(Equal(novaServiceAccountName.Name))
 
 			th.SimulateStatefulSetReplicaReady(novaAPIdeploymentName)
 			th.SimulateKeystoneEndpointReady(novaAPIKeystoneEndpointName)
@@ -354,7 +399,7 @@ var _ = Describe("Nova controller", func() {
 
 			scheduler := GetNovaScheduler(novaSchedulerName)
 			Expect(scheduler.Spec.APIMessageBusSecretName).To(Equal("rabbitmq-secret"))
-			Expect(scheduler.Spec.ServiceAccount).To(Equal(novaServiceAccountName))
+			Expect(scheduler.Spec.ServiceAccount).To(Equal(novaServiceAccountName.Name))
 
 			th.SimulateStatefulSetReplicaReady(novaSchedulerStatefulSetName)
 
@@ -390,7 +435,7 @@ var _ = Describe("Nova controller", func() {
 
 			metadata := GetNovaMetadata(novaMetadataName)
 			Expect(metadata.Spec.APIMessageBusSecretName).To(Equal("rabbitmq-secret"))
-			Expect(metadata.Spec.ServiceAccount).To(Equal(novaServiceAccountName))
+			Expect(metadata.Spec.ServiceAccount).To(Equal(novaServiceAccountName.Name))
 
 			th.SimulateStatefulSetReplicaReady(novaMetadataStatefulSetName)
 

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -32,6 +32,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -148,6 +149,8 @@ var _ = BeforeSuite(func() {
 	err = networkv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 	err = aee.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+	err = rbacv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	//+kubebuilder:scaffold:scheme


### PR DESCRIPTION

* Make ServiceAccount Required in sub CRs
It was only defaulted in https://github.com/openstack-k8s-operators/nova-operator/pull/347 to avoid breaking the test. But semantically we want them to be Required. So this patch removes the default value from the field and update the test to provide ServiceAccount value to sub CRs. Also updates our samples with serviceAccount fields to keep them valid.
* [envtest]Assert ServiceAccount propagation to sub CRs
* [envtest]ServiceAccount, Role, Rolebinding
This patch covers the ServiceAccount, Role, and RoleBinding creation in
nova-controller.
