### PR TITLE
add inital molecule setup.

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,8 @@
+[allowlist]
+   description = "ignore test dirs"
+
+  # Ignore based on any subset of the file path
+  paths = [
+    '''\/test''',
+    '''\/molecule''',
+  ]

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,33 @@
+---
+# Based on ansible-lint config
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable
+  truthy: disable

--- a/molecule/default/INSTALL.rst
+++ b/molecule/default/INSTALL.rst
@@ -1,0 +1,23 @@
+*********************************
+Vagrant driver installation guide
+*********************************
+
+Requirements
+============
+
+* Vagrant
+* Virtualbox, Parallels, VMware Fusion, VMware Workstation or VMware Desktop
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ pip install 'molecule-plugins[vagrant]'

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,0 +1,100 @@
+
+- name: Setup Test Environment
+  hosts: AEE
+  tasks:
+    - name: Copy playbooks to AEE vm
+      ansible.builtin.copy:
+        src: "{{ item.src }}"
+        dest: "{{ item.dest }}"
+        mode: "{{ item.mode | default('640') }}"
+      with_items:
+      - { "src": "../../playbooks/deploy-libvirt.yaml",
+          "dest": "~/deploy-libvirt.yaml"
+        }
+      - { "src": "../../playbooks/deploy-nova.yaml",
+          "dest": "~/deploy-nova.yaml"
+        }
+    - name: Copy molecule files
+      ansible.builtin.copy:
+        src: "{{ item.src }}"
+        dest: "{{ item.dest }}"
+        mode: "{{ item.mode | default('600') }}"
+      with_items:
+      - { "src": "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/.vagrant/machines/compute-1/libvirt/private_key",
+          "dest": "~/private_key"
+        }
+    - name: install packages
+      become: true
+      ansible.builtin.package:
+        name:
+          - podman
+          - rsync
+        state: present
+    - name: secret config dir
+      become: true
+      ansible.builtin.file:
+        path: "{{ item.path }}"
+        state: directory
+        setype: "{{ item.setype | default('container_file_t') }}"
+        owner: "{{ item.owner | default(ansible_user) }}"
+        group: "{{ item.group | default(ansible_user) }}"
+        mode: "{{ item.mode | default('750') }}"
+        recurse: true
+      with_items:
+      - {"path": /var/lib/openstack/config/}
+    - name: Copy playbooks to AEE vm
+      ansible.posix.synchronize:
+        src: "test-data/compute-secret/"
+        dest: "/var/lib/openstack/config/"
+        delete: true
+
+- name: Setup DUT
+  hosts: "compute-1"
+  tasks:
+    - name: install packages
+      become: true
+      ansible.builtin.package:
+        name:
+          - podman
+          - rsync
+          - python-pyyaml
+        state: present
+    - name: set /etc/localtime
+      become: true
+      ansible.builtin.file:
+        path: /etc/localtime
+        src: /usr/share/zoneinfo/UTC
+        state: link
+    - name: emulate ovs installation
+      become: true
+      ansible.builtin.file:
+        path: /run/openvswitch
+        state: directory
+
+
+- name: Run Playbooks
+  hosts: AEE
+  tasks:
+    # NOTE: this is a workaround to ensure that the files that are bind mounted
+    # into the AEE containers are accssible to ansible. Selinux is not disabled
+    # on the compute-1 vm so this has no impact on the playbook testing.
+    - name: disable selinux
+      become: true
+      ansible.builtin.selinux:
+        state: disabled
+    - name: pull quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest image with podman
+      ansible.builtin.command: podman pull quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
+    - name: run deploy-libvirt.yaml with podman
+      ansible.builtin.command: |
+        podman run --net host --rm -v /var/lib/openstack/config/:/var/lib/openstack/config/ \
+        -v ~/deploy-libvirt.yaml:/runner/deploy-libvirt.yaml -v ~/private_key:/runner/private_key -e ANSIBLE_HOST_KEY_CHECKING=False \
+        -e ANSIBLE_REMOTE_USER=vagrant -e ANSIBLE_SSH_PRIVATE_KEY_FILE=/runner/private_key \
+        -e ANSIBLE_SSH_ARGS="-o StrictHostKeyChecking=no" quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest \
+        ansible-playbook -i 'compute-1,' --key-file /runner/private_key -u vagrant  /runner/deploy-libvirt.yaml
+    - name: run deploy-nova.yaml with podman
+      ansible.builtin.command: |
+        podman run --net host --rm -v /var/lib/openstack/config/:/var/lib/openstack/config/ \
+        -v ~/deploy-nova.yaml:/runner/deploy-nova.yaml -v ~/private_key:/runner/private_key -e ANSIBLE_HOST_KEY_CHECKING=False \
+        -e ANSIBLE_REMOTE_USER=vagrant -e ANSIBLE_SSH_PRIVATE_KEY_FILE=/runner/private_key \
+        -e ANSIBLE_SSH_ARGS="-o StrictHostKeyChecking=no" quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest \
+        ansible-playbook -i 'compute-1,' --key-file /runner/private_key -u vagrant  /runner/deploy-nova.yaml

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,34 @@
+---
+dependency:
+  name: galaxy
+verifier:
+  name: ansible
+driver:
+  name: vagrant
+  provider:
+    name: libvirt
+  provision: no
+  cachier: machine
+  parallel: true
+  default_box: 'generic/rocky9'
+platforms:
+  - name: AEE
+    memory: 2048
+    cpus: 2
+    provider_options:
+      cpu_mode: 'host-passthrough'
+      nested: true
+      machine_type: 'q35'
+    groups:
+      - oepnshift
+  - name: compute-1
+    memory: 6000
+    cpus: 4
+    provider_options:
+      cpu_mode: 'host-passthrough'
+      nested: true
+      machine_type: 'q35'
+    groups:
+      - compute
+provisioner:
+  name: ansible

