### PR TITLE
Store service configs in Secrets

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -37,10 +37,10 @@ import (
 	"github.com/openstack-k8s-operators/nova-operator/pkg/nova"
 
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
-	"github.com/openstack-k8s-operators/lib-common/modules/common/configmap"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
 	helper "github.com/openstack-k8s-operators/lib-common/modules/common/helper"
 	nad "github.com/openstack-k8s-operators/lib-common/modules/common/networkattachment"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/secret"
 	util "github.com/openstack-k8s-operators/lib-common/modules/common/util"
 )
 
@@ -385,7 +385,7 @@ func (r *ReconcilerBase) generateConfigsGeneric(
 	cms := []util.Template{
 		// ConfigMap
 		{
-			Name:               nova.GetServiceConfigConfigMapName(instance.GetName()),
+			Name:               nova.GetServiceConfigSecretName(instance.GetName()),
 			Namespace:          instance.GetNamespace(),
 			Type:               util.TemplateTypeConfig,
 			InstanceType:       instance.GetObjectKind().GroupVersionKind().Kind,
@@ -398,7 +398,7 @@ func (r *ReconcilerBase) generateConfigsGeneric(
 	}
 	if withScripts {
 		cms = append(cms, util.Template{
-			Name:               nova.GetScriptConfigMapName(instance.GetName()),
+			Name:               nova.GetScriptSecretName(instance.GetName()),
 			Namespace:          instance.GetNamespace(),
 			Type:               util.TemplateTypeScripts,
 			InstanceType:       instance.GetObjectKind().GroupVersionKind().Kind,
@@ -407,10 +407,7 @@ func (r *ReconcilerBase) generateConfigsGeneric(
 			Labels:             cmLabels,
 		})
 	}
-	// TODO(sean): make this create a secret instead.
-	// consider taking this as a function pointer or interface
-	// to enable unit testing at some point.
-	return configmap.EnsureConfigMaps(ctx, h, instance, cms, envVars)
+	return secret.EnsureSecrets(ctx, h, instance, cms, envVars)
 }
 
 // GenerateConfigs helper function to generate config maps

--- a/controllers/nova_controller.go
+++ b/controllers/nova_controller.go
@@ -32,7 +32,6 @@ import (
 
 	"github.com/openstack-k8s-operators/lib-common/modules/common"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
-	"github.com/openstack-k8s-operators/lib-common/modules/common/configmap"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/endpoint"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
 	helper "github.com/openstack-k8s-operators/lib-common/modules/common/helper"
@@ -1309,8 +1308,7 @@ func (r *NovaReconciler) ensureCellMapped(
 	}
 
 	configHash := make(map[string]env.Setter)
-	// TODO(sean): make this create a secret instead.
-	err = configmap.EnsureConfigMaps(ctx, h, instance, cms, &configHash)
+	err = secret.EnsureSecrets(ctx, h, instance, cms, &configHash)
 
 	if err != nil {
 		return nova.CellMappingFailed, err

--- a/controllers/novaapi_controller.go
+++ b/controllers/novaapi_controller.go
@@ -180,7 +180,7 @@ func (r *NovaAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 	// all our input checks out so report InputReady
 	instance.Status.Conditions.MarkTrue(condition.InputReadyCondition, condition.InputReadyMessage)
 
-	err = r.ensureConfigMaps(ctx, h, instance, &hashes, secret)
+	err = r.ensureConfigs(ctx, h, instance, &hashes, secret)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -306,7 +306,7 @@ func (r *NovaAPIReconciler) initConditions(
 	return nil
 }
 
-func (r *NovaAPIReconciler) ensureConfigMaps(
+func (r *NovaAPIReconciler) ensureConfigs(
 	ctx context.Context,
 	h *helper.Helper,
 	instance *novav1.NovaAPI,

--- a/controllers/novaconductor_controller.go
+++ b/controllers/novaconductor_controller.go
@@ -156,7 +156,7 @@ func (r *NovaConductorReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// all our input checks out so report InputReady
 	instance.Status.Conditions.MarkTrue(condition.InputReadyCondition, condition.InputReadyMessage)
 
-	err = r.ensureConfigMaps(ctx, h, instance, &hashes, secret)
+	err = r.ensureConfigs(ctx, h, instance, &hashes, secret)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -251,7 +251,7 @@ func (r *NovaConductorReconciler) initConditions(
 	return nil
 }
 
-func (r *NovaConductorReconciler) ensureConfigMaps(
+func (r *NovaConductorReconciler) ensureConfigs(
 	ctx context.Context,
 	h *helper.Helper,
 	instance *novav1.NovaConductor,

--- a/controllers/novaexternalcompute_controller.go
+++ b/controllers/novaexternalcompute_controller.go
@@ -747,14 +747,12 @@ func initAEE(
 	ansibleEEMounts.Mounts = append(ansibleEEMounts.Mounts, playbookMount)
 
 	// mount nova and libvirt configs
-	serviceConfigCMName := fmt.Sprintf("%s-config-data", instance.Name)
+	serviceConfigSecretName := fmt.Sprintf("%s-config-data", instance.Name)
 	serviceConfigVolume := corev1.Volume{
 		Name: "compute-configs",
 		VolumeSource: corev1.VolumeSource{
-			ConfigMap: &corev1.ConfigMapVolumeSource{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: serviceConfigCMName,
-				},
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: serviceConfigSecretName,
 			},
 		},
 	}

--- a/controllers/novametadata_controller.go
+++ b/controllers/novametadata_controller.go
@@ -158,7 +158,7 @@ func (r *NovaMetadataReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// all our input checks out so report InputReady
 	instance.Status.Conditions.MarkTrue(condition.InputReadyCondition, condition.InputReadyMessage)
 
-	err = r.ensureConfigMaps(ctx, h, instance, &hashes, secret)
+	err = r.ensureConfigs(ctx, h, instance, &hashes, secret)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -265,7 +265,7 @@ func (r *NovaMetadataReconciler) initConditions(
 	return nil
 }
 
-func (r *NovaMetadataReconciler) ensureConfigMaps(
+func (r *NovaMetadataReconciler) ensureConfigs(
 	ctx context.Context,
 	h *helper.Helper,
 	instance *novav1beta1.NovaMetadata,

--- a/controllers/novascheduler_controller.go
+++ b/controllers/novascheduler_controller.go
@@ -154,7 +154,7 @@ func (r *NovaSchedulerReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// all our input checks out so report InputReady
 	instance.Status.Conditions.MarkTrue(condition.InputReadyCondition, condition.InputReadyMessage)
 
-	err = r.ensureConfigMaps(ctx, h, instance, &hashes, secret)
+	err = r.ensureConfigs(ctx, h, instance, &hashes, secret)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -258,7 +258,7 @@ func (r *NovaSchedulerReconciler) initConditions(
 	return nil
 }
 
-func (r *NovaSchedulerReconciler) ensureConfigMaps(
+func (r *NovaSchedulerReconciler) ensureConfigs(
 	ctx context.Context,
 	h *helper.Helper,
 	instance *novav1.NovaScheduler,

--- a/pkg/nova/common.go
+++ b/pkg/nova/common.go
@@ -32,15 +32,15 @@ const (
 	NovaCell0DatabaseName = "nova_cell0"
 )
 
-// GetScriptConfigMapName returns the name of the ConfigMap used for the
-// config merger and the service init scripts
-func GetScriptConfigMapName(crName string) string {
+// GetScriptSecretName returns the name of the Secret used for the
+// db sync scripts
+func GetScriptSecretName(crName string) string {
 	return fmt.Sprintf("%s-scripts", crName)
 }
 
-// GetServiceConfigConfigMapName returns the name of the ConfigMap used to
+// GetServiceConfigSecretName returns the name of the Secret used to
 // store the service configuration files
-func GetServiceConfigConfigMapName(crName string) string {
+func GetServiceConfigSecretName(crName string) string {
 	return fmt.Sprintf("%s-config-data", crName)
 }
 

--- a/pkg/nova/volumes.go
+++ b/pkg/nova/volumes.go
@@ -39,15 +39,13 @@ func GetConfigVolumeMount() corev1.VolumeMount {
 	}
 }
 
-func GetConfigVolume(configMapName string) corev1.Volume {
+func GetConfigVolume(secretName string) corev1.Volume {
 	return corev1.Volume{
 		Name: configVolume,
 		VolumeSource: corev1.VolumeSource{
-			ConfigMap: &corev1.ConfigMapVolumeSource{
+			Secret: &corev1.SecretVolumeSource{
 				DefaultMode: &configMode,
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: configMapName,
-				},
+				SecretName:  secretName,
 			},
 		},
 	}
@@ -78,15 +76,13 @@ func GetScriptVolumeMount() corev1.VolumeMount {
 	}
 }
 
-func GetScriptVolume(configMapName string) corev1.Volume {
+func GetScriptVolume(secretName string) corev1.Volume {
 	return corev1.Volume{
 		Name: scriptVolume,
 		VolumeSource: corev1.VolumeSource{
-			ConfigMap: &corev1.ConfigMapVolumeSource{
+			Secret: &corev1.SecretVolumeSource{
 				DefaultMode: &scriptMode,
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: configMapName,
-				},
+				SecretName:  secretName,
 			},
 		},
 	}

--- a/pkg/novaapi/deployment.go
+++ b/pkg/novaapi/deployment.go
@@ -122,7 +122,7 @@ func StatefulSet(
 				Spec: corev1.PodSpec{
 					ServiceAccountName: instance.Spec.ServiceAccount,
 					Volumes: []corev1.Volume{
-						nova.GetConfigVolume(nova.GetServiceConfigConfigMapName(instance.Name)),
+						nova.GetConfigVolume(nova.GetServiceConfigSecretName(instance.Name)),
 						nova.GetLogVolume(),
 					},
 					Containers: []corev1.Container{

--- a/pkg/novaconductor/dbsync.go
+++ b/pkg/novaconductor/dbsync.go
@@ -70,8 +70,8 @@ func CellDBSyncJob(
 					RestartPolicy:      corev1.RestartPolicyOnFailure,
 					ServiceAccountName: instance.Spec.ServiceAccount,
 					Volumes: []corev1.Volume{
-						nova.GetConfigVolume(nova.GetServiceConfigConfigMapName(instance.Name)),
-						nova.GetScriptVolume(nova.GetScriptConfigMapName(instance.Name)),
+						nova.GetConfigVolume(nova.GetServiceConfigSecretName(instance.Name)),
+						nova.GetScriptVolume(nova.GetScriptSecretName(instance.Name)),
 					},
 					Containers: []corev1.Container{
 						{

--- a/pkg/novaconductor/deployment.go
+++ b/pkg/novaconductor/deployment.go
@@ -118,7 +118,7 @@ func StatefulSet(
 				Spec: corev1.PodSpec{
 					ServiceAccountName: instance.Spec.ServiceAccount,
 					Volumes: []corev1.Volume{
-						nova.GetConfigVolume(nova.GetServiceConfigConfigMapName(instance.Name)),
+						nova.GetConfigVolume(nova.GetServiceConfigSecretName(instance.Name)),
 					},
 					Containers: []corev1.Container{
 						{

--- a/pkg/novametadata/deployment.go
+++ b/pkg/novametadata/deployment.go
@@ -122,7 +122,7 @@ func StatefulSet(
 				Spec: corev1.PodSpec{
 					ServiceAccountName: instance.Spec.ServiceAccount,
 					Volumes: []corev1.Volume{
-						nova.GetConfigVolume(nova.GetServiceConfigConfigMapName(instance.Name)),
+						nova.GetConfigVolume(nova.GetServiceConfigSecretName(instance.Name)),
 						nova.GetLogVolume(),
 					},
 					Containers: []corev1.Container{

--- a/pkg/novascheduler/deployment.go
+++ b/pkg/novascheduler/deployment.go
@@ -127,7 +127,7 @@ func StatefulSet(
 				Spec: corev1.PodSpec{
 					ServiceAccountName: instance.Spec.ServiceAccount,
 					Volumes: []corev1.Volume{
-						nova.GetConfigVolume(nova.GetServiceConfigConfigMapName(instance.Name)),
+						nova.GetConfigVolume(nova.GetServiceConfigSecretName(instance.Name)),
 					},
 					Containers: []corev1.Container{
 						{

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -197,6 +197,7 @@ func GetDefaultNovaConductorSpec() map[string]interface{} {
 		"containerImage":           ContainerImage,
 		"keystoneAuthURL":          "keystone-auth-url",
 		"serviceAccount":           "nova",
+		"customServiceConfig":      "foo=bar",
 	}
 }
 

--- a/test/functional/nova_metadata_controller_test.go
+++ b/test/functional/nova_metadata_controller_test.go
@@ -162,7 +162,7 @@ var _ = Describe("NovaMetadata controller", func() {
 					corev1.ConditionTrue,
 				)
 
-				configDataMap := th.GetConfigMap(
+				configDataMap := th.GetSecret(
 					types.NamespacedName{
 						Namespace: novaNames.MetadataName.Namespace,
 						Name:      fmt.Sprintf("%s-config-data", novaNames.MetadataName.Name),
@@ -170,17 +170,13 @@ var _ = Describe("NovaMetadata controller", func() {
 				)
 				Expect(configDataMap).ShouldNot(BeNil())
 				Expect(configDataMap.Data).Should(HaveKey("01-nova.conf"))
-				Expect(configDataMap.Data).Should(
-					HaveKeyWithValue("01-nova.conf",
-						ContainSubstring("transport_url=rabbit://rabbitmq-secret/fake")))
-				Expect(configDataMap.Data).Should(
-					HaveKeyWithValue("01-nova.conf",
-						ContainSubstring("metadata_proxy_shared_secret = 12345678")))
-				Expect(configDataMap.Data).Should(
-					HaveKeyWithValue("01-nova.conf",
-						ContainSubstring("local_metadata_per_cell = false")))
-				Expect(configDataMap.Data).Should(
-					HaveKeyWithValue("02-nova-override.conf", "foo=bar"))
+				configData := string(configDataMap.Data["01-nova.conf"])
+				Expect(configData).Should(ContainSubstring("transport_url=rabbit://rabbitmq-secret/fake"))
+				Expect(configData).Should(ContainSubstring("metadata_proxy_shared_secret = 12345678"))
+				Expect(configData).Should(ContainSubstring("local_metadata_per_cell = false"))
+				Expect(configDataMap.Data).Should(HaveKey("02-nova-override.conf"))
+				extraData := string(configDataMap.Data["02-nova-override.conf"])
+				Expect(extraData).To(Equal("foo=bar"))
 			})
 
 			It("stored the input hash in the Status", func() {
@@ -332,7 +328,7 @@ var _ = Describe("NovaMetadata controller", func() {
 				corev1.ConditionTrue,
 			)
 
-			configDataMap := th.GetConfigMap(
+			configDataMap := th.GetSecret(
 				types.NamespacedName{
 					Namespace: novaNames.MetadataName.Namespace,
 					Name:      fmt.Sprintf("%s-config-data", novaNames.MetadataName.Name),
@@ -340,15 +336,13 @@ var _ = Describe("NovaMetadata controller", func() {
 			)
 			Expect(configDataMap).ShouldNot(BeNil())
 			Expect(configDataMap.Data).Should(HaveKey("01-nova.conf"))
-			Expect(configDataMap.Data).Should(
-				HaveKeyWithValue("01-nova.conf",
-					ContainSubstring("transport_url=rabbit://rabbitmq-secret/fake")))
-			Expect(configDataMap.Data).Should(
-				HaveKeyWithValue("01-nova.conf",
-					ContainSubstring("metadata_proxy_shared_secret = 12345678")))
-			Expect(configDataMap.Data).Should(
-				HaveKeyWithValue("01-nova.conf",
-					ContainSubstring("local_metadata_per_cell = true")))
+			configData := string(configDataMap.Data["01-nova.conf"])
+			Expect(configData).Should(
+				ContainSubstring("transport_url=rabbit://rabbitmq-secret/fake"))
+			Expect(configData).Should(
+				ContainSubstring("metadata_proxy_shared_secret = 12345678"))
+			Expect(configData).Should(
+				ContainSubstring("local_metadata_per_cell = true"))
 			th.ExpectCondition(
 				novaNames.MetadataName,
 				ConditionGetterFunc(NovaMetadataConditionGetter),

--- a/test/functional/nova_scheduler_test.go
+++ b/test/functional/nova_scheduler_test.go
@@ -165,7 +165,7 @@ var _ = Describe("NovaScheduler controller", func() {
 				corev1.ConditionTrue,
 			)
 
-			configDataMap := th.GetConfigMap(
+			configDataMap := th.GetSecret(
 				types.NamespacedName{
 					Namespace: novaNames.SchedulerName.Namespace,
 					Name:      fmt.Sprintf("%s-config-data", novaNames.SchedulerName.Name),
@@ -173,11 +173,11 @@ var _ = Describe("NovaScheduler controller", func() {
 			)
 			Expect(configDataMap).ShouldNot(BeNil())
 			Expect(configDataMap.Data).Should(HaveKey("01-nova.conf"))
-			Expect(configDataMap.Data).Should(
-				HaveKeyWithValue("01-nova.conf",
-					ContainSubstring("transport_url=rabbit://rabbitmq-secret/fake")))
-			Expect(configDataMap.Data).Should(
-				HaveKeyWithValue("02-nova-override.conf", "foo=bar"))
+			configData := string(configDataMap.Data["01-nova.conf"])
+			Expect(configData).To(ContainSubstring("transport_url=rabbit://rabbitmq-secret/fake"))
+			Expect(configDataMap.Data).Should(HaveKey("02-nova-override.conf"))
+			extraConfigData := string(configDataMap.Data["02-nova-override.conf"])
+			Expect(extraConfigData).To(Equal("foo=bar"))
 		})
 
 		It("stored the input hash in the Status", func() {

--- a/test/functional/novaapi_controller_test.go
+++ b/test/functional/novaapi_controller_test.go
@@ -168,7 +168,7 @@ var _ = Describe("NovaAPI controller", func() {
 					corev1.ConditionTrue,
 				)
 
-				configDataMap := th.GetConfigMap(
+				configDataMap := th.GetSecret(
 					types.NamespacedName{
 						Namespace: novaNames.APIName.Namespace,
 						Name:      fmt.Sprintf("%s-config-data", novaNames.APIName.Name),
@@ -176,15 +176,14 @@ var _ = Describe("NovaAPI controller", func() {
 				)
 				Expect(configDataMap).ShouldNot(BeNil())
 				Expect(configDataMap.Data).Should(HaveKey("01-nova.conf"))
-				Expect(configDataMap.Data).Should(
-					HaveKeyWithValue("01-nova.conf",
-						ContainSubstring("transport_url=rabbit://rabbitmq-secret/fake")))
+				configData := string(configDataMap.Data["01-nova.conf"])
+				Expect(configData).Should(ContainSubstring("transport_url=rabbit://rabbitmq-secret/fake"))
 				// as of I3629b84d3255a8fe9d8a7cea8c6131d7c40899e8 nova now requires
-				// service_user configuration to work to adress Bug: #2004555
-				Expect(configDataMap.Data).Should(
-					HaveKeyWithValue("01-nova.conf", ContainSubstring("[service_user]")))
-				Expect(configDataMap.Data).Should(
-					HaveKeyWithValue("02-nova-override.conf", "foo=bar"))
+				// service_user configuration to work to address Bug: #2004555
+				Expect(configData).Should(ContainSubstring("[service_user]"))
+				Expect(configDataMap.Data).Should(HaveKey("02-nova-override.conf"))
+				extraData := string(configDataMap.Data["02-nova-override.conf"])
+				Expect(extraData).To(Equal("foo=bar"))
 			})
 
 			It("stored the input hash in the Status", func() {


### PR DESCRIPTION
The generated service configs containing sensitive data like database password. So we switch the config generation code to store them in Secrets instead of ConfigMaps.

Related: https://issues.redhat.com/browse/OSPRH-98