### PR TITLE
Always enable NovaExternalCompute webhook

### DIFF
--- a/main.go
+++ b/main.go
@@ -152,10 +152,6 @@ func main() {
 			setupLog.Error(err, "unable to create webhook", "webhook", "NovaConductor")
 			os.Exit(1)
 		}
-		if err = (&novav1beta1.NovaExternalCompute{}).SetupWebhookWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "NovaExternalCompute")
-			os.Exit(1)
-		}
 		if err = (&novav1beta1.NovaMetadata{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "NovaMetadata")
 			os.Exit(1)
@@ -168,6 +164,14 @@ func main() {
 			setupLog.Error(err, "unable to create webhook", "webhook", "NovaScheduler")
 			os.Exit(1)
 		}
+	}
+
+	// NOTE: HACK: NovaExternalCompute webhooks are always enabled due to a current
+	//             challenge to our pattern posed by NovaExternalCompute usage within
+	//             the Dataplane operator context
+	if err = (&novav1beta1.NovaExternalCompute{}).SetupWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "NovaExternalCompute")
+		os.Exit(1)
 	}
 
 	//+kubebuilder:scaffold:builder


### PR DESCRIPTION
We have discovered a context in which the current webhook pattern used across our operators is not currently viable.  This happens when the DataPlane operator creates a `NovaExternalCompute` CR in the context of an overall deployment via OpenStack operator.  A problem then arises because...

1. The Nova operator is deployed via OpenStack operator and thus the Nova operator webhooks are disabled
2. The DataPlane operator creates a `NovaExternalCompute` CR
3. Because the `NovaExternalCompute` CR comes from the DataPlane operator and not the OpenStack operator, it avoids the OpenStack operator's defaulting webhooks
4. Without the OpenStack operator's defaulting webhooks firing, no default images can be set on the `NovaExternalCompute` CR
5. And also, since the Nova operator webhooks are disabled, no default images are set via that mechanism as well

The stop-gap solution proposed in this PR is to always have the `NovaExternalCompute` webhook enable for the Nova operator, regardless of whether the operator is deployed separately or as part of the OpenStack operator bundle.  We will then take time to think of a potential better solution.