--- a/molecule/default/test-data/compute-secret/01-nova.conf
+++ b/molecule/default/test-data/compute-secret/01-nova.conf
@@ -1,0 +1,184 @@
+[DEFAULT]
+# concurrent live migrations are more likely to fail and are slower
+# overall then serializing live migrations so set this to 1 explictly
+max_concurrent_live_migrations=1
+state_path = /var/lib/nova
+allow_resize_to_same_host = true
+# enable log rotation in oslo config by default
+max_logfile_count=5
+max_logfile_size_mb=50
+log_rotation_type=size
+
+log_file = /var/log/containers/nova/nova-compute.log
+
+debug=true
+
+compute_driver=libvirt.LibvirtDriver
+
+# ensure safe defaults for new hosts
+initial_cpu_allocation_ratio=4.0
+initial_ram_allocation_ratio=1.0
+initial_disk_allocation_ratio=0.9
+
+
+force_config_drive=True
+transport_url=rabbit://default_user_DGeM7Q2ru6F-QypVkXX:ZKkjLjOOKdsqYtCmObzzIRkjEpTmpDUu@rabbitmq-cell1.openstack.svc:5672
+
+
+
+[oslo_concurrency]
+lock_path = /var/lib/nova/tmp
+
+[oslo_messaging_rabbit]
+amqp_durable_queues=false
+amqp_auto_delete=false
+# we should consider using quorum queues instead
+# rabbit_quorum_queue=true
+
+
+heartbeat_in_pthread=false
+
+
+
+
+
+
+
+
+
+
+
+
+[oslo_messaging_notifications]
+
+driver = noop
+
+
+
+
+
+[vnc]
+enabled = True
+novncproxy_host = "::0"
+novncproxy_port = 6080
+server_listen = "::0"
+
+
+# note we may want to use console_host instead of my_ip however it wont be resolved via
+# dns currently so we need to use my_ip for now.
+# https://docs.openstack.org/nova/latest/configuration/config.html#DEFAULT.console_host
+server_proxyclient_address = "$my_ip"
+novncproxy_base_url = http://nova-novncproxy-cell1-public-openstack.apps-crc.testing/vnc_lite.html
+
+
+
+[cache]
+# always enable caching
+enabled = True
+
+# on compute nodes or where memcache is not deployed we should use an in memory
+# dict cache
+backend = oslo_cache.dict
+
+
+[workarounds]
+disable_fallback_pcpu_query=true
+
+enable_qemu_monitor_announce_self=true
+reserve_disk_resource_for_image_cache=true
+
+
+
+[libvirt]
+live_migration_permit_post_copy=true
+live_migration_permit_auto_converge=true
+live_migration_timeout_action=force_complete
+cpu_mode=host-model
+hw_machine_type=x86_64=q35
+sysinfo_serial=unique
+mem_stats_period_seconds=0
+num_pcie_ports=24
+images_type=qcow2
+rx_queue_size=512
+tx_queue_size=512
+swtpm_enabled=True
+
+
+
+
+
+
+
+[keystone_authtoken]
+www_authenticate_uri = http://keystone-internal.openstack.svc:5000
+auth_url =  http://keystone-internal.openstack.svc:5000
+auth_type = password
+project_domain_name = Default
+user_domain_name = Default
+project_name = service
+username = nova
+password = 12345678
+cafile =
+region_name = regionOne
+
+[placement]
+auth_url =  http://keystone-internal.openstack.svc:5000
+auth_type = password
+project_domain_name = Default
+user_domain_name = Default
+project_name = service
+username = nova
+password = 12345678
+cafile =
+region_name = regionOne
+valid_interfaces = internal
+
+[glance]
+auth_url = http://keystone-internal.openstack.svc:5000
+auth_type = password
+project_domain_name = Default
+user_domain_name = Default
+project_name = service
+username = nova
+password = 12345678
+cafile =
+region_name = regionOne
+valid_interfaces = internal
+
+
+[neutron]
+auth_url = http://keystone-internal.openstack.svc:5000
+auth_type = password
+project_domain_name = Default
+user_domain_name = Default
+project_name = service
+username = nova
+password = 12345678
+cafile =
+region_name = regionOne
+valid_interfaces = internal
+
+service_metadata_proxy = true
+
+[cinder]
+auth_url = http://keystone-internal.openstack.svc:5000
+auth_type = password
+project_domain_name = Default
+user_domain_name = Default
+project_name = service
+username = nova
+password = 12345678
+cafile =
+region_name = regionOne
+catalog_info = volumev3:cinderv3:internalURL
+
+[service_user]
+send_service_user_token = true
+auth_url = http://keystone-internal.openstack.svc:5000
+auth_type = password
+project_domain_name = Default
+user_domain_name = Default
+project_name = service
+username = nova
+password = 12345678
+cafile =

