### PR TITLE
update ceph bind mounts

### DIFF
--- a/templates/libvirt_virtqemud/libvirt-virtqemud.json
+++ b/templates/libvirt_virtqemud/libvirt-virtqemud.json
@@ -6,9 +6,21 @@
             "dest": "/etc/libvirt/virtqemud.conf",
             "owner": "libvirt",
             "perm": "0600"
+        },
+        {
+            "source": "/var/lib/openstack/config/ceph",
+            "dest": "/etc/ceph",
+            "owner": "libvirt:qemu",
+            "perm": "0770",
+            "optional": true
         }
     ],
     "permissions": [
+        {
+            "path": "/etc/ceph/*",
+            "owner": "libvirt:qemu",
+            "perm:": "0660"
+        },
         {
             "path": "/var/log/containers/libvirt",
             "owner": "libvirt:libvirt",

--- a/templates/libvirt_virtqemud/libvirt_virtqemud.json
+++ b/templates/libvirt_virtqemud/libvirt_virtqemud.json
@@ -18,6 +18,6 @@
         "/var/lib/nova:/var/lib/nova",
         "/run/libvirt:/run/libvirt",
         "/dev:/dev",
-        "/etc/ceph:/etc/ceph:ro"
+        "/etc/ceph:/var/lib/openstack/config/ceph:ro"
     ]
   }

--- a/templates/novacompute/nova-compute.json
+++ b/templates/novacompute/nova-compute.json
@@ -19,6 +19,13 @@
             "owner": "nova",
             "perm": "0600",
             "optional": true
+        },
+        {
+            "source": "/var/lib/openstack/config/ceph",
+            "dest": "/etc/ceph",
+            "owner": "nova",
+            "perm": "0700",
+            "optional": true
         }
     ],
     "permissions": [
@@ -26,6 +33,11 @@
             "path": "/var/log/containers/nova",
             "owner": "nova:nova",
             "recurse": true
+        },
+        {
+            "path": "/etc/ceph/*",
+            "owner": "nova:nova",
+            "perm:": "0600"
         },
         {
             "path": "/var/lib/nova",

--- a/templates/novacompute/nova_compute.json
+++ b/templates/novacompute/nova_compute.json
@@ -19,6 +19,6 @@
         "/var/log/containers/nova:/var/log/containers/nova",
         "/var/lib/libvirt:/var/lib/libvirt",
         "/var/lib/nova/:/var/lib/nova/",
-        "/etc/ceph:/etc/ceph:ro"
+        "/etc/ceph:/var/lib/openstack/config/ceph:ro"
     ]
 }


### PR DESCRIPTION
This change ensure we nolonger do a direct passthough of the hosts
/etc/ceph and instead bind it to a read only location and copy
the files with updated permissions to /etc/ceph in the container.

This change is applied to teh nova_compute and libvirt_virtqemud
containers.

Closes: [OSPRH-209](https://issues.redhat.com//browse/OSPRH-209)
Signed-off-by: Sean Mooney <work@seanmooney.info>
