### PR TITLE
always generate the service_user config when deploying nova.

### DIFF
--- a/templates/nova.conf
+++ b/templates/nova.conf
@@ -235,3 +235,14 @@ password = {{ .nova_keystone_password }}
 cafile = {{ .openstack_cacert }}
 region_name = {{ .openstack_region_name }}
 catalog_info = volumev3:cinderv3:internalURL
+
+[service_user]
+send_service_user_token = true
+auth_url = {{ .keystone_internal_url }}
+auth_type = password
+project_domain_name = {{ .default_project_domain }}
+user_domain_name = {{ .default_user_domain}}
+project_name = service
+username = {{ .nova_keystone_user }}
+password = {{ .nova_keystone_password }}
+cafile = {{ .openstack_cacert }}

--- a/test/functional/novaapi_controller_test.go
+++ b/test/functional/novaapi_controller_test.go
@@ -177,6 +177,10 @@ var _ = Describe("NovaAPI controller", func() {
 				Expect(configDataMap.Data).Should(
 					HaveKeyWithValue("01-nova.conf",
 						ContainSubstring("transport_url=rabbit://rabbitmq-secret/fake")))
+				// as of I3629b84d3255a8fe9d8a7cea8c6131d7c40899e8 nova now requires
+				// service_user configuration to work to adress Bug: #2004555
+				Expect(configDataMap.Data).Should(
+					HaveKeyWithValue("01-nova.conf", ContainSubstring("[service_user]")))
 				Expect(configDataMap.Data).Should(
 					HaveKeyWithValue("02-nova-override.conf", "foo=bar"))
 			})


### PR DESCRIPTION
As part of adressing CVE-2023-2088 nova was modifed to required
the service_user to be configured. This change adapts the
config template to enable the service_user section.
see: https://bugs.launchpad.net/nova/+bug/2004555 for details.