--- a/molecule/default/test-data/compute-secret/libvirt_virtlogd__libvirt-virtlogd.json
+++ b/molecule/default/test-data/compute-secret/libvirt_virtlogd__libvirt-virtlogd.json
@@ -1,0 +1,28 @@
+{
+    "command": "/usr/sbin/virtlogd --config /etc/libvirt/virtlogd.conf",
+    "config_files": [
+        {
+            "source": "/var/lib/openstack/config/virtlogd.conf",
+            "dest": "/etc/libvirt/virtlogd.conf",
+            "owner": "libvirt",
+            "perm": "0600"
+        }
+    ],
+    "permissions": [
+        {
+            "path": "/var/log/containers/libvirt",
+            "owner": "libvirt:libvirt",
+            "recurse": true
+        },
+        {
+            "path": "/var/lib/libvirt",
+            "owner": "libvirt:libvirt",
+            "recurse": true
+        },
+        {
+            "path": "/run/libvirt",
+            "owner": "libvirt:libvirt",
+            "recurse": true
+        }
+    ]
+}

--- a/molecule/default/test-data/compute-secret/libvirt_virtlogd__libvirt_virtlogd.json
+++ b/molecule/default/test-data/compute-secret/libvirt_virtlogd__libvirt_virtlogd.json
@@ -1,0 +1,19 @@
+{
+    "image": "quay.io/podified-antelope-centos9/openstack-nova-libvirt:current-podified",
+    "restart": "always",
+    "command": "kolla_start",
+    "net": "host",
+    "privileged": "true",
+    "environment": {
+        "KOLLA_CONFIG_STRATEGY":"COPY_ALWAYS",
+        "KOLLA_CONFIG_FILE":"/var/lib/openstack/config/libvirt-virtlogd.json"
+    },
+    "volumes": [
+        "/var/lib/openstack/config/libvirt:/var/lib/openstack/config:ro",
+        "/etc/localtime:/etc/localtime:ro",
+        "/var/log/containers/libvirt:/var/log/containers/libvirt",
+        "/var/lib/libvirt:/var/lib/libvirt",
+        "/var/lib/nova:/var/lib/nova",
+        "/run/libvirt:/run/libvirt"
+    ]
+  }

--- a/molecule/default/test-data/compute-secret/libvirt_virtlogd__virtlogd.conf
+++ b/molecule/default/test-data/compute-secret/libvirt_virtlogd__virtlogd.conf
@@ -1,0 +1,2 @@
+log_filters="1:logging 4:object 4:json 4:event 1:util"
+log_outputs="1:file:/var/log/containers/libvirt/virtlogd.log"

--- a/molecule/default/test-data/compute-secret/libvirt_virtnodedevd__libvirt-virtnodedevd.json
+++ b/molecule/default/test-data/compute-secret/libvirt_virtnodedevd__libvirt-virtnodedevd.json
@@ -1,0 +1,28 @@
+{
+    "command": "/usr/sbin/virtnodedevd --config /etc/libvirt/virtnodedevd.conf",
+    "config_files": [
+        {
+            "source": "/var/lib/openstack/config/virtnodedevd.conf",
+            "dest": "/etc/libvirt/virtnodedevd.conf",
+            "owner": "libvirt",
+            "perm": "0600"
+        }
+    ],
+    "permissions": [
+        {
+            "path": "/var/log/containers/libvirt",
+            "owner": "libvirt:libvirt",
+            "recurse": true
+        },
+        {
+            "path": "/var/lib/libvirt",
+            "owner": "libvirt:libvirt",
+            "recurse": true
+        },
+        {
+            "path": "/run/libvirt",
+            "owner": "libvirt:libvirt",
+            "recurse": true
+        }
+    ]
+}

--- a/molecule/default/test-data/compute-secret/libvirt_virtnodedevd__libvirt_virtnodedevd.json
+++ b/molecule/default/test-data/compute-secret/libvirt_virtnodedevd__libvirt_virtnodedevd.json
@@ -1,0 +1,19 @@
+{
+    "image": "quay.io/podified-antelope-centos9/openstack-nova-libvirt:current-podified",
+    "restart": "always",
+    "command": "kolla_start",
+    "net": "host",
+    "privileged": "true",
+    "environment": {
+        "KOLLA_CONFIG_STRATEGY":"COPY_ALWAYS",
+        "KOLLA_CONFIG_FILE":"/var/lib/openstack/config/libvirt-virtnodedevd.json"
+    },
+    "volumes": [
+        "/var/lib/openstack/config/libvirt:/var/lib/openstack/config:ro",
+        "/etc/localtime:/etc/localtime:ro",
+        "/var/log/containers/libvirt:/var/log/containers/libvirt",
+        "/var/lib/libvirt:/var/lib/libvirt",
+        "/run/libvirt:/run/libvirt",
+        "/dev:/dev"
+    ]
+  }

