### PR TITLE
Remove DatabaseUser configurability

### DIFF
--- a/api/v1beta1/nova_types.go
+++ b/api/v1beta1/nova_types.go
@@ -49,7 +49,7 @@ type NovaSpec struct {
 	APIMessageBusInstance string `json:"apiMessageBusInstance"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={cell0: {cellDatabaseUser: nova_cell0, hasAPIAccess: true}, cell1: {cellDatabaseUser: nova_cell1, cellDatabaseInstance: openstack-cell1, cellMessageBusInstance: rabbitmq-cell1, hasAPIAccess: true}}
+	// +kubebuilder:default={cell0: {hasAPIAccess: true}, cell1: {cellDatabaseInstance: openstack-cell1, cellMessageBusInstance: rabbitmq-cell1, hasAPIAccess: true}}
 	// Cells is a mapping of cell names to NovaCellTemplate objects defining
 	// the cells in the deployment. The "cell0" cell is a mandatory cell in
 	// every deployment. Moreover any real deployment needs at least one
@@ -60,11 +60,6 @@ type NovaSpec struct {
 	// +kubebuilder:default="nova"
 	// ServiceUser - optional username used for this service to register in keystone
 	ServiceUser string `json:"serviceUser"`
-
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="nova_api"
-	// APIDatabaseUser - username to use when accessing the API DB
-	APIDatabaseUser string `json:"apiDatabaseUser"`
 
 	// +kubebuilder:validation:Required
 	// Secret is the name of the Secret instance containing password

--- a/api/v1beta1/novaapi_types.go
+++ b/api/v1beta1/novaapi_types.go
@@ -98,11 +98,6 @@ type NovaAPISpec struct {
 	// +kubebuilder:validation:Required
 	KeystoneAuthURL string `json:"keystoneAuthURL"`
 
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="nova_api"
-	// APIDatabaseUser - username to use when accessing the API DB
-	APIDatabaseUser string `json:"apiDatabaseUser"`
-
 	// +kubebuilder:validation:Required
 	// APIDatabaseHostname - hostname to use when accessing the API DB
 	APIDatabaseHostname string `json:"apiDatabaseHostname"`
@@ -112,11 +107,6 @@ type NovaAPISpec struct {
 	// transport URL information to use when accessing the API message
 	// bus.
 	APIMessageBusSecretName string `json:"apiMessageBusSecretName"`
-
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="nova_cell0"
-	// APIDatabaseUser - username to use when accessing the cell0 DB
-	Cell0DatabaseUser string `json:"cell0DatabaseUser"`
 
 	// +kubebuilder:validation:Required
 	// APIDatabaseHostname - hostname to use when accessing the cell0 DB

--- a/api/v1beta1/novacell_types.go
+++ b/api/v1beta1/novacell_types.go
@@ -33,10 +33,6 @@ type NovaCellTemplate struct {
 	// Service instance used as the DB of this cell.
 	CellDatabaseInstance string `json:"cellDatabaseInstance"`
 
-	// +kubebuilder:validation:Required
-	// CellDatabaseUser - username to use when accessing the give cell DB
-	CellDatabaseUser string `json:"cellDatabaseUser"`
-
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=rabbitmq
 	// CellMessageBusInstance is the name of the RabbitMqCluster CR to select
@@ -108,21 +104,11 @@ type NovaCellSpec struct {
 	KeystoneAuthURL string `json:"keystoneAuthURL"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=nova
-	// APIDatabaseUser - username to use when accessing the API DB
-	APIDatabaseUser string `json:"apiDatabaseUser"`
-
-	// +kubebuilder:validation:Optional
 	// APIDatabaseHostname - hostname to use when accessing the API DB. If not
 	// provided then up-calls will be disabled. This filed is Required for
 	// cell0.
 	// TODO(gibi): Add a webhook to validate cell0 constraint
 	APIDatabaseHostname string `json:"apiDatabaseHostname"`
-
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=nova
-	// CellDatabaseUser - username to use when accessing the cell DB
-	CellDatabaseUser string `json:"cellDatabaseUser"`
 
 	// +kubebuilder:validation:Required
 	// CellDatabaseHostname - hostname to use when accessing the cell DB

--- a/api/v1beta1/novaconductor_types.go
+++ b/api/v1beta1/novaconductor_types.go
@@ -97,21 +97,11 @@ type NovaConductorSpec struct {
 	KeystoneAuthURL string `json:"keystoneAuthURL"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=nova
-	// APIDatabaseUser - username to use when accessing the API DB
-	APIDatabaseUser string `json:"apiDatabaseUser"`
-
-	// +kubebuilder:validation:Optional
 	// APIDatabaseHostname - hostname to use when accessing the API DB. If not
 	// provided then up-calls will be disabled. This filed is Required for
 	// cell0.
 	// TODO(gibi): Add a webhook to validate cell0 constraint
 	APIDatabaseHostname string `json:"apiDatabaseHostname"`
-
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=nova
-	// CellDatabaseUser - username to use when accessing the cell DB
-	CellDatabaseUser string `json:"cellDatabaseUser"`
 
 	// +kubebuilder:validation:Optional
 	// NOTE(gibi): This should be Required, see notes in KeystoneAuthURL
@@ -198,9 +188,7 @@ func NewNovaConductorSpec(
 		CellName:                 novaCell.CellName,
 		Secret:                   novaCell.Secret,
 		CellDatabaseHostname:     novaCell.CellDatabaseHostname,
-		CellDatabaseUser:         novaCell.CellDatabaseUser,
 		APIDatabaseHostname:      novaCell.APIDatabaseHostname,
-		APIDatabaseUser:          novaCell.APIDatabaseUser,
 		CellMessageBusSecretName: novaCell.CellMessageBusSecretName,
 		Debug:                    novaCell.Debug,
 		NovaServiceBase:          NovaServiceBase(novaCell.ConductorServiceTemplate),

--- a/api/v1beta1/novametadata_types.go
+++ b/api/v1beta1/novametadata_types.go
@@ -104,20 +104,10 @@ type NovaMetadataSpec struct {
 	KeystoneAuthURL string `json:"keystoneAuthURL"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="nova_api"
-	// APIDatabaseUser - username to use when accessing the API DB
-	APIDatabaseUser string `json:"apiDatabaseUser"`
-
-	// +kubebuilder:validation:Optional
 	// APIDatabaseHostname - hostname to use when accessing the API DB.
 	// This filed is Required if the CellName is not provided
 	// TODO(gibi): Add a webhook to validate the CellName constraint
 	APIDatabaseHostname string `json:"apiDatabaseHostname"`
-
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=nova
-	// CellDatabaseUser - username to use when accessing the cell DB
-	CellDatabaseUser string `json:"cellDatabaseUser"`
 
 	// +kubebuilder:validation:Optional
 	// CellDatabaseHostname - hostname to use when accessing the cell DB
@@ -222,15 +212,13 @@ func NewNovaMetadataSpec(
 	novaCell NovaCellSpec,
 ) NovaMetadataSpec {
 	metadataSpec := NovaMetadataSpec{
-		CellName:                 novaCell.CellName,
-		Secret:                   novaCell.Secret,
-		CellDatabaseHostname:     novaCell.CellDatabaseHostname,
-		CellDatabaseUser:         novaCell.CellDatabaseUser,
-		APIDatabaseHostname:      novaCell.APIDatabaseHostname,
-		APIDatabaseUser:          novaCell.APIDatabaseUser,
-		APIMessageBusSecretName:  novaCell.CellMessageBusSecretName,
-		Debug:                    novaCell.Debug,
-		NovaServiceBase:          NovaServiceBase{
+		CellName:                novaCell.CellName,
+		Secret:                  novaCell.Secret,
+		CellDatabaseHostname:    novaCell.CellDatabaseHostname,
+		APIDatabaseHostname:     novaCell.APIDatabaseHostname,
+		APIMessageBusSecretName: novaCell.CellMessageBusSecretName,
+		Debug:                   novaCell.Debug,
+		NovaServiceBase: NovaServiceBase{
 			ContainerImage:         novaCell.MetadataServiceTemplate.ContainerImage,
 			Replicas:               novaCell.MetadataServiceTemplate.Replicas,
 			NodeSelector:           novaCell.MetadataServiceTemplate.NodeSelector,
@@ -239,9 +227,9 @@ func NewNovaMetadataSpec(
 			Resources:              novaCell.MetadataServiceTemplate.Resources,
 			NetworkAttachments:     novaCell.MetadataServiceTemplate.NetworkAttachments,
 		},
-		KeystoneAuthURL:          novaCell.KeystoneAuthURL,
-		ServiceUser:              novaCell.ServiceUser,
-		PasswordSelectors:        novaCell.PasswordSelectors,
+		KeystoneAuthURL:   novaCell.KeystoneAuthURL,
+		ServiceUser:       novaCell.ServiceUser,
+		PasswordSelectors: novaCell.PasswordSelectors,
 	}
 	return metadataSpec
 }

--- a/api/v1beta1/novanovncproxy_types.go
+++ b/api/v1beta1/novanovncproxy_types.go
@@ -95,11 +95,6 @@ type NovaNoVNCProxySpec struct {
 	// talk to keystone
 	KeystoneAuthURL string `json:"keystoneAuthURL"`
 
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=nova
-	// CellDatabaseUser - username to use when accessing the cell DB
-	CellDatabaseUser string `json:"cellDatabaseUser"`
-
 	// +kubebuilder:validation:Required
 	// CellDatabaseHostname - hostname to use when accessing the cell DB
 	CellDatabaseHostname string `json:"cellDatabaseHostname"`

--- a/api/v1beta1/novascheduler_types.go
+++ b/api/v1beta1/novascheduler_types.go
@@ -92,11 +92,6 @@ type NovaSchedulerSpec struct {
 	// talk to keystone
 	KeystoneAuthURL string `json:"keystoneAuthURL"`
 
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=nova_api
-	// APIDatabaseUser - username to use when accessing the API DB
-	APIDatabaseUser string `json:"apiDatabaseUser"`
-
 	// +kubebuilder:validation:Required
 	// APIDatabaseHostname - hostname to use when accessing the API DB
 	APIDatabaseHostname string `json:"apiDatabaseHostname"`
@@ -106,11 +101,6 @@ type NovaSchedulerSpec struct {
 	// transport URL information to use when accessing the API message
 	// bus.
 	APIMessageBusSecretName string `json:"apiMessageBusSecretName"`
-
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="nova_cell0"
-	// Cell0DatabaseUser - username to use when accessing the cell0 DB
-	Cell0DatabaseUser string `json:"cell0DatabaseUser"`
 
 	// +kubebuilder:validation:Required
 	// Cell0DatabaseHostname - hostname to use when accessing the cell0 DB

--- a/config/crd/bases/nova.openstack.org_nova.yaml
+++ b/config/crd/bases/nova.openstack.org_nova.yaml
@@ -40,11 +40,6 @@ spec:
                 description: APIDatabaseInstance is the name of the MariaDB CR to
                   select the DB Service instance used for the Nova API DB.
                 type: string
-              apiDatabaseUser:
-                default: nova_api
-                description: APIDatabaseUser - username to use when accessing the
-                  API DB
-                type: string
               apiMessageBusInstance:
                 default: rabbitmq
                 description: APIMessageBusInstance is the name of the RabbitMqCluster
@@ -198,10 +193,6 @@ spec:
                       description: CellDatabaseInstance is the name of the MariaDB
                         CR to select the DB Service instance used as the DB of this
                         cell.
-                      type: string
-                    cellDatabaseUser:
-                      description: CellDatabaseUser - username to use when accessing
-                        the give cell DB
                       type: string
                     cellMessageBusInstance:
                       default: rabbitmq
@@ -552,16 +543,13 @@ spec:
                         cell.
                       type: object
                   required:
-                  - cellDatabaseUser
                   - hasAPIAccess
                   type: object
                 default:
                   cell0:
-                    cellDatabaseUser: nova_cell0
                     hasAPIAccess: true
                   cell1:
                     cellDatabaseInstance: openstack-cell1
-                    cellDatabaseUser: nova_cell1
                     cellMessageBusInstance: rabbitmq-cell1
                     hasAPIAccess: true
                 description: Cells is a mapping of cell names to NovaCellTemplate

--- a/config/crd/bases/nova.openstack.org_novaapis.yaml
+++ b/config/crd/bases/nova.openstack.org_novaapis.yaml
@@ -52,11 +52,6 @@ spec:
                 description: APIDatabaseHostname - hostname to use when accessing
                   the API DB
                 type: string
-              apiDatabaseUser:
-                default: nova_api
-                description: APIDatabaseUser - username to use when accessing the
-                  API DB
-                type: string
               apiMessageBusSecretName:
                 description: APIMessageBusSecretName - the name of the Secret conntaining
                   the transport URL information to use when accessing the API message
@@ -65,11 +60,6 @@ spec:
               cell0DatabaseHostname:
                 description: APIDatabaseHostname - hostname to use when accessing
                   the cell0 DB
-                type: string
-              cell0DatabaseUser:
-                default: nova_cell0
-                description: APIDatabaseUser - username to use when accessing the
-                  cell0 DB
                 type: string
               containerImage:
                 description: The service specific Container Image URL (will be set

--- a/config/crd/bases/nova.openstack.org_novacells.yaml
+++ b/config/crd/bases/nova.openstack.org_novacells.yaml
@@ -41,19 +41,9 @@ spec:
                   filed is Required for cell0. TODO(gibi): Add a webhook to validate
                   cell0 constraint'
                 type: string
-              apiDatabaseUser:
-                default: nova
-                description: APIDatabaseUser - username to use when accessing the
-                  API DB
-                type: string
               cellDatabaseHostname:
                 description: CellDatabaseHostname - hostname to use when accessing
                   the cell DB
-                type: string
-              cellDatabaseUser:
-                default: nova
-                description: CellDatabaseUser - username to use when accessing the
-                  cell DB
                 type: string
               cellMessageBusSecretName:
                 description: CellMessageBusSecretName - the name of the Secret containing

--- a/config/crd/bases/nova.openstack.org_novaconductors.yaml
+++ b/config/crd/bases/nova.openstack.org_novaconductors.yaml
@@ -54,19 +54,9 @@ spec:
                   filed is Required for cell0. TODO(gibi): Add a webhook to validate
                   cell0 constraint'
                 type: string
-              apiDatabaseUser:
-                default: nova
-                description: APIDatabaseUser - username to use when accessing the
-                  API DB
-                type: string
               cellDatabaseHostname:
                 description: 'NOTE(gibi): This should be Required, see notes in KeystoneAuthURL
                   CellDatabaseHostname - hostname to use when accessing the cell DB'
-                type: string
-              cellDatabaseUser:
-                default: nova
-                description: CellDatabaseUser - username to use when accessing the
-                  cell DB
                 type: string
               cellMessageBusSecretName:
                 description: CellMessageBusSecretName - the name of the Secret containing

--- a/config/crd/bases/nova.openstack.org_novametadata.yaml
+++ b/config/crd/bases/nova.openstack.org_novametadata.yaml
@@ -53,11 +53,6 @@ spec:
                   the API DB. This filed is Required if the CellName is not provided
                   TODO(gibi): Add a webhook to validate the CellName constraint'
                 type: string
-              apiDatabaseUser:
-                default: nova_api
-                description: APIDatabaseUser - username to use when accessing the
-                  API DB
-                type: string
               apiMessageBusSecretName:
                 description: 'APIMessageBusSecretName - the name of the Secret containing
                   the transport URL information to use when accessing the API message
@@ -69,11 +64,6 @@ spec:
                   the cell DB This is unused if CellName is not provided. But if it
                   is provided then CellDatabaseHostName is also Required. TODO(gibi):
                   add webhook to validate this CellName constraint'
-                type: string
-              cellDatabaseUser:
-                default: nova
-                description: CellDatabaseUser - username to use when accessing the
-                  cell DB
                 type: string
               cellName:
                 description: CellName is the name of the Nova Cell this metadata service

--- a/config/crd/bases/nova.openstack.org_novanovncproxies.yaml
+++ b/config/crd/bases/nova.openstack.org_novanovncproxies.yaml
@@ -52,11 +52,6 @@ spec:
                 description: CellDatabaseHostname - hostname to use when accessing
                   the cell DB
                 type: string
-              cellDatabaseUser:
-                default: nova
-                description: CellDatabaseUser - username to use when accessing the
-                  cell DB
-                type: string
               cellName:
                 description: CellName is the name of the Nova Cell this novncproxy
                   belongs to.

--- a/config/crd/bases/nova.openstack.org_novaschedulers.yaml
+++ b/config/crd/bases/nova.openstack.org_novaschedulers.yaml
@@ -52,11 +52,6 @@ spec:
                 description: APIDatabaseHostname - hostname to use when accessing
                   the API DB
                 type: string
-              apiDatabaseUser:
-                default: nova_api
-                description: APIDatabaseUser - username to use when accessing the
-                  API DB
-                type: string
               apiMessageBusSecretName:
                 description: APIMessageBusSecretName - the name of the Secret containing
                   the transport URL information to use when accessing the API message
@@ -65,11 +60,6 @@ spec:
               cell0DatabaseHostname:
                 description: Cell0DatabaseHostname - hostname to use when accessing
                   the cell0 DB
-                type: string
-              cell0DatabaseUser:
-                default: nova_cell0
-                description: Cell0DatabaseUser - username to use when accessing the
-                  cell0 DB
                 type: string
               containerImage:
                 description: The service specific Container Image URL (will be set

--- a/controllers/novaapi_controller.go
+++ b/controllers/novaapi_controller.go
@@ -41,6 +41,7 @@ import (
 
 	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
 	novav1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
+	"github.com/openstack-k8s-operators/nova-operator/pkg/nova"
 	"github.com/openstack-k8s-operators/nova-operator/pkg/novaapi"
 
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
@@ -355,13 +356,15 @@ func (r *NovaAPIReconciler) generateConfigs(
 		"keystone_internal_url":  instance.Spec.KeystoneAuthURL,
 		"nova_keystone_user":     instance.Spec.ServiceUser,
 		"nova_keystone_password": string(secret.Data[instance.Spec.PasswordSelectors.Service]),
-		"api_db_name":            instance.Spec.APIDatabaseUser, // fixme
-		"api_db_user":            instance.Spec.APIDatabaseUser,
-		"api_db_password":        string(secret.Data[instance.Spec.PasswordSelectors.APIDatabase]),
-		"api_db_address":         instance.Spec.APIDatabaseHostname,
-		"api_db_port":            3306,
-		"cell_db_name":           instance.Spec.Cell0DatabaseUser, // fixme
-		"cell_db_user":           instance.Spec.Cell0DatabaseUser,
+		"api_db_name":            nova.NovaAPIDatabaseName,
+		// mariadb-operator use the DB schema name as the user name
+		"api_db_user":     nova.NovaAPIDatabaseName,
+		"api_db_password": string(secret.Data[instance.Spec.PasswordSelectors.APIDatabase]),
+		"api_db_address":  instance.Spec.APIDatabaseHostname,
+		"api_db_port":     3306,
+		// mariadb-operator use the DB schema name as the user name
+		"cell_db_name":           "nova_cell0",
+		"cell_db_user":           "nova_cell0",
 		"cell_db_password":       string(secret.Data[instance.Spec.PasswordSelectors.CellDatabase]),
 		"cell_db_address":        instance.Spec.Cell0DatabaseHostname,
 		"cell_db_port":           3306,

--- a/controllers/novametadata_controller.go
+++ b/controllers/novametadata_controller.go
@@ -38,6 +38,7 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/statefulset"
 	util "github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	novav1beta1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
+	"github.com/openstack-k8s-operators/nova-operator/pkg/nova"
 	"github.com/openstack-k8s-operators/nova-operator/pkg/novametadata"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 )
@@ -309,17 +310,19 @@ func (r *NovaMetadataReconciler) generateConfigs(
 	}
 
 	templateParameters := map[string]interface{}{
-		"service_name":            novametadata.ServiceName,
-		"keystone_internal_url":   instance.Spec.KeystoneAuthURL,
-		"nova_keystone_user":      instance.Spec.ServiceUser,
-		"nova_keystone_password":  string(secret.Data[instance.Spec.PasswordSelectors.Service]),
-		"api_db_name":             instance.Spec.APIDatabaseUser, // fixme
-		"api_db_user":             instance.Spec.APIDatabaseUser,
-		"api_db_password":         string(secret.Data[instance.Spec.PasswordSelectors.APIDatabase]),
-		"api_db_address":          instance.Spec.APIDatabaseHostname,
-		"api_db_port":             3306,
-		"cell_db_name":            instance.Spec.CellDatabaseUser, // fixme
-		"cell_db_user":            instance.Spec.CellDatabaseUser,
+		"service_name":           novametadata.ServiceName,
+		"keystone_internal_url":  instance.Spec.KeystoneAuthURL,
+		"nova_keystone_user":     instance.Spec.ServiceUser,
+		"nova_keystone_password": string(secret.Data[instance.Spec.PasswordSelectors.Service]),
+		"api_db_name":            nova.NovaAPIDatabaseName,
+		// mariadb-operator use the DB schema name as the user name
+		"api_db_user":     nova.NovaAPIDatabaseName,
+		"api_db_password": string(secret.Data[instance.Spec.PasswordSelectors.APIDatabase]),
+		"api_db_address":  instance.Spec.APIDatabaseHostname,
+		"api_db_port":     3306,
+		// mariadb-operator use the DB schema name as the user name
+		"cell_db_name":            "nova_" + instance.Spec.CellName,
+		"cell_db_user":            "nova_" + instance.Spec.CellName,
 		"cell_db_password":        string(secret.Data[instance.Spec.PasswordSelectors.CellDatabase]),
 		"cell_db_address":         instance.Spec.CellDatabaseHostname,
 		"cell_db_port":            3306,

--- a/controllers/novascheduler_controller.go
+++ b/controllers/novascheduler_controller.go
@@ -37,6 +37,7 @@ import (
 	util "github.com/openstack-k8s-operators/lib-common/modules/common/util"
 
 	novav1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
+	"github.com/openstack-k8s-operators/nova-operator/pkg/nova"
 	"github.com/openstack-k8s-operators/nova-operator/pkg/novascheduler"
 )
 
@@ -305,13 +306,15 @@ func (r *NovaSchedulerReconciler) generateConfigs(
 		"keystone_internal_url":  instance.Spec.KeystoneAuthURL,
 		"nova_keystone_user":     instance.Spec.ServiceUser,
 		"nova_keystone_password": string(secret.Data[instance.Spec.PasswordSelectors.Service]),
-		"api_db_name":            instance.Spec.APIDatabaseUser, // fixme
-		"api_db_user":            instance.Spec.APIDatabaseUser,
-		"api_db_password":        string(secret.Data[instance.Spec.PasswordSelectors.APIDatabase]),
-		"api_db_address":         instance.Spec.APIDatabaseHostname,
-		"api_db_port":            3306,
-		"cell_db_name":           instance.Spec.Cell0DatabaseUser, // fixme
-		"cell_db_user":           instance.Spec.Cell0DatabaseUser,
+		"api_db_name":            nova.NovaAPIDatabaseName,
+		// mariadb-operator use the DB schema name as the user name
+		"api_db_user":     nova.NovaAPIDatabaseName,
+		"api_db_password": string(secret.Data[instance.Spec.PasswordSelectors.APIDatabase]),
+		"api_db_address":  instance.Spec.APIDatabaseHostname,
+		"api_db_port":     3306,
+		// mariadb-operator use the DB schema name as the user name
+		"cell_db_name":           "nova_cell0",
+		"cell_db_user":           "nova_cell0",
 		"cell_db_password":       string(secret.Data[instance.Spec.PasswordSelectors.CellDatabase]),
 		"cell_db_address":        instance.Spec.Cell0DatabaseHostname,
 		"cell_db_port":           3306,


### PR DESCRIPTION
The current mariadb-operator ignores the provided database user name and always creates a user based on the name of the DB schema. So this PR removes the defunct database user configurability from our CRDs.