### PR TITLE
Watch Spec.Secret

### DIFF
--- a/api/v1beta1/novaapi_types.go
+++ b/api/v1beta1/novaapi_types.go
@@ -205,3 +205,8 @@ func init() {
 func (s NovaAPIStatus) GetConditions() condition.Conditions {
 	return s.Conditions
 }
+
+// GetSecret returns the value of the NovaAPI.Spec.Secret
+func (n NovaAPI) GetSecret() string {
+	return n.Spec.Secret
+}

--- a/api/v1beta1/novaconductor_types.go
+++ b/api/v1beta1/novaconductor_types.go
@@ -211,3 +211,8 @@ func NewNovaConductorSpec(
 	}
 	return conductorSpec
 }
+
+// GetSecret returns the value of the NovaConductor.Spec.Secret
+func (n NovaConductor) GetSecret() string {
+	return n.Spec.Secret
+}

--- a/api/v1beta1/novametadata_types.go
+++ b/api/v1beta1/novametadata_types.go
@@ -222,15 +222,15 @@ func NewNovaMetadataSpec(
 	novaCell NovaCellSpec,
 ) NovaMetadataSpec {
 	metadataSpec := NovaMetadataSpec{
-		CellName:                 novaCell.CellName,
-		Secret:                   novaCell.Secret,
-		CellDatabaseHostname:     novaCell.CellDatabaseHostname,
-		CellDatabaseUser:         novaCell.CellDatabaseUser,
-		APIDatabaseHostname:      novaCell.APIDatabaseHostname,
-		APIDatabaseUser:          novaCell.APIDatabaseUser,
-		APIMessageBusSecretName:  novaCell.CellMessageBusSecretName,
-		Debug:                    novaCell.Debug,
-		NovaServiceBase:          NovaServiceBase{
+		CellName:                novaCell.CellName,
+		Secret:                  novaCell.Secret,
+		CellDatabaseHostname:    novaCell.CellDatabaseHostname,
+		CellDatabaseUser:        novaCell.CellDatabaseUser,
+		APIDatabaseHostname:     novaCell.APIDatabaseHostname,
+		APIDatabaseUser:         novaCell.APIDatabaseUser,
+		APIMessageBusSecretName: novaCell.CellMessageBusSecretName,
+		Debug:                   novaCell.Debug,
+		NovaServiceBase: NovaServiceBase{
 			ContainerImage:         novaCell.MetadataServiceTemplate.ContainerImage,
 			Replicas:               novaCell.MetadataServiceTemplate.Replicas,
 			NodeSelector:           novaCell.MetadataServiceTemplate.NodeSelector,
@@ -239,9 +239,14 @@ func NewNovaMetadataSpec(
 			Resources:              novaCell.MetadataServiceTemplate.Resources,
 			NetworkAttachments:     novaCell.MetadataServiceTemplate.NetworkAttachments,
 		},
-		KeystoneAuthURL:          novaCell.KeystoneAuthURL,
-		ServiceUser:              novaCell.ServiceUser,
-		PasswordSelectors:        novaCell.PasswordSelectors,
+		KeystoneAuthURL:   novaCell.KeystoneAuthURL,
+		ServiceUser:       novaCell.ServiceUser,
+		PasswordSelectors: novaCell.PasswordSelectors,
 	}
 	return metadataSpec
+}
+
+// GetSecret returns the value of the NovaMetadata.Spec.Secret
+func (n NovaMetadata) GetSecret() string {
+	return n.Spec.Secret
 }

--- a/api/v1beta1/novascheduler_types.go
+++ b/api/v1beta1/novascheduler_types.go
@@ -188,3 +188,8 @@ func init() {
 func (s NovaSchedulerStatus) GetConditions() condition.Conditions {
 	return s.Conditions
 }
+
+// GetSecret returns the value of the NovaScheduler.Spec.Secret
+func (n NovaScheduler) GetSecret() string {
+	return n.Spec.Secret
+}

--- a/controllers/novaapi_controller.go
+++ b/controllers/novaapi_controller.go
@@ -24,8 +24,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	routev1 "github.com/openshift/api/route/v1"
 
@@ -615,6 +619,39 @@ func getAPIServiceLabels() map[string]string {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *NovaAPIReconciler) SetupWithManager(mgr ctrl.Manager) error {
+
+	secretToReconcileReqs := func(o client.Object) []reconcile.Request {
+		var namespace string = o.GetNamespace()
+		var secretName string = o.GetName()
+		result := []reconcile.Request{}
+
+		crs := &novav1.NovaAPIList{}
+		listOpts := []client.ListOption{
+			client.InNamespace(namespace),
+		}
+		if err := r.Client.List(context.TODO(), crs, listOpts...); err != nil {
+			r.Log.Error(err, "Unable to retrieve the list of NovaAPIs")
+			return nil
+		}
+		for _, cr := range crs.Items {
+			if secretName == cr.Spec.Secret {
+				name := client.ObjectKey{
+					Namespace: namespace,
+					Name:      cr.Name,
+				}
+				r.Log.Info(
+					"Requesting reconcile due to secret change",
+					"Secret", secretName, "NovaAPI", cr.Name,
+				)
+				result = append(result, reconcile.Request{NamespacedName: name})
+			}
+		}
+		if len(result) > 0 {
+			return result
+		}
+		return nil
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&novav1.NovaAPI{}).
 		Owns(&v1.StatefulSet{}).
@@ -622,5 +659,10 @@ func (r *NovaAPIReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.ConfigMap{}).
 		Owns(&routev1.Route{}).
 		Owns(&keystonev1.KeystoneEndpoint{}).
+		// NOTE(gibi): If watching for every secret is too much then
+		// we should consider switching to immutable Secret instead of watching
+		// mutable Secrets
+		Watches(&source.Kind{Type: &corev1.Secret{}},
+			handler.EnqueueRequestsFromMapFunc(secretToReconcileReqs)).
 		Complete(r)
 }

--- a/controllers/novaapi_controller.go
+++ b/controllers/novaapi_controller.go
@@ -24,11 +24,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	routev1 "github.com/openshift/api/route/v1"
@@ -619,39 +617,6 @@ func getAPIServiceLabels() map[string]string {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *NovaAPIReconciler) SetupWithManager(mgr ctrl.Manager) error {
-
-	secretToReconcileReqs := func(o client.Object) []reconcile.Request {
-		var namespace string = o.GetNamespace()
-		var secretName string = o.GetName()
-		result := []reconcile.Request{}
-
-		crs := &novav1.NovaAPIList{}
-		listOpts := []client.ListOption{
-			client.InNamespace(namespace),
-		}
-		if err := r.Client.List(context.TODO(), crs, listOpts...); err != nil {
-			r.Log.Error(err, "Unable to retrieve the list of NovaAPIs")
-			return nil
-		}
-		for _, cr := range crs.Items {
-			if secretName == cr.Spec.Secret {
-				name := client.ObjectKey{
-					Namespace: namespace,
-					Name:      cr.Name,
-				}
-				r.Log.Info(
-					"Requesting reconcile due to secret change",
-					"Secret", secretName, "NovaAPI", cr.Name,
-				)
-				result = append(result, reconcile.Request{NamespacedName: name})
-			}
-		}
-		if len(result) > 0 {
-			return result
-		}
-		return nil
-	}
-
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&novav1.NovaAPI{}).
 		Owns(&v1.StatefulSet{}).
@@ -659,10 +624,7 @@ func (r *NovaAPIReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.ConfigMap{}).
 		Owns(&routev1.Route{}).
 		Owns(&keystonev1.KeystoneEndpoint{}).
-		// NOTE(gibi): If watching for every secret is too much then
-		// we should consider switching to immutable Secret instead of watching
-		// mutable Secrets
 		Watches(&source.Kind{Type: &corev1.Secret{}},
-			handler.EnqueueRequestsFromMapFunc(secretToReconcileReqs)).
+			handler.EnqueueRequestsFromMapFunc(r.GetSecretMapperFor(&novav1.NovaAPIList{}))).
 		Complete(r)
 }

--- a/controllers/novaconductor_controller.go
+++ b/controllers/novaconductor_controller.go
@@ -26,10 +26,8 @@ import (
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	common "github.com/openstack-k8s-operators/lib-common/modules/common"
@@ -477,48 +475,12 @@ func (r *NovaConductorReconciler) ensureDeployment(
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *NovaConductorReconciler) SetupWithManager(mgr ctrl.Manager) error {
-
-	secretToReconcileReqs := func(o client.Object) []reconcile.Request {
-		var namespace string = o.GetNamespace()
-		var secretName string = o.GetName()
-		result := []reconcile.Request{}
-
-		crs := &novav1.NovaConductorList{}
-		listOpts := []client.ListOption{
-			client.InNamespace(namespace),
-		}
-		if err := r.Client.List(context.TODO(), crs, listOpts...); err != nil {
-			r.Log.Error(err, "Unable to retrieve the list of NovaConductors")
-			return nil
-		}
-		for _, cr := range crs.Items {
-			if secretName == cr.Spec.Secret {
-				name := client.ObjectKey{
-					Namespace: namespace,
-					Name:      cr.Name,
-				}
-				r.Log.Info(
-					"Requesting reconcile due to secret change",
-					"Secret", secretName, "NovaConductor", cr.Name,
-				)
-				result = append(result, reconcile.Request{NamespacedName: name})
-			}
-		}
-		if len(result) > 0 {
-			return result
-		}
-		return nil
-	}
-
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&novav1.NovaConductor{}).
 		Owns(&v1.StatefulSet{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&batchv1.Job{}).
-		// NOTE(gibi): If watching for every secret is too much then
-		// we should consider switching to immutable Secret instead of watching
-		// mutable Secrets
 		Watches(&source.Kind{Type: &corev1.Secret{}},
-			handler.EnqueueRequestsFromMapFunc(secretToReconcileReqs)).
+			handler.EnqueueRequestsFromMapFunc(r.GetSecretMapperFor(&novav1.NovaConductorList{}))).
 		Complete(r)
 }

--- a/controllers/novaconductor_controller.go
+++ b/controllers/novaconductor_controller.go
@@ -26,7 +26,11 @@ import (
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	common "github.com/openstack-k8s-operators/lib-common/modules/common"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
@@ -473,10 +477,48 @@ func (r *NovaConductorReconciler) ensureDeployment(
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *NovaConductorReconciler) SetupWithManager(mgr ctrl.Manager) error {
+
+	secretToReconcileReqs := func(o client.Object) []reconcile.Request {
+		var namespace string = o.GetNamespace()
+		var secretName string = o.GetName()
+		result := []reconcile.Request{}
+
+		crs := &novav1.NovaConductorList{}
+		listOpts := []client.ListOption{
+			client.InNamespace(namespace),
+		}
+		if err := r.Client.List(context.TODO(), crs, listOpts...); err != nil {
+			r.Log.Error(err, "Unable to retrieve the list of NovaConductors")
+			return nil
+		}
+		for _, cr := range crs.Items {
+			if secretName == cr.Spec.Secret {
+				name := client.ObjectKey{
+					Namespace: namespace,
+					Name:      cr.Name,
+				}
+				r.Log.Info(
+					"Requesting reconcile due to secret change",
+					"Secret", secretName, "NovaConductor", cr.Name,
+				)
+				result = append(result, reconcile.Request{NamespacedName: name})
+			}
+		}
+		if len(result) > 0 {
+			return result
+		}
+		return nil
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&novav1.NovaConductor{}).
 		Owns(&v1.StatefulSet{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&batchv1.Job{}).
+		// NOTE(gibi): If watching for every secret is too much then
+		// we should consider switching to immutable Secret instead of watching
+		// mutable Secrets
+		Watches(&source.Kind{Type: &corev1.Secret{}},
+			handler.EnqueueRequestsFromMapFunc(secretToReconcileReqs)).
 		Complete(r)
 }

--- a/controllers/novametadata_controller.go
+++ b/controllers/novametadata_controller.go
@@ -24,7 +24,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	routev1 "github.com/openshift/api/route/v1"
 
@@ -37,6 +41,7 @@ import (
 	nad "github.com/openstack-k8s-operators/lib-common/modules/common/networkattachment"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/statefulset"
 	util "github.com/openstack-k8s-operators/lib-common/modules/common/util"
+	novav1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
 	novav1beta1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/nova-operator/pkg/novametadata"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
@@ -504,11 +509,49 @@ func getMetadataServiceLabels() map[string]string {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *NovaMetadataReconciler) SetupWithManager(mgr ctrl.Manager) error {
+
+	secretToReconcileReqs := func(o client.Object) []reconcile.Request {
+		var namespace string = o.GetNamespace()
+		var secretName string = o.GetName()
+		result := []reconcile.Request{}
+
+		crs := &novav1.NovaMetadataList{}
+		listOpts := []client.ListOption{
+			client.InNamespace(namespace),
+		}
+		if err := r.Client.List(context.TODO(), crs, listOpts...); err != nil {
+			r.Log.Error(err, "Unable to retrieve the list of NovaMetadata")
+			return nil
+		}
+		for _, cr := range crs.Items {
+			if secretName == cr.Spec.Secret {
+				name := client.ObjectKey{
+					Namespace: namespace,
+					Name:      cr.Name,
+				}
+				r.Log.Info(
+					"Requesting reconcile due to secret change",
+					"Secret", secretName, "NovaMetadata", cr.Name,
+				)
+				result = append(result, reconcile.Request{NamespacedName: name})
+			}
+		}
+		if len(result) > 0 {
+			return result
+		}
+		return nil
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&novav1beta1.NovaMetadata{}).
 		Owns(&v1.StatefulSet{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.Service{}).
 		Owns(&routev1.Route{}).
+		// NOTE(gibi): If watching for every secret is too much then
+		// we should consider switching to immutable Secret instead of watching
+		// mutable Secrets
+		Watches(&source.Kind{Type: &corev1.Secret{}},
+			handler.EnqueueRequestsFromMapFunc(secretToReconcileReqs)).
 		Complete(r)
 }

--- a/controllers/novametadata_controller.go
+++ b/controllers/novametadata_controller.go
@@ -24,10 +24,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	routev1 "github.com/openshift/api/route/v1"
@@ -509,49 +507,13 @@ func getMetadataServiceLabels() map[string]string {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *NovaMetadataReconciler) SetupWithManager(mgr ctrl.Manager) error {
-
-	secretToReconcileReqs := func(o client.Object) []reconcile.Request {
-		var namespace string = o.GetNamespace()
-		var secretName string = o.GetName()
-		result := []reconcile.Request{}
-
-		crs := &novav1.NovaMetadataList{}
-		listOpts := []client.ListOption{
-			client.InNamespace(namespace),
-		}
-		if err := r.Client.List(context.TODO(), crs, listOpts...); err != nil {
-			r.Log.Error(err, "Unable to retrieve the list of NovaMetadata")
-			return nil
-		}
-		for _, cr := range crs.Items {
-			if secretName == cr.Spec.Secret {
-				name := client.ObjectKey{
-					Namespace: namespace,
-					Name:      cr.Name,
-				}
-				r.Log.Info(
-					"Requesting reconcile due to secret change",
-					"Secret", secretName, "NovaMetadata", cr.Name,
-				)
-				result = append(result, reconcile.Request{NamespacedName: name})
-			}
-		}
-		if len(result) > 0 {
-			return result
-		}
-		return nil
-	}
-
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&novav1beta1.NovaMetadata{}).
 		Owns(&v1.StatefulSet{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.Service{}).
 		Owns(&routev1.Route{}).
-		// NOTE(gibi): If watching for every secret is too much then
-		// we should consider switching to immutable Secret instead of watching
-		// mutable Secrets
 		Watches(&source.Kind{Type: &corev1.Secret{}},
-			handler.EnqueueRequestsFromMapFunc(secretToReconcileReqs)).
+			handler.EnqueueRequestsFromMapFunc(r.GetSecretMapperFor(&novav1.NovaMetadataList{}))).
 		Complete(r)
 }

--- a/controllers/novascheduler_controller.go
+++ b/controllers/novascheduler_controller.go
@@ -25,10 +25,8 @@ import (
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	common "github.com/openstack-k8s-operators/lib-common/modules/common"
@@ -195,48 +193,12 @@ func (r *NovaSchedulerReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *NovaSchedulerReconciler) SetupWithManager(mgr ctrl.Manager) error {
-
-	secretToReconcileReqs := func(o client.Object) []reconcile.Request {
-		var namespace string = o.GetNamespace()
-		var secretName string = o.GetName()
-		result := []reconcile.Request{}
-
-		crs := &novav1.NovaSchedulerList{}
-		listOpts := []client.ListOption{
-			client.InNamespace(namespace),
-		}
-		if err := r.Client.List(context.TODO(), crs, listOpts...); err != nil {
-			r.Log.Error(err, "Unable to retrieve the list of NovaScheduler")
-			return nil
-		}
-		for _, cr := range crs.Items {
-			if secretName == cr.Spec.Secret {
-				name := client.ObjectKey{
-					Namespace: namespace,
-					Name:      cr.Name,
-				}
-				r.Log.Info(
-					"Requesting reconcile due to secret change",
-					"Secret", secretName, "NovaScheduler", cr.Name,
-				)
-				result = append(result, reconcile.Request{NamespacedName: name})
-			}
-		}
-		if len(result) > 0 {
-			return result
-		}
-		return nil
-	}
-
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&novav1.NovaScheduler{}).
 		Owns(&v1.StatefulSet{}).
 		Owns(&corev1.ConfigMap{}).
-		// NOTE(gibi): If watching for every secret is too much then
-		// we should consider switching to immutable Secret instead of watching
-		// mutable Secrets
 		Watches(&source.Kind{Type: &corev1.Secret{}},
-			handler.EnqueueRequestsFromMapFunc(secretToReconcileReqs)).
+			handler.EnqueueRequestsFromMapFunc(r.GetSecretMapperFor(&novav1.NovaSchedulerList{}))).
 		Complete(r)
 }
 

--- a/controllers/novascheduler_controller.go
+++ b/controllers/novascheduler_controller.go
@@ -25,7 +25,11 @@ import (
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	common "github.com/openstack-k8s-operators/lib-common/modules/common"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
@@ -191,10 +195,48 @@ func (r *NovaSchedulerReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *NovaSchedulerReconciler) SetupWithManager(mgr ctrl.Manager) error {
+
+	secretToReconcileReqs := func(o client.Object) []reconcile.Request {
+		var namespace string = o.GetNamespace()
+		var secretName string = o.GetName()
+		result := []reconcile.Request{}
+
+		crs := &novav1.NovaSchedulerList{}
+		listOpts := []client.ListOption{
+			client.InNamespace(namespace),
+		}
+		if err := r.Client.List(context.TODO(), crs, listOpts...); err != nil {
+			r.Log.Error(err, "Unable to retrieve the list of NovaScheduler")
+			return nil
+		}
+		for _, cr := range crs.Items {
+			if secretName == cr.Spec.Secret {
+				name := client.ObjectKey{
+					Namespace: namespace,
+					Name:      cr.Name,
+				}
+				r.Log.Info(
+					"Requesting reconcile due to secret change",
+					"Secret", secretName, "NovaScheduler", cr.Name,
+				)
+				result = append(result, reconcile.Request{NamespacedName: name})
+			}
+		}
+		if len(result) > 0 {
+			return result
+		}
+		return nil
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&novav1.NovaScheduler{}).
 		Owns(&v1.StatefulSet{}).
 		Owns(&corev1.ConfigMap{}).
+		// NOTE(gibi): If watching for every secret is too much then
+		// we should consider switching to immutable Secret instead of watching
+		// mutable Secrets
+		Watches(&source.Kind{Type: &corev1.Secret{}},
+			handler.EnqueueRequestsFromMapFunc(secretToReconcileReqs)).
 		Complete(r)
 }
 

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -422,14 +422,15 @@ func SimulateAEESucceeded(name types.NamespacedName) {
 }
 
 type CellNames struct {
-	CellName                 types.NamespacedName
-	MariaDBDatabaseName      types.NamespacedName
-	CellConductorName        types.NamespacedName
-	CellDBSyncJobName        types.NamespacedName
-	ConductorStatefulSetName types.NamespacedName
-	TransportURLName         types.NamespacedName
-	CellMappingJobName       types.NamespacedName
-	MetadataStatefulSetName  types.NamespacedName
+	CellName                    types.NamespacedName
+	MariaDBDatabaseName         types.NamespacedName
+	CellConductorName           types.NamespacedName
+	CellDBSyncJobName           types.NamespacedName
+	ConductorStatefulSetName    types.NamespacedName
+	TransportURLName            types.NamespacedName
+	CellMappingJobName          types.NamespacedName
+	MetadataStatefulSetName     types.NamespacedName
+	CellConductorConfigDataName types.NamespacedName
 }
 
 func GetCellNames(novaName types.NamespacedName, cell string) CellNames {
@@ -464,6 +465,10 @@ func GetCellNames(novaName types.NamespacedName, cell string) CellNames {
 		MetadataStatefulSetName: types.NamespacedName{
 			Namespace: novaName.Namespace,
 			Name:      cellName.Name + "-metadata",
+		},
+		CellConductorConfigDataName: types.NamespacedName{
+			Namespace: novaName.Namespace,
+			Name:      cellConductor.Name + "-config-data",
 		},
 	}
 
@@ -737,4 +742,13 @@ func GetDefaultNovaNoVNCProxySpec() map[string]interface{} {
 		"serviceAccount":       "nova",
 		"cellName":             "cell0",
 	}
+}
+
+func UpdateSecret(secretName types.NamespacedName, key string, newValue []byte) {
+	Eventually(func(g Gomega) {
+		secret := th.GetSecret(secretName)
+		secret.Data[key] = newValue
+		g.Expect(k8sClient.Update(ctx, &secret)).Should(Succeed())
+	}, timeout, interval).Should(Succeed())
+	logger.Info("Secret updated", "secret", secretName, "key", key)
 }


### PR DESCRIPTION
If the content of the Secret pointed by the Nova*.Spec.Secret fields
changes then the given CR will be reconciled. If one of the relevant
passwords in that Secret is changed then the affected nova service
configs are regenerated and the CONFIG_HASH in the statefulsets are
updated to trigger service restart.

Closes: https://issues.redhat.com/browse/OSPRH-215