--- a/molecule/default/test-data/compute-secret/libvirt_virtnodedevd__virtnodedevd.conf
+++ b/molecule/default/test-data/compute-secret/libvirt_virtnodedevd__virtnodedevd.conf
@@ -1,0 +1,7 @@
+unix_sock_group="libvirt"
+unix_sock_ro_perms="0444"
+unix_sock_rw_perms="0770"
+auth_unix_ro="none"
+auth_unix_rw="none"
+log_filters="1:qemu 1:libvirt 4:object 4:json 4:event 1:util"
+log_outputs="1:file:/var/log/containers/libvirt/virtnodedevd.log"

--- a/molecule/default/test-data/compute-secret/libvirt_virtproxyd__libvirt-virtproxyd.json
+++ b/molecule/default/test-data/compute-secret/libvirt_virtproxyd__libvirt-virtproxyd.json
@@ -1,0 +1,28 @@
+{
+    "command": "/usr/sbin/virtproxyd --config /etc/libvirt/virtproxyd.conf",
+    "config_files": [
+        {
+            "source": "/var/lib/openstack/config/virtproxyd.conf",
+            "dest": "/etc/libvirt/virtproxyd.conf",
+            "owner": "libvirt",
+            "perm": "0600"
+        }
+    ],
+    "permissions": [
+        {
+            "path": "/var/log/containers/libvirt",
+            "owner": "libvirt:libvirt",
+            "recurse": true
+        },
+        {
+            "path": "/var/lib/libvirt",
+            "owner": "libvirt:libvirt",
+            "recurse": true
+        },
+        {
+            "path": "/run/libvirt",
+            "owner": "libvirt:libvirt",
+            "recurse": true
+        }
+    ]
+}

--- a/molecule/default/test-data/compute-secret/libvirt_virtproxyd__libvirt_virtproxyd.json
+++ b/molecule/default/test-data/compute-secret/libvirt_virtproxyd__libvirt_virtproxyd.json
@@ -1,0 +1,18 @@
+{
+    "image": "quay.io/podified-antelope-centos9/openstack-nova-libvirt:current-podified",
+    "restart": "always",
+    "command": "kolla_start",
+    "net": "host",
+    "privileged": "true",
+    "environment": {
+        "KOLLA_CONFIG_STRATEGY":"COPY_ALWAYS",
+        "KOLLA_CONFIG_FILE":"/var/lib/openstack/config/libvirt-virtproxyd.json"
+    },
+    "volumes": [
+        "/var/lib/openstack/config/libvirt:/var/lib/openstack/config:ro",
+        "/etc/localtime:/etc/localtime:ro",
+        "/var/log/containers/libvirt:/var/log/containers/libvirt",
+        "/var/lib/libvirt:/var/lib/libvirt",
+        "/run/libvirt:/run/libvirt"
+    ]
+  }

--- a/molecule/default/test-data/compute-secret/libvirt_virtproxyd__virtproxyd.conf
+++ b/molecule/default/test-data/compute-secret/libvirt_virtproxyd__virtproxyd.conf
@@ -1,0 +1,9 @@
+listen_tls=0
+listen_tcp=0
+unix_sock_group="libvirt"
+unix_sock_ro_perms="0444"
+unix_sock_rw_perms="0770"
+auth_unix_ro="none"
+auth_unix_rw="none"
+log_filters="1:qemu 1:libvirt 4:object 4:json 4:event 1:util"
+log_outputs="1:file:/var/log/containers/libvirt/virtproxyd.log"

--- a/molecule/default/test-data/compute-secret/libvirt_virtqemud__libvirt-virtqemud.json
+++ b/molecule/default/test-data/compute-secret/libvirt_virtqemud__libvirt-virtqemud.json
@@ -1,0 +1,40 @@
+{
+    "command": "/usr/sbin/virtqemud --config /etc/libvirt/virtqemud.conf",
+    "config_files": [
+        {
+            "source": "/var/lib/openstack/config/virtqemud.conf",
+            "dest": "/etc/libvirt/virtqemud.conf",
+            "owner": "libvirt",
+            "perm": "0600"
+        },
+        {
+            "source": "/var/lib/openstack/config/ceph",
+            "dest": "/etc/ceph",
+            "owner": "libvirt:qemu",
+            "perm": "0770",
+            "optional": true
+        }
+    ],
+    "permissions": [
+        {
+            "path": "/etc/ceph/*",
+            "owner": "libvirt:qemu",
+            "perm:": "0660"
+        },
+        {
+            "path": "/var/log/containers/libvirt",
+            "owner": "libvirt:libvirt",
+            "recurse": true
+        },
+        {
+            "path": "/var/lib/libvirt",
+            "owner": "libvirt:libvirt",
+            "recurse": true
+        } ,
+        {
+            "path": "/run/libvirt",
+            "owner": "libvirt:libvirt",
+            "recurse": true
+        }
+    ]
+}

