### PR TITLE
Allow skip firewall setup when starting webhooks locally

### DIFF
--- a/hack/configure_local_webhook.sh
+++ b/hack/configure_local_webhook.sh
@@ -5,10 +5,13 @@ TMPDIR=${TMPDIR:-"/tmp/k8s-webhook-server/serving-certs"}
 SKIP_CERT=${SKIP_CERT:-false}
 CRC_IP=${CRC_IP:-$(/sbin/ip -o -4 addr list crc | awk '{print $4}' | cut -d/ -f1)}
 FIREWALL_ZONE=${FIREWALL_ZONE:-"libvirt"}
+SKIP_FIREWALL=${SKIP_FIREWALL:-false}
 
-#Open 9443
-sudo firewall-cmd --zone=${FIREWALL_ZONE} --add-port=9443/tcp
-sudo firewall-cmd --runtime-to-permanent
+if [ "$SKIP_FIREWALL" = false ] ; then
+    #Open 9443
+    sudo firewall-cmd --zone=${FIREWALL_ZONE} --add-port=9443/tcp
+    sudo firewall-cmd --runtime-to-permanent
+fi
 
 # Generate the certs and the ca bundle
 if [ "$SKIP_CERT" = false ] ; then


### PR DESCRIPTION
The hacking/configure_local_webhooks.sh depends on `firewall-cmd` to open a port in the localhost's firewall. This is distro dependent. So this patch makes it possible to skip the firewall setup via an SKIP_FIREWALL ENV variable.

```
  SKIP_FIREWALL=true OPERATOR_TEMPLATES=./templates make run-with-webhook
```