### PR TITLE
[envtest]Remove unknown cellName field from template

### DIFF
--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -148,7 +148,6 @@ func GetDefaultNovaSpec() map[string]interface{} {
 
 func GetDefaultNovaCellTemplate() map[string]interface{} {
 	return map[string]interface{}{
-		"cellName":         "cell0",
 		"cellDatabaseUser": "nova_cell0",
 		"hasAPIAccess":     true,
 	}

--- a/test/functional/nova_multicell_test.go
+++ b/test/functional/nova_multicell_test.go
@@ -173,18 +173,15 @@ var _ = Describe("Nova multi cell", func() {
 
 			spec := GetDefaultNovaSpec()
 			cell0 := GetDefaultNovaCellTemplate()
-			cell0["cellName"] = "cell0"
 			cell0["cellDatabaseInstance"] = "db-for-api"
 			cell0["cellDatabaseUser"] = "nova_cell0"
 
 			cell1 := GetDefaultNovaCellTemplate()
-			cell1["cellName"] = "cell1"
 			cell1["cellDatabaseInstance"] = "db-for-cell1"
 			cell1["cellDatabaseUser"] = "nova_cell1"
 			cell1["cellMessageBusInstance"] = "mq-for-cell1"
 
 			cell2 := GetDefaultNovaCellTemplate()
-			cell2["cellName"] = "cell2"
 			cell2["cellDatabaseInstance"] = "db-for-cell2"
 			cell2["cellDatabaseUser"] = "nova_cell2"
 			cell2["cellMessageBusInstance"] = "mq-for-cell2"
@@ -651,7 +648,6 @@ var _ = Describe("Nova multi cell", func() {
 
 			spec := GetDefaultNovaSpec()
 			cell0 := GetDefaultNovaCellTemplate()
-			cell0["cellName"] = "cell0"
 			cell0["cellDatabaseInstance"] = "openstack"
 			cell0["cellDatabaseUser"] = "nova_cell0"
 			cell0["hasAPIAccess"] = true
@@ -664,7 +660,6 @@ var _ = Describe("Nova multi cell", func() {
 			// cell1 is configured to have API access and use the same
 			// message bus as the top level services. Hence cell1 conductor
 			// will act both as a super conductor and as cell1 conductor
-			cell1["cellName"] = "cell1"
 			cell1["cellDatabaseInstance"] = "openstack"
 			cell1["cellDatabaseUser"] = "nova_cell1"
 			cell1["cellMessageBusInstance"] = "mq-for-api"

--- a/test/functional/nova_reconfiguration_test.go
+++ b/test/functional/nova_reconfiguration_test.go
@@ -114,18 +114,15 @@ func CreateNovaWith3CellsAndEnsureReady(namespace string) types.NamespacedName {
 
 	spec := GetDefaultNovaSpec()
 	cell0Template := GetDefaultNovaCellTemplate()
-	cell0Template["cellName"] = "cell0"
 	cell0Template["cellDatabaseInstance"] = "db-for-api"
 	cell0Template["cellDatabaseUser"] = "nova_cell0"
 
 	cell1Template := GetDefaultNovaCellTemplate()
-	cell1Template["cellName"] = "cell1"
 	cell1Template["cellDatabaseInstance"] = "db-for-cell1"
 	cell1Template["cellDatabaseUser"] = "nova_cell1"
 	cell1Template["cellMessageBusInstance"] = "mq-for-cell1"
 
 	cell2Template := GetDefaultNovaCellTemplate()
-	cell2Template["cellName"] = "cell2"
 	cell2Template["cellDatabaseInstance"] = "db-for-cell2"
 	cell2Template["cellDatabaseUser"] = "nova_cell2"
 	cell2Template["cellMessageBusInstance"] = "mq-for-cell2"


### PR DESCRIPTION
The Nova.Spec.CellTemplate[].CellName is not a valid field. It was probably mixed up with NovaCell.Spec.CellName which exists. The k8s client ignores undefined fields so this only caused a warning in the test logs. Still it is better not to have it so now it is removed.