### PR TITLE
Update cell0 DB Instance name in sample

### DIFF
--- a/config/samples/nova_v1beta1_nova-multi-cell.yaml
+++ b/config/samples/nova_v1beta1_nova-multi-cell.yaml
@@ -53,7 +53,7 @@ spec:
     nodeSelector: {}
   cellTemplates:
     cell0:
-      cellDatabaseInstance: mariadb-cell0
+      cellDatabaseInstance: openstack
       cellDatabaseUser: nova_cell0
       cellMessageBusInstance: rabbitmq
       # cell0 alway needs access to the API DB and MQ as it hosts the super


### PR DESCRIPTION
Update the target database name in the multi-cell config sample to use openstack instead of mariadb-cell0.