### PR TITLE
update external dataplane samples

### DIFF
--- a/config/samples/external-compute/openstackdataplanenode.yaml
+++ b/config/samples/external-compute/openstackdataplanenode.yaml
@@ -1,28 +1,18 @@
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneNode
 metadata:
-  name: compute-1
+  name: edpm-compute-0
 spec:
-  role: compute
-  hostName: nova-compute-1
-  ansibleHost:  console-openshift-console.apps.oks-dev.seanmooney.info
+  role: edpm-compute
+  hostName: edpm-compute-0
+  ansibleHost: 192.168.122.100
   node:
-    networks:
-      - network: ctlplane
-        fixedIP: 10.0.2.2
-    ansibleUser: centos
-    ansiblePort: 30067
+    nova: {}
     ansibleVars: |
-      edpm_network_config_template: templates/net_config_bridge.j2
-      edpm_network_config_hide_sensitive_logs: false
-      neutron_physical_bridge_name: br-ex
-      neutron_public_interface_name: eth0
-      ctlplane_dns_nameservers:
-      - 8.8.8.8
-      - 172.30.0.10
-      dns_search_domains: []
-      internal_api_ip: 10.0.2.2
-      tenant_ip: 10.0.2.2
-      fqdn_internal_api: '{{ ansible_fqdn }}'
+        ctlplane_ip: 192.168.122.100
+        internal_api_ip: 172.17.0.100
+        storage_ip: 172.18.0.100
+        tenant_ip: 172.19.0.100
+        fqdn_internal_api: edpm-compute-0.example.com
+  deployStrategy:
     deploy: true
-    ansibleSSHPrivateKeySecret: edpm-ssh-key

--- a/config/samples/external-compute/openstackdataplanerole.yaml
+++ b/config/samples/external-compute/openstackdataplanerole.yaml
@@ -1,14 +1,91 @@
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneRole
 metadata:
-  name: compute
+  name: edpm-compute
 spec:
-  dataPlaneNodes:
-    - name: nova-compute-1
-      nodeFrom: compute-1
   nodeTemplate:
-    networkConfig:
-      template: templates/net_config_bridge.j2
+    services:
+      - configure-network
+      - validate-network
+      - install-os
+      - configure-os
+      - run-os
+    nova: {}
     managed: false
     managementNetwork: ctlplane
-    ansibleUser: centos
+    ansibleUser: root
+    ansiblePort: 22
+    ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+    ansibleVars: |
+      # i dont actully know what this is for.
+      service_net_map:
+        nova_api_network: internal_api
+        nova_libvirt_network: internal_api
+      # edpm_network_config
+      # Default nic config template for a EDPM compute node
+      # These vars are edpm_network_config role vars
+      # https://github.com/openstack-k8s-operators/edpm-ansible/blob/92c656d7803a636b5c84c04a866d9b2368af9fd6/edpm_ansible/roles/edpm_network_config/templates/single_nic_vlans/single_nic_vlans.j2
+      edpm_network_config_template: templates/single_nic_vlans/single_nic_vlans.j2
+      edpm_network_config_hide_sensitive_logs: false
+      #
+      # These vars are for the network config templates themselves and are
+      # considered EDPM network defaults.
+      neutron_physical_bridge_name: br-ex
+      neutron_public_interface_name: eth0
+      ctlplane_mtu: 1500
+      ctlplane_subnet_cidr: 24
+      ctlplane_gateway_ip: 192.168.122.1
+      ctlplane_host_routes:
+      - ip_netmask: 0.0.0.0/0
+        next_hop: 192.168.122.1
+      external_mtu: 1500
+      external_vlan_id: 44
+      external_cidr: '24'
+      external_host_routes: []
+      internal_api_mtu: 1500
+      internal_api_vlan_id: 20
+      internal_api_cidr: '24'
+      internal_api_host_routes: []
+      storage_mtu: 1500
+      storage_vlan_id: 21
+      storage_cidr: '24'
+      storage_host_routes: []
+      tenant_mtu: 1500
+      tenant_vlan_id: 22
+      tenant_cidr: '24'
+      tenant_host_routes: []
+      role_networks:
+      - InternalApi
+      - Storage
+      - Tenant
+      networks_lower:
+        External: external
+        InternalApi: internal_api
+        Storage: storage
+        Tenant: tenant
+      ctlplane_dns_nameservers:
+      - 192.168.122.1
+      dns_search_domains: []
+
+      edpm_ovn_dbs: 172.17.0.39
+      edpm_chrony_ntp_servers:
+        - time1.google.com
+        - time2.google.com
+      registry_name: "quay.io"
+      registry_namespace: "podified-antelope-centos9"
+      image_tag: "current-podified"
+      edpm_ovn_controller_agent_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-ovn-controller:{{ image_tag }}"
+      edpm_iscsid_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-iscsid:{{ image_tag }}"
+      edpm_logrotate_crond_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-cron:{{ image_tag }}"
+      edpm_ovn_metadata_agent_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-neutron-metadata-agent-ovn:{{ image_tag }}"
+      edpm_hosts_entries_undercloud_hosts_entries: []
+      # edpm_hosts_entries role
+      edpm_hosts_entries_extra_hosts_entries:
+        - 172.17.0.80 glance-internal.openstack.svc neutron-internal.openstack.svc cinder-internal.openstack.svc nova-internal.openstack.svc placement-internal.openstack.svc keystone-internal.openstack.svc
+        - 172.17.0.85 rabbitmq.openstack.svc
+        - 172.17.0.86 rabbitmq-cell1.openstack.svc
+      edpm_hosts_entries_vip_hosts_entries: []
+      hosts_entries: []
+      hosts_entry: []
+  deployStrategy:
+    deploy: false


### PR DESCRIPTION
This change updtateds the exernal dataplane samples to work with
the recent change to use network isolation with crc and the
dataplane operator.
