### PR TITLE
Refactor validation webhook for cell

### DIFF
--- a/api/v1beta1/novacell_types.go
+++ b/api/v1beta1/novacell_types.go
@@ -24,6 +24,11 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
+const (
+	// Cell0Name is the name of Cell0 cell that is mandatory in every deployment
+	Cell0Name = "cell0"
+)
+
 // NovaCellTemplate defines the input parameters specified by the user to
 // create a NovaCell via higher level CRDs.
 type NovaCellTemplate struct {

--- a/api/v1beta1/novametadata_webhook.go
+++ b/api/v1beta1/novametadata_webhook.go
@@ -24,6 +24,7 @@ package v1beta1
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -97,4 +98,18 @@ func (r *NovaMetadata) ValidateDelete() error {
 
 	// TODO(user): fill in your validation logic upon object deletion.
 	return nil
+}
+
+// ValidateCell0 validates cell0 Metadata template. This is expected to be called
+// by higher level validation webhooks
+func (r *NovaMetadataTemplate) ValidateCell0(basePath *field.Path) field.ErrorList {
+	var errors field.ErrorList
+	if *r.Replicas != 0 {
+		errors = append(
+			errors,
+			field.Invalid(
+				basePath.Child("replicas"), *r.Replicas, "should be 0 for cell0"),
+		)
+	}
+	return errors
 }

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -66,8 +66,6 @@ const (
 	// DbSyncHash - the field name in Status.Hashes storing the has of the DB
 	// sync job
 	DbSyncHash = "dbsync"
-	// Cell0Name is the name of Cell0 cell that is mandatory in every deployment
-	Cell0Name = "cell0"
 	// CellSelector is the key name of a cell label
 	CellSelector = "cell"
 )

--- a/controllers/nova_controller.go
+++ b/controllers/nova_controller.go
@@ -237,9 +237,9 @@ func (r *NovaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 	// We need to create a list of cellNames to iterate on and as the map
 	// iteration order is undefined we need to make sure that cell0 is the
 	// first to allow dependency handling during ensureCell calls.
-	orderedCellNames := []string{Cell0Name}
+	orderedCellNames := []string{novav1.Cell0Name}
 	for cellName := range instance.Spec.CellTemplates {
-		if cellName != Cell0Name {
+		if cellName != novav1.Cell0Name {
 			orderedCellNames = append(orderedCellNames, cellName)
 		}
 	}
@@ -322,7 +322,7 @@ func (r *NovaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 		cellTemplate := instance.Spec.CellTemplates[cellName]
 		// cell0 does not need its own cell message bus it uses the
 		// API message bus instead
-		if cellName == Cell0Name {
+		if cellName == novav1.Cell0Name {
 			cellMQ = apiMQSecretName
 			status = apiMQStatus
 			err = apiMQError
@@ -394,8 +394,8 @@ func (r *NovaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 		// The cell0 is always handled first in the loop as we iterate on
 		// orderedCellNames. So for any other cells we can assume that if cell0
 		// is not in the list then cell0 is not ready
-		cell0Ready := (cells[Cell0Name] != nil && cells[Cell0Name].IsReady())
-		if cellName != Cell0Name && cellTemplate.HasAPIAccess && !cell0Ready {
+		cell0Ready := (cells[novav1.Cell0Name] != nil && cells[novav1.Cell0Name].IsReady())
+		if cellName != novav1.Cell0Name && cellTemplate.HasAPIAccess && !cell0Ready {
 			allCellsReady = false
 			skippedCells = append(skippedCells, cellName)
 			util.LogForObject(
@@ -460,7 +460,7 @@ func (r *NovaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 
 	// Don't move forward with the top level service creations like NovaAPI
 	// until cell0 is ready as top level services need cell0 to register in
-	if cell0, ok := cells[Cell0Name]; !ok || !cell0.IsReady() {
+	if cell0, ok := cells[novav1.Cell0Name]; !ok || !cell0.IsReady() {
 		// we need to stop here until cell0 is ready
 		util.LogForObject(h, "Waiting for cell0 to become Ready before creating the top level services", instance)
 		return ctrl.Result{}, nil
@@ -468,7 +468,7 @@ func (r *NovaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 
 	result, err = r.ensureAPI(
 		ctx, h, instance, cell0Template,
-		cellDBs[Cell0Name].Database, apiDB, apiMQSecretName, keystoneAuthURL,
+		cellDBs[novav1.Cell0Name].Database, apiDB, apiMQSecretName, keystoneAuthURL,
 	)
 	if err != nil {
 		return result, err
@@ -476,7 +476,7 @@ func (r *NovaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 
 	result, err = r.ensureScheduler(
 		ctx, h, instance, cell0Template,
-		cellDBs[Cell0Name].Database, apiDB, apiMQSecretName, keystoneAuthURL,
+		cellDBs[novav1.Cell0Name].Database, apiDB, apiMQSecretName, keystoneAuthURL,
 	)
 	if err != nil {
 		return result, err
@@ -485,7 +485,7 @@ func (r *NovaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 	if *instance.Spec.MetadataServiceTemplate.Replicas != 0 {
 		result, err = r.ensureMetadata(
 			ctx, h, instance, cell0Template,
-			cellDBs[Cell0Name].Database, apiDB, apiMQSecretName, keystoneAuthURL,
+			cellDBs[novav1.Cell0Name].Database, apiDB, apiMQSecretName, keystoneAuthURL,
 		)
 		if err != nil {
 			return result, err
@@ -625,14 +625,14 @@ func (r *NovaReconciler) getCell0Template(instance *novav1.Nova) (novav1.NovaCel
 	var cell0Template novav1.NovaCellTemplate
 	var ok bool
 
-	if cell0Template, ok = instance.Spec.CellTemplates[Cell0Name]; !ok {
+	if cell0Template, ok = instance.Spec.CellTemplates[novav1.Cell0Name]; !ok {
 		err := fmt.Errorf("missing cell0 specification from Spec.CellTemplates")
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			novav1.NovaAllCellsReadyCondition,
 			condition.ErrorReason,
 			condition.SeverityError,
 			novav1.NovaAllCellsReadyErrorMessage,
-			fmt.Sprintf("%s(%v)", Cell0Name, err.Error()),
+			fmt.Sprintf("%s(%v)", novav1.Cell0Name, err.Error()),
 		))
 
 		return cell0Template, err

--- a/controllers/novacell_controller.go
+++ b/controllers/novacell_controller.go
@@ -115,7 +115,7 @@ func (r *NovaCellReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 		return result, err
 	}
 
-	if *instance.Spec.MetadataServiceTemplate.Replicas != 0 && instance.Spec.CellName != Cell0Name {
+	if *instance.Spec.MetadataServiceTemplate.Replicas != 0 && instance.Spec.CellName != novav1.Cell0Name {
 		result, err = r.ensureMetadata(ctx, h, instance)
 		if err != nil {
 			return result, err

--- a/test/functional/nova_multicell_test.go
+++ b/test/functional/nova_multicell_test.go
@@ -778,48 +778,4 @@ var _ = Describe("Nova multicell", func() {
 			)
 		})
 	})
-	When("Nova CR instance is created with metadata in cell0", func() {
-		BeforeEach(func() {
-			DeferCleanup(k8sClient.Delete, ctx, CreateNovaSecret(novaNames.NovaName.Namespace, SecretName))
-			DeferCleanup(
-				k8sClient.Delete,
-				ctx,
-				CreateNovaMessageBusSecret(cell0.CellName.Namespace, fmt.Sprintf("%s-secret", cell0.TransportURLName.Name)),
-			)
-
-			serviceSpec := corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 3306}}}
-			DeferCleanup(th.DeleteDBService, th.CreateDBService(novaNames.APIMariaDBDatabaseName.Namespace, novaNames.APIMariaDBDatabaseName.Name, serviceSpec))
-			DeferCleanup(th.DeleteDBService, th.CreateDBService(cell0.MariaDBDatabaseName.Namespace, cell0.MariaDBDatabaseName.Name, serviceSpec))
-
-			spec := GetDefaultNovaSpec()
-			cell0Template := GetDefaultNovaCellTemplate()
-			cell0Template["cellDatabaseInstance"] = cell0.MariaDBDatabaseName.Name
-			cell0Template["cellDatabaseUser"] = "nova_cell0"
-
-			cell0Template["metadataServiceTemplate"] = map[string]interface{}{
-				"replicas": 1,
-			}
-
-			spec["cellTemplates"] = map[string]interface{}{
-				"cell0": cell0Template,
-			}
-			spec["metadataServiceTemplate"] = map[string]interface{}{
-				"replicas": 0,
-			}
-			spec["apiDatabaseInstance"] = novaNames.APIMariaDBDatabaseName.Name
-			spec["apiMessageBusInstance"] = cell0.TransportURLName.Name
-
-			DeferCleanup(th.DeleteInstance, CreateNova(novaNames.NovaName, spec))
-			keystoneAPIName := th.CreateKeystoneAPI(novaNames.NovaName.Namespace)
-			DeferCleanup(th.DeleteKeystoneAPI, keystoneAPIName)
-			keystoneAPI := th.GetKeystoneAPI(keystoneAPIName)
-			Eventually(func(g Gomega) {
-				g.Expect(k8sClient.Status().Update(ctx, keystoneAPI.DeepCopy())).Should(Succeed())
-			}, timeout, interval).Should(Succeed())
-			th.SimulateKeystoneServiceReady(novaNames.KeystoneServiceName)
-		})
-		It("cell0 never created", func() {
-			NovaCellNotExists(cell0.CellName)
-		})
-	})
 })

--- a/test/functional/validation_webhook_test.go
+++ b/test/functional/validation_webhook_test.go
@@ -1,0 +1,204 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package functional_test
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var _ = Describe("Nova validation", func() {
+	It("rejects Nova with metadata in cell0", func() {
+		spec := GetDefaultNovaSpec()
+		cell0Template := GetDefaultNovaCellTemplate()
+		cell0Template["metadataServiceTemplate"] = map[string]interface{}{
+			"replicas": 1,
+		}
+
+		spec["cellTemplates"] = map[string]interface{}{
+			"cell0": cell0Template,
+			// note that this is intentional to test that metadata 0 is allowed
+			// in cell1 but not in cell0
+			"cell1": cell0Template,
+		}
+		raw := map[string]interface{}{
+			"apiVersion": "nova.openstack.org/v1beta1",
+			"kind":       "Nova",
+			"metadata": map[string]interface{}{
+				"name":      novaNames.NovaName.Name,
+				"namespace": novaNames.Namespace,
+			},
+			"spec": spec,
+		}
+
+		unstructuredObj := &unstructured.Unstructured{Object: raw}
+		_, err := controllerutil.CreateOrPatch(
+			ctx, k8sClient, unstructuredObj, func() error { return nil })
+
+		Expect(err).Should(HaveOccurred())
+		statusError, ok := err.(*errors.StatusError)
+		Expect(ok).To(BeTrue())
+		Expect(statusError.ErrStatus.Details.Kind).To(Equal("Nova"))
+		Expect(statusError.ErrStatus.Message).To(
+			ContainSubstring(
+				"invalid: spec.cellTemplates[cell0].metadataServiceTemplate.replicas: " +
+					"Invalid value: 1: should be 0 for cell0"),
+		)
+	})
+	It("rejects NovaCell with metadata in cell0", func() {
+		spec := GetDefaultNovaCellSpec()
+		spec["metadataServiceTemplate"] = map[string]interface{}{
+			"replicas": 3,
+		}
+		raw := map[string]interface{}{
+			"apiVersion": "nova.openstack.org/v1beta1",
+			"kind":       "NovaCell",
+			"metadata": map[string]interface{}{
+				"name":      cell0.CellName.Name,
+				"namespace": novaNames.Namespace,
+			},
+			"spec": spec,
+		}
+
+		unstructuredObj := &unstructured.Unstructured{Object: raw}
+		_, err := controllerutil.CreateOrPatch(
+			ctx, k8sClient, unstructuredObj, func() error { return nil })
+
+		Expect(err).Should(HaveOccurred())
+		statusError, ok := err.(*errors.StatusError)
+		Expect(ok).To(BeTrue())
+		Expect(statusError.ErrStatus.Details.Kind).To(Equal("NovaCell"))
+		Expect(statusError.ErrStatus.Message).To(
+			ContainSubstring(
+				"invalid: spec.metadataServiceTemplate.replicas: " +
+					"Invalid value: 3: should be 0 for cell0"),
+		)
+	})
+	It("rejects Nova with too long cell name", func() {
+		spec := GetDefaultNovaSpec()
+		cell0Template := GetDefaultNovaCellTemplate()
+		spec["cellTemplates"] = map[string]interface{}{
+			// the limit is 35 chars, this is 5 + 31
+			"cell1" + strings.Repeat("x", 31): cell0Template,
+		}
+		raw := map[string]interface{}{
+			"apiVersion": "nova.openstack.org/v1beta1",
+			"kind":       "Nova",
+			"metadata": map[string]interface{}{
+				"name":      novaNames.NovaName.Name,
+				"namespace": novaNames.Namespace,
+			},
+			"spec": spec,
+		}
+
+		unstructuredObj := &unstructured.Unstructured{Object: raw}
+		_, err := controllerutil.CreateOrPatch(
+			ctx, k8sClient, unstructuredObj, func() error { return nil })
+
+		Expect(err).Should(HaveOccurred())
+		statusError, ok := err.(*errors.StatusError)
+		Expect(ok).To(BeTrue())
+		Expect(statusError.ErrStatus.Details.Kind).To(Equal("Nova"))
+		Expect(statusError.ErrStatus.Message).To(
+			ContainSubstring(
+				"invalid: spec.cellTemplates[cell1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx]: " +
+					"Invalid value: \"cell1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\": " +
+					"should be shorter than 36 characters"),
+		)
+	})
+	It("rejects NovaCell with too long cell name", func() {
+		spec := GetDefaultNovaCellSpec()
+		spec["cellName"] = "cell1" + strings.Repeat("x", 31)
+		raw := map[string]interface{}{
+			"apiVersion": "nova.openstack.org/v1beta1",
+			"kind":       "NovaCell",
+			"metadata": map[string]interface{}{
+				"name":      cell0.CellName.Name,
+				"namespace": novaNames.Namespace,
+			},
+			"spec": spec,
+		}
+		unstructuredObj := &unstructured.Unstructured{Object: raw}
+		_, err := controllerutil.CreateOrPatch(
+			ctx, k8sClient, unstructuredObj, func() error { return nil })
+
+		Expect(err).Should(HaveOccurred())
+		statusError, ok := err.(*errors.StatusError)
+		Expect(ok).To(BeTrue())
+		Expect(statusError.ErrStatus.Details.Kind).To(Equal("NovaCell"))
+		Expect(statusError.ErrStatus.Message).To(
+			ContainSubstring(
+				"invalid: spec.cellName: " +
+					"Invalid value: \"cell1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\": " +
+					"should be shorter than 36 characters"),
+		)
+	})
+	It("rejects Nova with multiple errors", func() {
+		spec := GetDefaultNovaSpec()
+		cell0Template := GetDefaultNovaCellTemplate()
+		cell0Template["metadataServiceTemplate"] = map[string]interface{}{
+			"replicas": 1,
+		}
+
+		spec["cellTemplates"] = map[string]interface{}{
+			// error: this is cell0 with metadata
+			"cell0": cell0Template,
+			// error: this is a too long cell name
+			"cell1" + strings.Repeat("x", 31): cell0Template,
+		}
+		raw := map[string]interface{}{
+			"apiVersion": "nova.openstack.org/v1beta1",
+			"kind":       "Nova",
+			"metadata": map[string]interface{}{
+				"name":      novaNames.NovaName.Name,
+				"namespace": novaNames.Namespace,
+			},
+			"spec": spec,
+		}
+
+		unstructuredObj := &unstructured.Unstructured{Object: raw}
+		_, err := controllerutil.CreateOrPatch(
+			ctx, k8sClient, unstructuredObj, func() error { return nil })
+
+		Expect(err).Should(HaveOccurred())
+		statusError, ok := err.(*errors.StatusError)
+		Expect(ok).To(BeTrue())
+		Expect(statusError.ErrStatus.Details.Kind).To(Equal("Nova"))
+		Expect(statusError.ErrStatus.Details.Causes).To(HaveLen(2))
+		Expect(statusError.ErrStatus.Details.Causes).To(
+			ContainElement(metav1.StatusCause{
+				Type:    "FieldValueInvalid",
+				Message: "Invalid value: 1: should be 0 for cell0",
+				Field:   "spec.cellTemplates[cell0].metadataServiceTemplate.replicas",
+			}),
+		)
+		Expect(statusError.ErrStatus.Details.Causes).To(
+			ContainElement(metav1.StatusCause{
+				Type: "FieldValueInvalid",
+				Message: "Invalid value: \"cell1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\": " +
+					"should be shorter than 36 characters",
+				Field: "spec.cellTemplates[cell1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx]",
+			}),
+		)
+	})
+})


### PR DESCRIPTION
This is needed if we want to reject the API request at Nova CR creation. Also this will allow us to hook into the validation logic from openstack-operator as well see https://github.com/openstack-k8s-operators/openstack-operator/pull/355

This fixed the field descriptors to follow the yaml field names. This also fixed the Kind returned in the error message to match with the Kind being created.