### PR TITLE
Bump controller manager memory request and limit

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -64,9 +64,9 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 128Mi
+            memory: 256Mi
           requests:
             cpu: 10m
-            memory: 64Mi
+            memory: 128Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
Based on the measurement the main memory cost occurs at the startup of the controllers later during deployment of openstack services the operator memory consumption is fairly steady.

The measurements shows that the current operator consumes close to 120Mi memory after init. So the resource request of the operator is bumped to from 64Mi to 128Mi and the limit is bumped from 128Mi to 256Mi.

This was needed as we observed random OOM kills during operator startup.

Related: https://issues.redhat.com/browse/OSP-25984