### PR TITLE
[envtest] Fix k8s conflict handling logic

### DIFF
--- a/test/functional/nova_metadata_controller_test.go
+++ b/test/functional/nova_metadata_controller_test.go
@@ -25,7 +25,6 @@ import (
 	. "github.com/openstack-k8s-operators/lib-common/modules/test/helpers"
 
 	corev1 "k8s.io/api/core/v1"
-	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -552,8 +551,7 @@ var _ = Describe("NovaMetadata controller", func() {
 				novaMetadata := GetNovaMetadata(novaNames.MetadataName)
 				novaMetadata.Spec.NetworkAttachments = append(novaMetadata.Spec.NetworkAttachments, "internalapi")
 
-				err := k8sClient.Update(ctx, novaMetadata)
-				g.Expect(err == nil || k8s_errors.IsConflict(err)).To(BeTrue())
+				g.Expect(k8sClient.Update(ctx, novaMetadata)).To(Succeed())
 			}, timeout, interval).Should(Succeed())
 
 			th.ExpectConditionWithDetails(
@@ -630,8 +628,7 @@ var _ = Describe("NovaMetadata controller", func() {
 			Eventually(func(g Gomega) {
 				novaMetadata := GetNovaMetadata(novaNames.MetadataName)
 				novaMetadata.Spec.RegisteredCells = map[string]string{"cell0": "cell0-config-hash"}
-				err := k8sClient.Update(ctx, novaMetadata)
-				g.Expect(err == nil || k8s_errors.IsConflict(err)).To(BeTrue())
+				g.Expect(k8sClient.Update(ctx, novaMetadata)).To(Succeed())
 			}, timeout, interval).Should(Succeed())
 
 			// Assert that the CONFIG_HASH of the StateFulSet is changed due to this reconfiguration

--- a/test/functional/nova_novncproxy_test.go
+++ b/test/functional/nova_novncproxy_test.go
@@ -16,6 +16,7 @@ package functional_test
 import (
 	"encoding/json"
 	"fmt"
+
 	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -24,7 +25,6 @@ import (
 	. "github.com/openstack-k8s-operators/lib-common/modules/test/helpers"
 	novav1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -520,8 +520,7 @@ var _ = Describe("NovaNoVNCProxy controller", func() {
 				noVNCProxy := GetNovaNoVNCProxy(novaNames.NoVNCProxyName)
 				noVNCProxy.Spec.NetworkAttachments = append(noVNCProxy.Spec.NetworkAttachments, "internalapi")
 
-				err := k8sClient.Update(ctx, noVNCProxy)
-				g.Expect(err == nil || k8s_errors.IsConflict(err)).To(BeTrue())
+				g.Expect(k8sClient.Update(ctx, noVNCProxy)).To(Succeed())
 			}, timeout, interval).Should(Succeed())
 
 			th.ExpectConditionWithDetails(

--- a/test/functional/nova_reconfiguration_test.go
+++ b/test/functional/nova_reconfiguration_test.go
@@ -26,7 +26,6 @@ import (
 	novav1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -159,8 +158,7 @@ var _ = Describe("Nova reconfiguration", func() {
 				(&cell0).ConductorServiceTemplate.Replicas = &zero
 				nova.Spec.CellTemplates["cell0"] = cell0
 
-				err := k8sClient.Update(ctx, nova)
-				g.Expect(err == nil || k8s_errors.IsConflict(err)).To(BeTrue())
+				g.Expect(k8sClient.Update(ctx, nova)).To(Succeed())
 
 				deployment = &appsv1.StatefulSet{}
 				g.Expect(k8sClient.Get(ctx, cell0DeploymentName, deployment)).Should(Succeed())
@@ -179,8 +177,7 @@ var _ = Describe("Nova reconfiguration", func() {
 				(&cell1).ConductorServiceTemplate.NetworkAttachments = attachments
 				nova.Spec.CellTemplates["cell1"] = cell1
 
-				err := k8sClient.Update(ctx, nova)
-				g.Expect(err == nil || k8s_errors.IsConflict(err)).To(BeTrue())
+				g.Expect(k8sClient.Update(ctx, nova)).To(Succeed())
 			}, timeout, interval).Should(Succeed())
 
 			th.ExpectConditionWithDetails(
@@ -271,8 +268,7 @@ var _ = Describe("Nova reconfiguration", func() {
 				newSelector := map[string]string{"foo": "bar"}
 				nova.Spec.NodeSelector = newSelector
 
-				err := k8sClient.Update(ctx, nova)
-				g.Expect(err == nil || k8s_errors.IsConflict(err)).To(BeTrue())
+				g.Expect(k8sClient.Update(ctx, nova)).To(Succeed())
 
 				novaDeploymentName := serviceNameFunc()
 				serviceDeployment := th.GetStatefulSet(novaDeploymentName)
@@ -287,8 +283,7 @@ var _ = Describe("Nova reconfiguration", func() {
 				newSelector := map[string]string{}
 				nova.Spec.NodeSelector = newSelector
 
-				err := k8sClient.Update(ctx, nova)
-				g.Expect(err == nil || k8s_errors.IsConflict(err)).To(BeTrue())
+				g.Expect(k8sClient.Update(ctx, nova)).To(Succeed())
 
 				serviceDeploymentName := serviceNameFunc()
 				serviceDeployment := th.GetStatefulSet(serviceDeploymentName)
@@ -333,8 +328,7 @@ var _ = Describe("Nova reconfiguration", func() {
 					cellTemplate.ConductorServiceTemplate.NodeSelector = conductorSelector
 					nova.Spec.CellTemplates[cell] = cellTemplate
 				}
-				err := k8sClient.Update(ctx, nova)
-				g.Expect(err == nil || k8s_errors.IsConflict(err)).To(BeTrue())
+				g.Expect(k8sClient.Update(ctx, nova)).To(Succeed())
 
 				apiDeployment := th.GetStatefulSet(novaNames.APIDeploymentName)
 				g.Expect(apiDeployment.Spec.Template.Spec.NodeSelector).To(Equal(serviceSelector))
@@ -357,8 +351,7 @@ var _ = Describe("Nova reconfiguration", func() {
 				nova := GetNova(novaNames.NovaName)
 				nova.Spec.NodeSelector = globalSelector
 
-				err := k8sClient.Update(ctx, nova)
-				g.Expect(err == nil || k8s_errors.IsConflict(err)).To(BeTrue())
+				g.Expect(k8sClient.Update(ctx, nova)).To(Succeed())
 
 				// NovaService's deployment keeps it own selector
 				apiDeployment := th.GetStatefulSet(novaNames.APIDeploymentName)
@@ -393,8 +386,7 @@ var _ = Describe("Nova reconfiguration", func() {
 				cell1.CellMessageBusInstance = "alternate-mq-for-cell1"
 				nova.Spec.CellTemplates["cell1"] = cell1
 
-				err := k8sClient.Update(ctx, nova)
-				g.Expect(err == nil || k8s_errors.IsConflict(err)).To(BeTrue())
+				g.Expect(k8sClient.Update(ctx, nova)).To(Succeed())
 			}, timeout, interval).Should(Succeed())
 
 			// The new TransportURL will point to a new secret so we need to

--- a/test/functional/nova_scheduler_test.go
+++ b/test/functional/nova_scheduler_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	novav1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -443,8 +442,7 @@ var _ = Describe("NovaScheduler controller", func() {
 				novaScheduler := GetNovaScheduler(novaNames.SchedulerName)
 				novaScheduler.Spec.NetworkAttachments = append(novaScheduler.Spec.NetworkAttachments, "internalapi")
 
-				err := k8sClient.Update(ctx, novaScheduler)
-				g.Expect(err == nil || k8s_errors.IsConflict(err)).To(BeTrue())
+				g.Expect(k8sClient.Update(ctx, novaScheduler)).To(Succeed())
 			}, timeout, interval).Should(Succeed())
 
 			th.ExpectConditionWithDetails(
@@ -523,8 +521,7 @@ var _ = Describe("NovaScheduler controller", func() {
 			Eventually(func(g Gomega) {
 				novaAPI := GetNovaScheduler(novaNames.SchedulerName)
 				novaAPI.Spec.RegisteredCells = map[string]string{"cell0": "cell0-config-hash"}
-				err := k8sClient.Update(ctx, novaAPI)
-				g.Expect(err == nil || k8s_errors.IsConflict(err)).To(BeTrue())
+				g.Expect(k8sClient.Update(ctx, novaAPI)).To(Succeed())
 			}, timeout, interval).Should(Succeed())
 
 			// Assert that the CONFIG_HASH of the StateFulSet is changed due to this reconfiguration

--- a/test/functional/novaapi_controller_test.go
+++ b/test/functional/novaapi_controller_test.go
@@ -26,7 +26,6 @@ import (
 	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	novav1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -594,8 +593,7 @@ var _ = Describe("NovaAPI controller", func() {
 				novaAPI := GetNovaAPI(novaNames.APIName)
 				novaAPI.Spec.NetworkAttachments = append(novaAPI.Spec.NetworkAttachments, "internalapi")
 
-				err := k8sClient.Update(ctx, novaAPI)
-				g.Expect(err == nil || k8s_errors.IsConflict(err)).To(BeTrue())
+				g.Expect(k8sClient.Update(ctx, novaAPI)).To(Succeed())
 			}, timeout, interval).Should(Succeed())
 
 			th.ExpectConditionWithDetails(
@@ -673,8 +671,7 @@ var _ = Describe("NovaAPI controller", func() {
 			Eventually(func(g Gomega) {
 				novaAPI := GetNovaAPI(novaNames.APIName)
 				novaAPI.Spec.RegisteredCells = map[string]string{"cell0": "cell0-config-hash"}
-				err := k8sClient.Update(ctx, novaAPI)
-				g.Expect(err == nil || k8s_errors.IsConflict(err)).To(BeTrue())
+				g.Expect(k8sClient.Update(ctx, novaAPI)).To(Succeed())
 			}, timeout, interval).Should(Succeed())
 
 			// Assert that the CONFIG_HASH of the StateFulSet is changed due to this reconfiguration

--- a/test/functional/novacell_controller_test.go
+++ b/test/functional/novacell_controller_test.go
@@ -22,7 +22,6 @@ import (
 	. "github.com/openstack-k8s-operators/lib-common/modules/test/helpers"
 
 	corev1 "k8s.io/api/core/v1"
-	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -153,8 +152,7 @@ var _ = Describe("NovaCell controller", func() {
 				novaCell.Spec.ConductorServiceTemplate.NetworkAttachments = append(
 					novaCell.Spec.ConductorServiceTemplate.NetworkAttachments, "internalapi")
 
-				err := k8sClient.Update(ctx, novaCell)
-				g.Expect(err == nil || k8s_errors.IsConflict(err)).To(BeTrue())
+				g.Expect(k8sClient.Update(ctx, novaCell)).To(Succeed())
 			}, timeout, interval).Should(Succeed())
 
 			th.ExpectConditionWithDetails(

--- a/test/functional/novaconductor_controller_test.go
+++ b/test/functional/novaconductor_controller_test.go
@@ -25,7 +25,6 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -615,8 +614,7 @@ var _ = Describe("NovaConductor controller", func() {
 				novaConductor := GetNovaConductor(novaNames.ConductorName)
 				novaConductor.Spec.NetworkAttachments = append(novaConductor.Spec.NetworkAttachments, "internalapi")
 
-				err := k8sClient.Update(ctx, novaConductor)
-				g.Expect(err == nil || k8s_errors.IsConflict(err)).To(BeTrue())
+				g.Expect(k8sClient.Update(ctx, novaConductor)).To(Succeed())
 			}, timeout, interval).Should(Succeed())
 
 			th.ExpectConditionWithDetails(

--- a/test/functional/novaexternalcompute_controller_test.go
+++ b/test/functional/novaexternalcompute_controller_test.go
@@ -23,7 +23,6 @@ import (
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	. "github.com/openstack-k8s-operators/lib-common/modules/test/helpers"
 	corev1 "k8s.io/api/core/v1"
-	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -401,8 +400,7 @@ var _ = Describe("NovaExternalCompute", func() {
 			Eventually(func(g Gomega) {
 				compute := GetNovaExternalCompute(novaNames.ComputeName)
 				compute.Spec.InventoryConfigMapName = "non-existent"
-				err := k8sClient.Update(ctx, compute)
-				g.Expect(err == nil || k8s_errors.IsConflict(err)).To(BeTrue())
+				g.Expect(k8sClient.Update(ctx, compute)).To(Succeed())
 			}, timeout, interval).Should(Succeed())
 
 			th.ExpectConditionWithDetails(


### PR DESCRIPTION
We used
```
Eventualy(func(){
...
  g.Expect(err == nil || k8s_errors.IsConflict(err)).To(BeTrue())
  ...
})...
```
to say that we want to retry on conflict. But actually this will report success when conflict happens. So in the rare case when that conflict happens during test execution the test moves forward instead of retrying. This is fixed now.