### PR TITLE
this change adapts the makefile for split namespaces

### DIFF
--- a/controllers/novaexternalcompute_controller.go
+++ b/controllers/novaexternalcompute_controller.go
@@ -229,7 +229,7 @@ func (r *NovaExternalComputeReconciler) Reconcile(ctx context.Context, req ctrl.
 			)
 		}
 
-		// we only get here if we completed successfully so we can just delete them
+		// we only get here if we completed successfully so we can just delete themg
 		err = r.cleanupAEE(ctx, h, libvirtAEE)
 		if err != nil {
 			return ctrl.Result{}, err


### PR DESCRIPTION
As part of the fallout for moving to split namespaces the
make target to remove the nova opearator and webhooks was broken

This change resolves that so that make run-with-webhooks
will now remove the deploy operator and olm installed
webhooks via delegating to an update-nova-csv target.
