### PR TITLE
Remove endpoint url and keystone service id from status

### DIFF
--- a/api/v1beta1/novaapi_types.go
+++ b/api/v1beta1/novaapi_types.go
@@ -153,14 +153,8 @@ type NovaAPIStatus struct {
 	// Map of hashes to track e.g. job status
 	Hash map[string]string `json:"hash,omitempty"`
 
-	// API endpoint
-	APIEndpoints map[string]string `json:"apiEndpoint,omitempty"`
-
 	// Conditions
 	Conditions condition.Conditions `json:"conditions,omitempty" optional:"true"`
-
-	// ServiceID - the ID of the registered service in keystone
-	ServiceID string `json:"serviceID,omitempty"`
 
 	// ReadyCount defines the number of replicas ready from nova-api
 	ReadyCount int32 `json:"readyCount,omitempty"`

--- a/api/v1beta1/novametadata_types.go
+++ b/api/v1beta1/novametadata_types.go
@@ -175,9 +175,6 @@ type NovaMetadataStatus struct {
 
 	// NetworkAttachments status of the deployment pods
 	NetworkAttachments map[string][]string `json:"networkAttachments,omitempty"`
-
-	// API endpoint
-	APIEndpoints map[string]string `json:"apiEndpoint,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -218,13 +218,6 @@ func (in *NovaAPIStatus) DeepCopyInto(out *NovaAPIStatus) {
 			(*out)[key] = val
 		}
 	}
-	if in.APIEndpoints != nil {
-		in, out := &in.APIEndpoints, &out.APIEndpoints
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make(condition.Conditions, len(*in))
@@ -953,13 +946,6 @@ func (in *NovaMetadataStatus) DeepCopyInto(out *NovaMetadataStatus) {
 				copy(*out, *in)
 			}
 			(*out)[key] = outVal
-		}
-	}
-	if in.APIEndpoints != nil {
-		in, out := &in.APIEndpoints, &out.APIEndpoints
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
 		}
 	}
 }

--- a/config/crd/bases/nova.openstack.org_novaapis.yaml
+++ b/config/crd/bases/nova.openstack.org_novaapis.yaml
@@ -264,11 +264,6 @@ spec:
           status:
             description: NovaAPIStatus defines the observed state of NovaAPI
             properties:
-              apiEndpoint:
-                additionalProperties:
-                  type: string
-                description: API endpoint
-                type: object
               conditions:
                 description: Conditions
                 items:
@@ -329,9 +324,6 @@ spec:
                   nova-api
                 format: int32
                 type: integer
-              serviceID:
-                description: ServiceID - the ID of the registered service in keystone
-                type: string
             type: object
         type: object
     served: true

--- a/config/crd/bases/nova.openstack.org_novametadata.yaml
+++ b/config/crd/bases/nova.openstack.org_novametadata.yaml
@@ -273,11 +273,6 @@ spec:
           status:
             description: NovaMetadataStatus defines the observed state of NovaMetadata
             properties:
-              apiEndpoint:
-                additionalProperties:
-                  type: string
-                description: API endpoint
-                type: object
               conditions:
                 description: Conditions
                 items:

--- a/controllers/novametadata_controller.go
+++ b/controllers/novametadata_controller.go
@@ -213,9 +213,6 @@ func (r *NovaMetadataReconciler) initStatus(
 	if instance.Status.Hash == nil {
 		instance.Status.Hash = map[string]string{}
 	}
-	if instance.Status.APIEndpoints == nil {
-		instance.Status.APIEndpoints = map[string]string{}
-	}
 	if instance.Status.NetworkAttachments == nil {
 		instance.Status.NetworkAttachments = map[string][]string{}
 	}
@@ -475,7 +472,6 @@ func (r *NovaMetadataReconciler) ensureServiceExposed(
 		apiEndpoints[k] = v
 	}
 
-	instance.Status.APIEndpoints = apiEndpoints
 	return ctrl.Result{}, nil
 }
 

--- a/test/functional/nova_multicell_test.go
+++ b/test/functional/nova_multicell_test.go
@@ -761,7 +761,6 @@ var _ = Describe("Nova multicell", func() {
 			keystoneAPIName := th.CreateKeystoneAPI(novaNames.NovaName.Namespace)
 			DeferCleanup(th.DeleteKeystoneAPI, keystoneAPIName)
 			keystoneAPI := th.GetKeystoneAPI(keystoneAPIName)
-			keystoneAPI.Status.APIEndpoints["internal"] = "http://keystone-internal-openstack.testing"
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Status().Update(ctx, keystoneAPI.DeepCopy())).Should(Succeed())
 			}, timeout, interval).Should(Succeed())

--- a/test/functional/novaapi_controller_test.go
+++ b/test/functional/novaapi_controller_test.go
@@ -58,9 +58,7 @@ var _ = Describe("NovaAPI controller", func() {
 			// they are initialized to {} that value is omitted from the output
 			// when sent to the client. So we see nils here.
 			Expect(instance.Status.Hash).To(BeEmpty())
-			Expect(instance.Status.APIEndpoints).To(BeEmpty())
 			Expect(instance.Status.ReadyCount).To(Equal(int32(0)))
-			Expect(instance.Status.ServiceID).To(Equal(""))
 		})
 
 		It("is missing the secret", func() {


### PR DESCRIPTION
These items presented in CR status are not really used. Endpoints can be discovered using Keystone and we have no use case to require service id.