### PR TITLE
Revert "Do not left behind AnsibleEE job pods"

### DIFF
--- a/controllers/novaexternalcompute_controller.go
+++ b/controllers/novaexternalcompute_controller.go
@@ -592,10 +592,6 @@ func (r *NovaExternalComputeReconciler) ensureAEEDeployLibvirt(
 		_, err = controllerutil.CreateOrPatch(ctx, h.GetClient(), ansibleEE, func() error {
 			initAEE(instance, ansibleEE, "deploy-libvirt.yaml")
 
-			err = controllerutil.SetControllerReference(instance, ansibleEE, h.GetScheme())
-			if err != nil {
-				return err
-			}
 			return nil
 		})
 
@@ -640,10 +636,6 @@ func (r *NovaExternalComputeReconciler) ensureAEEDeployNova(
 		_, err = controllerutil.CreateOrPatch(ctx, h.GetClient(), ansibleEE, func() error {
 			initAEE(instance, ansibleEE, "deploy-nova.yaml")
 
-			err = controllerutil.SetControllerReference(instance, ansibleEE, h.GetScheme())
-			if err != nil {
-				return err
-			}
 			return nil
 		})
 		if err != nil {

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -404,17 +404,10 @@ func CreateNovaExternalComputeSSHSecret(name types.NamespacedName) *corev1.Secre
 
 func GetAEE(name types.NamespacedName) *aee.OpenStackAnsibleEE {
 	instance := &aee.OpenStackAnsibleEE{}
-	novaExt := GetNovaExternalCompute(novaNames.ComputeName)
 
 	Eventually(func(g Gomega) {
 		g.Expect(k8sClient.Get(ctx, name, instance)).Should(Succeed())
 	}, timeout, interval).Should(Succeed())
-
-	Expect(instance.GetOwnerReferences()).To(HaveLen(1))
-	Expect(instance.GetOwnerReferences()[0]).To(HaveField("Name", novaExt.GetName()))
-	t := true
-	Expect(instance.GetOwnerReferences()[0]).To(HaveField("Controller", &t))
-
 	return instance
 }
 

--- a/test/functional/novaexternalcompute_controller_test.go
+++ b/test/functional/novaexternalcompute_controller_test.go
@@ -51,7 +51,6 @@ func CreateNovaCellAndEnsureReady(cell CellNames) {
 }
 
 var _ = Describe("NovaExternalCompute", func() {
-
 	When("created", func() {
 		var libvirtAEEName types.NamespacedName
 		var novaAEEName types.NamespacedName
@@ -81,12 +80,12 @@ var _ = Describe("NovaExternalCompute", func() {
 			}
 			CreateNovaExternalComputeSSHSecret(sshSecretName)
 			DeferCleanup(th.DeleteSecret, sshSecretName)
-			libvirtAEEName = types.NamespacedName{
+			libvirtAEEName := types.NamespacedName{
 				Namespace: novaNames.ComputeName.Namespace,
 				Name:      fmt.Sprintf("%s-%s-deploy-libvirt", compute.Spec.NovaInstance, compute.Name),
 			}
 			SimulateAEESucceeded(libvirtAEEName)
-			novaAEEName = types.NamespacedName{
+			novaAEEName := types.NamespacedName{
 				Namespace: novaNames.ComputeName.Namespace,
 				Name:      fmt.Sprintf("%s-%s-deploy-nova", compute.Spec.NovaInstance, compute.Name),
 			}
@@ -164,22 +163,6 @@ var _ = Describe("NovaExternalCompute", func() {
 			// it first
 			compute := GetNovaExternalCompute(novaNames.ComputeName)
 			th.DeleteInstance(compute)
-		})
-		It("adds controller reference to AnsibleEE", func() {
-			th.ExpectCondition(
-				novaNames.ComputeName,
-				ConditionGetterFunc(NovaExternalComputeConditionGetter),
-				condition.ReadyCondition,
-				corev1.ConditionTrue,
-			)
-
-			// Both AnsibleEE has a controller reference so that they
-			// are automatically cleaned up
-			var ansibleeeNames = []types.NamespacedName{libvirtAEEName, novaAEEName}
-			compute := GetNovaExternalCompute(novaNames.ComputeName)
-			for _, name := range ansibleeeNames {
-				AssertControllerRef(GetAEE(name), compute)
-			}
 		})
 	})
 	When("created but Secrets are missing or fields missing", func() {

--- a/test/functional/novaexternalcompute_controller_test.go
+++ b/test/functional/novaexternalcompute_controller_test.go
@@ -80,12 +80,12 @@ var _ = Describe("NovaExternalCompute", func() {
 			}
 			CreateNovaExternalComputeSSHSecret(sshSecretName)
 			DeferCleanup(th.DeleteSecret, sshSecretName)
-			libvirtAEEName := types.NamespacedName{
+			libvirtAEEName = types.NamespacedName{
 				Namespace: novaNames.ComputeName.Namespace,
 				Name:      fmt.Sprintf("%s-%s-deploy-libvirt", compute.Spec.NovaInstance, compute.Name),
 			}
 			SimulateAEESucceeded(libvirtAEEName)
-			novaAEEName := types.NamespacedName{
+			novaAEEName = types.NamespacedName{
 				Namespace: novaNames.ComputeName.Namespace,
 				Name:      fmt.Sprintf("%s-%s-deploy-nova", compute.Spec.NovaInstance, compute.Name),
 			}


### PR DESCRIPTION
This reverts commit 48c9264e2c3393dd796bd987620a2cb0c69771e9.

That commit added controller reference from NovaExternalCompute to the AnsibleEE CR so that those CRs are cleaned up properly when NovaExternalCompute is deleted. However it has a side effect that NovaExternalCompute will be reconciled *after* the AnsibleEE is deleted. So in the happy path when the deploy succeeded and the nova-operator deleted the AnsibleEE there will be an extra reconcile on the NovaExternalCompute due to the controller reference. There is a know issue #294 in nova-operator that the successful run of AnsibleEE is not persisted properly. Therefore such extra reconcile now triggered a new AnsibleEE creation causing an infinite deploy loop.

We do need the controller reference for cleanup. But we cannot have it until #294 is fixed.

Note that there is a second revert in this PR that reverts the test refactor happened on top of 48c9264e2c3393dd796bd987620a2cb0c69771e9 