--- a/molecule/default/test-data/compute-secret/libvirt_virtqemud__libvirt_virtqemud.json
+++ b/molecule/default/test-data/compute-secret/libvirt_virtqemud__libvirt_virtqemud.json
@@ -1,0 +1,23 @@
+{
+    "image": "quay.io/podified-antelope-centos9/openstack-nova-libvirt:current-podified",
+    "restart": "always",
+    "command": "kolla_start",
+    "pid": "host",
+    "net": "host",
+    "cgroupns": "host",
+    "privileged": "true",
+    "environment": {
+        "KOLLA_CONFIG_STRATEGY":"COPY_ALWAYS",
+        "KOLLA_CONFIG_FILE":"/var/lib/openstack/config/libvirt-virtqemud.json"
+    },
+    "volumes": [
+        "/var/lib/openstack/config/libvirt:/var/lib/openstack/config:ro",
+        "/etc/localtime:/etc/localtime:ro",
+        "/var/log/containers/libvirt:/var/log/containers/libvirt",
+        "/var/lib/libvirt:/var/lib/libvirt",
+        "/var/lib/nova:/var/lib/nova",
+        "/run/libvirt:/run/libvirt",
+        "/dev:/dev",
+        "/etc/ceph:/var/lib/openstack/config/ceph:ro"
+    ]
+  }

--- a/molecule/default/test-data/compute-secret/libvirt_virtqemud__qemu.conf
+++ b/molecule/default/test-data/compute-secret/libvirt_virtqemud__qemu.conf
@@ -1,0 +1,9 @@
+max_files = 32768
+max_processes = 131072
+vnc_tls = 0
+vnc_tls_x509_verify = 0
+vnc_listen = 0.0.0.0
+default_tls_x509_verify = 1
+nbd_tls = 0
+migration_port_min = 61152
+migration_port_max = 61215

--- a/molecule/default/test-data/compute-secret/libvirt_virtqemud__virtqemud.conf
+++ b/molecule/default/test-data/compute-secret/libvirt_virtqemud__virtqemud.conf
@@ -1,0 +1,7 @@
+unix_sock_group="libvirt"
+unix_sock_ro_perms="0444"
+unix_sock_rw_perms="0770"
+auth_unix_ro="none"
+auth_unix_rw="none"
+log_filters="1:qemu 1:libvirt 4:object 4:json 4:event 1:util"
+log_outputs="1:file:/var/log/containers/libvirt/virtqemud.log"

--- a/molecule/default/test-data/compute-secret/libvirt_virtsecretd__libvirt-virtsecretd.json
+++ b/molecule/default/test-data/compute-secret/libvirt_virtsecretd__libvirt-virtsecretd.json
@@ -1,0 +1,28 @@
+{
+    "command": "/usr/sbin/virtsecretd --config /etc/libvirt/virtsecretd.conf",
+    "config_files": [
+        {
+            "source": "/var/lib/openstack/config/virtsecretd.conf",
+            "dest": "/etc/libvirt/virtsecretd.conf",
+            "owner": "libvirt",
+            "perm": "0600"
+        }
+    ],
+    "permissions": [
+        {
+            "path": "/var/log/containers/libvirt",
+            "owner": "libvirt:libvirt",
+            "recurse": true
+        },
+        {
+            "path": "/var/lib/libvirt",
+            "owner": "libvirt:libvirt",
+            "recurse": true
+        },
+        {
+            "path": "/run/libvirt",
+            "owner": "libvirt:libvirt",
+            "recurse": true
+        }
+    ]
+}

--- a/molecule/default/test-data/compute-secret/libvirt_virtsecretd__libvirt_virtsecretd.json
+++ b/molecule/default/test-data/compute-secret/libvirt_virtsecretd__libvirt_virtsecretd.json
@@ -1,0 +1,18 @@
+{
+    "image": "quay.io/podified-antelope-centos9/openstack-nova-libvirt:current-podified",
+    "restart": "always",
+    "command": "kolla_start",
+    "net": "host",
+    "privileged": "true",
+    "environment": {
+        "KOLLA_CONFIG_STRATEGY":"COPY_ALWAYS",
+        "KOLLA_CONFIG_FILE":"/var/lib/openstack/config/libvirt-virtsecretd.json"
+    },
+    "volumes": [
+        "/var/lib/openstack/config/libvirt:/var/lib/openstack/config:ro",
+        "/etc/localtime:/etc/localtime:ro",
+        "/var/log/containers/libvirt:/var/log/containers/libvirt",
+        "/var/lib/libvirt:/var/lib/libvirt",
+        "/run/libvirt:/run/libvirt"
+    ]
+  }

