### PR TITLE
Remote FIXME from envtest

### DIFF
--- a/test/functional/nova_controller_test.go
+++ b/test/functional/nova_controller_test.go
@@ -265,6 +265,8 @@ var _ = Describe("Nova controller", func() {
 			)
 			Expect(mappingJobScript.Data).Should(HaveKeyWithValue(
 				"ensure_cell_mapping.sh", ContainSubstring("nova-manage cell_v2 update_cell")))
+			Expect(mappingJobScript.Data).Should(HaveKeyWithValue(
+				"ensure_cell_mapping.sh", ContainSubstring("nova-manage cell_v2 map_cell0")))
 
 			Eventually(func(g Gomega) {
 				nova := GetNova(novaNames.NovaName)

--- a/test/functional/novaconductor_controller_test.go
+++ b/test/functional/novaconductor_controller_test.go
@@ -183,9 +183,6 @@ var _ = Describe("NovaConductor controller", func() {
 					"dbsync.sh", ContainSubstring("nova-manage db sync")))
 				Expect(scriptMap.Data).Should(HaveKeyWithValue(
 					"dbsync.sh", ContainSubstring("nova-manage api_db sync")))
-				// FIXME(bogdando): have I lost this change upon rebasing?
-				//Expect(scriptMap.Data).Should(HaveKeyWithValue(
-				//	"dbsync.sh", ContainSubstring("nova-manage cell_v2 map_cell0")))
 			})
 
 			It("stored the input hash in the Status", func() {


### PR DESCRIPTION
The map_cell0 call moved from conductor dbsync job to a cell mapping job run from the nova controller. This happened while the envtest name handling refactor was in flight. So the FIXME is now resolved.