### PR TITLE
Bump nova-api probe timeout

### DIFF
--- a/pkg/novaapi/deployment.go
+++ b/pkg/novaapi/deployment.go
@@ -47,13 +47,13 @@ func StatefulSet(
 	// After the first successful startupProbe, livenessProbe takes over
 	livenessProbe := &corev1.Probe{
 		// TODO might need tuning
-		TimeoutSeconds: 10,
-		PeriodSeconds:  10,
+		TimeoutSeconds: 30,
+		PeriodSeconds:  30,
 	}
 	readinessProbe := &corev1.Probe{
 		// TODO might need tuning
-		TimeoutSeconds: 5,
-		PeriodSeconds:  5,
+		TimeoutSeconds: 30,
+		PeriodSeconds:  30,
 	}
 
 	args := []string{"-c"}


### PR DESCRIPTION
In tempest we saw[1] that a longer nova API request from tempest can block the pod probes resulting in a pod restart. So this patch bumps the timeout values of the probes to see if it mitigates the issue or not.

[1] https://github.com/openstack-k8s-operators/nova-operator/pull/377#issuecomment-1557188218