### PR TITLE
Simplify --coverpkg argument in ginkgo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ test: manifests generate fmt vet envtest ginkgo ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) -v debug --bin-dir $(LOCALBIN) use $(ENVTEST_K8S_VERSION) -p path)" \
 	OPERATOR_TEMPLATES="$(PWD)/templates" \
 	OPERATOR_PLAYBOOKS="$(PWD)/playbooks" \
-	$(GINKGO) --trace --cover --coverpkg=../../pkg/nova,../../pkg/novaapi,../../pkg/novaconductor,../../controllers,../../api/v1beta1,../../pkg/novascheduler,../../pkg/novametadata --coverprofile cover.out --covermode=atomic --randomize-all ${PROC_CMD} $(GINKGO_ARGS) ./test/...
+	$(GINKGO) --trace --cover --coverpkg=../../pkg/...,../../controllers,../../api/v1beta1 --coverprofile cover.out --covermode=atomic --randomize-all ${PROC_CMD} $(GINKGO_ARGS) ./test/...
 
 ##@ Build
 


### PR DESCRIPTION
ginkgo's --coverpkg option allows loading all packages in a directory using '...' . This replaces the explicit list of packages by that pattern to make the argument simpler.