### PR TITLE
CSV: Set operator-type: non-standalone

### DIFF
--- a/config/manifests/bases/nova-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/nova-operator.clusterserviceversion.yaml
@@ -5,6 +5,7 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     operatorframework.io/suggested-namespace: openstack
+    operators.operatorframework.io/operator-type: non-standalone
   name: nova-operator.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
This should hide the nova package/bundle in the OpenShift console as we only want the main OpenStack operator to show up there.