--- a/molecule/default/test-data/compute-secret/libvirt_virtsecretd__virtsecretd.conf
+++ b/molecule/default/test-data/compute-secret/libvirt_virtsecretd__virtsecretd.conf
@@ -1,0 +1,7 @@
+unix_sock_group="libvirt"
+unix_sock_ro_perms="0444"
+unix_sock_rw_perms="0770"
+auth_unix_ro="none"
+auth_unix_rw="none"
+log_filters="1:qemu 1:libvirt 4:object 4:json 4:event 1:util"
+log_outputs="1:file:/var/log/containers/libvirt/virtsecretd.log"

--- a/molecule/default/test-data/compute-secret/novacompute__nova-compute.json
+++ b/molecule/default/test-data/compute-secret/novacompute__nova-compute.json
@@ -1,0 +1,48 @@
+{
+    "command": "nova-compute",
+    "config_files": [
+        {
+            "source": "/var/lib/openstack/config/nova-blank.conf",
+            "dest": "/etc/nova/nova.conf",
+            "owner": "nova",
+            "perm": "0600"
+        },
+        {
+            "source": "/var/lib/openstack/config/01-nova.conf",
+            "dest": "/etc/nova/nova.conf.d/01-nova.conf",
+            "owner": "nova",
+            "perm": "0600"
+        },
+        {
+            "source": "/var/lib/openstack/config/02-nova-override.conf",
+            "dest": "/etc/nova/nova.conf.d/02-nova-override.conf",
+            "owner": "nova",
+            "perm": "0600",
+            "optional": true
+        },
+        {
+            "source": "/var/lib/openstack/config/ceph",
+            "dest": "/etc/ceph",
+            "owner": "nova",
+            "perm": "0700",
+            "optional": true
+        }
+    ],
+    "permissions": [
+        {
+            "path": "/var/log/containers/nova",
+            "owner": "nova:nova",
+            "recurse": true
+        },
+        {
+            "path": "/etc/ceph/*",
+            "owner": "nova:nova",
+            "perm:": "0600"
+        },
+        {
+            "path": "/var/lib/nova",
+            "owner": "nova:nova",
+            "recurse": true
+        }
+    ]
+}

--- a/molecule/default/test-data/compute-secret/novacompute__nova_compute.json
+++ b/molecule/default/test-data/compute-secret/novacompute__nova_compute.json
@@ -1,0 +1,24 @@
+{
+    "image": "quay.io/podified-antelope-centos9/openstack-nova-compute:current-podified",
+    "privileged": true,
+    "user": "nova",
+    "restart": "always",
+    "command": "kolla_start",
+    "net": "host",
+    "environment": {
+        "KOLLA_CONFIG_STRATEGY":"COPY_ALWAYS",
+        "KOLLA_CONFIG_FILE":"/var/lib/openstack/config/nova-compute.json"
+    },
+    "volumes": [
+        "/var/lib/openstack/config/nova:/var/lib/openstack/config/:ro",
+        "/etc/localtime:/etc/localtime:ro",
+        "/lib/modules:/lib/modules:ro",
+        "/dev:/dev",
+        "/run/openvswitch:/run/openvswitch",
+        "/run/libvirt:/run/libvirt",
+        "/var/log/containers/nova:/var/log/containers/nova",
+        "/var/lib/libvirt:/var/lib/libvirt",
+        "/var/lib/nova/:/var/lib/nova/",
+        "/etc/ceph:/var/lib/openstack/config/ceph:ro"
+    ]
+}

--- a/molecule/default/test-helpers/verify_dir.yaml
+++ b/molecule/default/test-helpers/verify_dir.yaml
@@ -1,0 +1,13 @@
+
+- name: verify dir exists
+  become: true
+  block:
+      - name: Check if directory exists
+        ansible.builtin.stat:
+          path: "{{ item }}"
+        register: dir_exists
+      - name: Assert directory exists
+        ansible.builtin.assert:
+          that:
+            - dir_exists.stat.exists
+          fail_msg: "Directory {{ item }} does not exist"

--- a/molecule/default/test-helpers/verify_podman.yaml
+++ b/molecule/default/test-helpers/verify_podman.yaml
@@ -1,0 +1,35 @@
+
+- name: verify podman containers
+  block:
+    - name: Check if podman container exists
+      become: true
+      ansible.builtin.command: podman ps -a --filter name={{item}} --format \{\{.Names\}\}
+      register: containers
+    - name: Assert podman container exists
+      ansible.builtin.assert:
+        that:
+          - containers.rc == 0
+          - containers.stdout_lines | length == 1
+          - item in containers.stdout_lines | first
+        fail_msg: "Podman container {{ item }} does not exist"
+    - name: Check if podman container is running
+      become: true
+      ansible.builtin.command: podman ps --filter name={{item}} --format \{\{.Status\}\}
+      register: containers
+    - name: Assert podman container is running
+      ansible.builtin.assert:
+        that:
+          - containers.rc == 0
+          - containers.stdout_lines | length == 1
+          - "'Up' in containers.stdout_lines | first"
+        fail_msg: "Podman container {{ item }} is not running"
+    - name: Check the contaienr stdout log exists
+      become: true
+      ansible.builtin.stat:
+        path: "/var/log/containers/stdouts/{{ item }}.log"
+      register: log_exists
+    - name: Assert the container stdout log exists
+      ansible.builtin.assert:
+        that:
+          - log_exists.stat.exists
+        fail_msg: "Container stdout log for {{ item }} does not exist"

