### PR TITLE
Validate lenght of cell name

### DIFF
--- a/api/v1beta1/novacell_webhook.go
+++ b/api/v1beta1/novacell_webhook.go
@@ -97,12 +97,25 @@ func (r *NovaCell) ValidateMetadata() *field.Error{
 
 var _ webhook.Validator = &NovaCell{}
 
+// ValidateName validate cell name lenght
+func (r *NovaCell) ValidateName() *field.Error{
+	if len(r.Spec.CellName) > 35{
+		return field.Forbidden(field.NewPath("spec").Child("CellName"), "should be shorter than 35 characters")
+	}
+	return nil
+}
+
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *NovaCell) ValidateCreate() error {
 	novacelllog.Info("validate create", "name", r.Name)
 	var allErrs field.ErrorList
 
+
 	if err := r.ValidateMetadata(); err != nil {
+		allErrs = append(allErrs, err)
+	}
+
+	if err := r.ValidateName(); err != nil {
 		allErrs = append(allErrs, err)
 	}
 
@@ -121,7 +134,12 @@ func (r *NovaCell) ValidateUpdate(old runtime.Object) error {
 
 	var allErrs field.ErrorList
 
+
 	if err := r.ValidateMetadata(); err != nil {
+		allErrs = append(allErrs, err)
+	}
+
+	if err := r.ValidateName(); err != nil {
 		allErrs = append(allErrs, err)
 	}
 

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -264,7 +264,7 @@ var _ = BeforeEach(func() {
 
 	novaName := types.NamespacedName{
 		Namespace: namespace,
-		Name:      uuid.New().String(),
+		Name:      uuid.New().String()[:25],
 	}
 
 	novaNames = GetNovaNames(novaName, []string{"cell0", "cell1", "cell2"})


### PR DESCRIPTION
We need to limit the lenght of the name of the nova-cell as the operator generates names for the sub CRs from this name as a prefix. E.g. <nova-CR-name>-<cell name>-metadata-internal
K8s limits the name of a CR to 63 chars.