### PR TITLE
Fix API and metadata worker counts

### DIFF
--- a/templates/nova.conf
+++ b/templates/nova.conf
@@ -30,11 +30,11 @@ force_config_drive=True
 {{if eq .service_name "nova-api"}}
 # scaling should be done by running more pods
 osapi_compute_workers=1
-metadata_workers=0
+enabled_apis=osapi_compute
 {{else if eq .service_name "nova-metadata"}}
 # scaling should be done by running more pods
-osapi_compute_workers=0
 metadata_workers=1
+enabled_apis=metadata
 {{end}}
 
 [oslo_concurrency]


### PR DESCRIPTION
We try to set metadata_workers 0 for nova-api and osapi_compute_workers to 0 for nova-metadata service. However both option defines that the minimum value is 1. So currently both the nova-api and nova-metadata services reporting config validation error and only partially parse the config files.

Instead of setting the worker count to 0 we can use enabled_apis to define which api service running by which binary. So this patch changes the config template to do so.