### PR TITLE
Renaming network related variables to align with edpm naming scheme

### DIFF
--- a/config/samples/external-compute/openstackdataplanerole.yaml
+++ b/config/samples/external-compute/openstackdataplanerole.yaml
@@ -30,8 +30,8 @@ spec:
       #
       # These vars are for the network config templates themselves and are
       # considered EDPM network defaults.
-      neutron_physical_bridge_name: br-ex
-      neutron_public_interface_name: eth0
+      edpm_network_config_bridge_name: br-ex
+      edpm_network_config_interface_name: eth0
       ctlplane_mtu: 1500
       ctlplane_subnet_cidr: 24
       ctlplane_gateway_ip: 192.168.122.1


### PR DESCRIPTION
The variables `neutron_public_interface_name` and `neutron_physical_bridge_name` have been renamed in edpm-ansible collection. This change hasn't been propagated correctly however. Therefore all the other occurrences have to be changed, to make sure that the role will affect deployment as requested.  
 
Please exercise caution while reviewing this PR. There is a considerable chance of new bugs being introduced as side effects.

Depends-On: https://github.com/openstack-k8s-operators/edpm-ansible/pull/201 