--- a/molecule/default/test-helpers/verify_podman_volumes.yaml
+++ b/molecule/default/test-helpers/verify_podman_volumes.yaml
@@ -1,0 +1,14 @@
+
+- name: verify podman container volumes
+  block:
+    - name: get contaienr volumes
+      become: true
+      ansible.builtin.command: podman inspect {{item.name}} --format \{\{.Mounts\}\}
+      register: volumes
+    - name: Assert podman container volumes exist
+      ansible.builtin.assert:
+        that:
+          - volumes.rc == 0
+          - volumes.stdout_lines | length == 1
+          - item.volumes == volumes.stdout
+        fail_msg: "Podman container {{ item.name }} does not have the expected volumes {{ item.volumes }} actual {{ volumes.stdout_lines }}"

--- a/molecule/default/test-helpers/verify_systemd_service.yaml
+++ b/molecule/default/test-helpers/verify_systemd_service.yaml
@@ -1,0 +1,35 @@
+
+- name: verify systemd service exists
+  block:
+    - name: Check if systemd file service exists
+      become: true
+      ansible.builtin.stat:
+        path: "/etc/systemd/system/{{ item }}.service"
+      register: service_exists
+    - name: Assert systemd service exists
+      ansible.builtin.assert:
+        that:
+          - service_exists.stat.exists
+        fail_msg: "Systemd service file for service {{ item }} does not exist"
+    - name: Check if systemd service is enabled
+      ansible.builtin.command: systemctl is-enabled {{ item }}
+      register: service_enabled
+      failed_when: false
+      changed_when: false
+      ignore_errors: true
+    - name: Assert systemd service is enabled
+      ansible.builtin.assert:
+        that:
+          - service_enabled.stdout == "enabled"
+        fail_msg: "Systemd service {{ item }} is not enabled"
+    - name: Check if systemd service is running
+      ansible.builtin.command: systemctl is-active {{ item }}
+      register: service_running
+      failed_when: false
+      changed_when: false
+      ignore_errors: true
+    - name: Assert systemd service is running
+      ansible.builtin.assert:
+        that:
+          - service_running.stdout == "active"
+        fail_msg: "Systemd service {{ item }} is not running"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,0 +1,10 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Example assertion
+      ansible.builtin.assert:
+        that: true

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -45,3 +45,63 @@
         - "libvirt_virtqemud"
         - "libvirt_virtsecretd"
         - "nova_compute"
