### PR TITLE
Do not left behind AnsibleEE job pods

### DIFF
--- a/controllers/novaexternalcompute_controller.go
+++ b/controllers/novaexternalcompute_controller.go
@@ -602,6 +602,10 @@ func (r *NovaExternalComputeReconciler) ensureAEEDeployLibvirt(
 		_, err = controllerutil.CreateOrPatch(ctx, h.GetClient(), ansibleEE, func() error {
 			initAEE(instance, ansibleEE, "deploy-libvirt.yaml")
 
+			err = controllerutil.SetControllerReference(instance, ansibleEE, h.GetScheme())
+			if err != nil {
+				return err
+			}
 			return nil
 		})
 
@@ -646,6 +650,10 @@ func (r *NovaExternalComputeReconciler) ensureAEEDeployNova(
 		_, err = controllerutil.CreateOrPatch(ctx, h.GetClient(), ansibleEE, func() error {
 			initAEE(instance, ansibleEE, "deploy-nova.yaml")
 
+			err = controllerutil.SetControllerReference(instance, ansibleEE, h.GetScheme())
+			if err != nil {
+				return err
+			}
 			return nil
 		})
 		if err != nil {

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -403,10 +403,17 @@ func CreateNovaExternalComputeSSHSecret(name types.NamespacedName) *corev1.Secre
 
 func GetAEE(name types.NamespacedName) *aee.OpenStackAnsibleEE {
 	instance := &aee.OpenStackAnsibleEE{}
+	novaExt := GetNovaExternalCompute(novaNames.ComputeName)
 
 	Eventually(func(g Gomega) {
 		g.Expect(k8sClient.Get(ctx, name, instance)).Should(Succeed())
 	}, timeout, interval).Should(Succeed())
+
+	Expect(instance.GetOwnerReferences()).To(HaveLen(1))
+	Expect(instance.GetOwnerReferences()[0]).To(HaveField("Name", novaExt.GetName()))
+	t := true
+	Expect(instance.GetOwnerReferences()[0]).To(HaveField("Controller", &t))
+
 	return instance
 }
 


### PR DESCRIPTION
Add nova external compute controller ref to the ansibleEE jobs to not leak them, if the external nova compute CR is deleted, while the AEE job running.

Related: https://github.com/openstack-k8s-operators/nova-operator/issues/319
Closes: https://github.com/openstack-k8s-operators/nova-operator/issues/296

Partial: [OSPRH-148](https://issues.redhat.com//browse/OSPRH-148)