+    - name: ensure podman container volume mounts
+      ansible.builtin.include_tasks: test-helpers/verify_podman_volumes.yaml
+      with_items:
+        - { name: "libvirt_virtlogd",
+            volumes: "\
+            [{bind  /var/lib/openstack/config/libvirt /var/lib/openstack/config   [rbind] false rprivate} \
+             {bind  /etc/localtime /etc/localtime   [rbind] false rprivate} \
+             {bind  /var/log/containers/libvirt /var/log/containers/libvirt   [rbind] true rprivate} \
+             {bind  /var/lib/libvirt /var/lib/libvirt   [rbind] true rprivate} \
+             {bind  /var/lib/nova /var/lib/nova   [rbind] true rprivate} \
+             {bind  /run/libvirt /run/libvirt   [nosuid nodev rbind] true rprivate}]"
+          }
+        - { name: "libvirt_virtnodedevd",
+            volumes: "\
+            [{bind  /dev /dev   [nosuid rbind] true rprivate} \
+             {bind  /var/lib/openstack/config/libvirt /var/lib/openstack/config   [rbind] false rprivate} \
+             {bind  /etc/localtime /etc/localtime   [rbind] false rprivate} \
+             {bind  /var/log/containers/libvirt /var/log/containers/libvirt   [rbind] true rprivate} \
+             {bind  /var/lib/libvirt /var/lib/libvirt   [rbind] true rprivate} \
+             {bind  /run/libvirt /run/libvirt   [nosuid nodev rbind] true rprivate}]"
+          }
+        - { name: "libvirt_virtproxyd",
+            volumes: "\
+            [{bind  /var/log/containers/libvirt /var/log/containers/libvirt   [rbind] true rprivate} \
+             {bind  /var/lib/libvirt /var/lib/libvirt   [rbind] true rprivate} \
+             {bind  /run/libvirt /run/libvirt   [nosuid nodev rbind] true rprivate} \
+             {bind  /var/lib/openstack/config/libvirt /var/lib/openstack/config   [rbind] false rprivate} \
+             {bind  /etc/localtime /etc/localtime   [rbind] false rprivate}]"
+          }
+        - { name: "libvirt_virtqemud",
+            volumes: "\
+            [{bind  /var/lib/libvirt /var/lib/libvirt   [rbind] true rprivate} \
+             {bind  /var/lib/nova /var/lib/nova   [rbind] true rprivate} \
+             {bind  /run/libvirt /run/libvirt   [nosuid nodev rbind] true rprivate} \
+             {bind  /dev /dev   [nosuid rbind] true rprivate} \
+             {bind  /etc/ceph /var/lib/openstack/config/ceph   [rbind] false rprivate} \
+             {bind  /var/lib/openstack/config/libvirt /var/lib/openstack/config   [rbind] false rprivate} \
+             {bind  /etc/localtime /etc/localtime   [rbind] false rprivate} \
+             {bind  /var/log/containers/libvirt /var/log/containers/libvirt   [rbind] true rprivate}]"
+          }
+        - { name: "libvirt_virtsecretd",
+            volumes: "\
+            [{bind  /etc/localtime /etc/localtime   [rbind] false rprivate} \
+             {bind  /var/log/containers/libvirt /var/log/containers/libvirt   [rbind] true rprivate} \
+             {bind  /var/lib/libvirt /var/lib/libvirt   [rbind] true rprivate} \
+             {bind  /run/libvirt /run/libvirt   [nosuid nodev rbind] true rprivate} \
+             {bind  /var/lib/openstack/config/libvirt /var/lib/openstack/config   [rbind] false rprivate}]"
+          }
+        - { name: "nova_compute",
+            volumes: "\
+            [{bind  /run/openvswitch /run/openvswitch   [nosuid nodev rbind] true rprivate} \
+             {bind  /etc/localtime /etc/localtime   [rbind] false rprivate} \
+             {bind  /var/lib/libvirt /var/lib/libvirt   [rbind] true rprivate} \
+             {bind  /lib/modules /lib/modules   [rbind] false rprivate} \
+             {bind  /var/log/containers/nova /var/log/containers/nova   [rbind] true rprivate} \
+             {bind  /var/lib/openstack/config/nova /var/lib/openstack/config/   [rbind] false rprivate} \
+             {bind  /run/libvirt /run/libvirt   [nosuid nodev rbind] true rprivate} \
+             {bind  /etc/ceph /var/lib/openstack/config/ceph   [rbind] false rprivate} \
+             {bind  /dev /dev   [nosuid rbind] true rprivate} {bind  /var/lib/nova /var/lib/nova/   [rbind] true rprivate}]"
+          }

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -2,9 +2,46 @@
 # This is an example playbook to execute Ansible tests.
 
 - name: Verify
-  hosts: all
+  hosts: compute-1
   gather_facts: false
   tasks:
-    - name: Example assertion
-      ansible.builtin.assert:
-        that: true
+    - name: ensure expected directories exist
+      ansible.builtin.include_tasks: test-helpers/verify_dir.yaml
+      with_items:
+        # common directories
+        - "/etc/tmpfiles.d/"
+        - "/var/lib/openstack"
+        - "/var/lib/openstack/config/containers"
+        - "/var/log/containers"
+        - "/var/log/containers/stdouts"
+        # extrenal deps
+        - "/etc/ceph"
+        - "/run/openvswitch"
+        # libvirt directories
+        - "/var/lib/libvirt"
+        - "/var/lib/openstack/config/libvirt"
+        - "/var/log/containers/libvirt"
+        # nova directories
+        - "/var/lib/nova"
+        - "/var/lib/openstack/config/nova"
+        - "/var/lib/_nova_secontext"
+        - "/var/lib/nova/instances"
+        - "/var/log/containers/nova"
+    - name: ensure systemd services are defined and functional
+      ansible.builtin.include_tasks: test-helpers/verify_systemd_service.yaml
+      with_items:
+        - "edpm_libvirt_virtlogd"
+        - "edpm_libvirt_virtnodedevd"
+        - "edpm_libvirt_virtproxyd"
+        - "edpm_libvirt_virtqemud"
+        - "edpm_libvirt_virtsecretd"
+        - "edpm_nova_compute"
+    - name: ensure podman container exists and are running
+      ansible.builtin.include_tasks: test-helpers/verify_podman.yaml
+      with_items:
+        - "libvirt_virtlogd"
+        - "libvirt_virtnodedevd"
+        - "libvirt_virtproxyd"
+        - "libvirt_virtqemud"
+        - "libvirt_virtsecretd"
+        - "nova_compute"

--- a/playbooks/deploy-libvirt.yaml
+++ b/playbooks/deploy-libvirt.yaml
@@ -14,6 +14,7 @@
       with_items:
       - { "path": /var/lib/openstack/config/libvirt}
       - { "path": /var/lib/openstack/config/containers}
+      - { 'path': /var/lib/nova}
       - { "path": /etc/tmpfiles.d/, "owner": "root", "group": "root"}
     - name: ensure /var/run/libvirt is present upon reboot
       become: true


### PR DESCRIPTION
This patch uses molecule to deploy nova and libvirt
via the in tree palybooks on vagrant vms using the
openstack-ansibleee-runner images.
Related: [OSPRH-229](https://issues.redhat.com//browse/OSPRH-229)
