### PR TITLE
Add test coverage for worker count

### DIFF
--- a/test/functional/nova_metadata_controller_test.go
+++ b/test/functional/nova_metadata_controller_test.go
@@ -168,6 +168,8 @@ var _ = Describe("NovaMetadata controller", func() {
 				Expect(configData).Should(ContainSubstring("password = service-password"))
 				Expect(configData).Should(ContainSubstring("metadata_proxy_shared_secret = metadata-secret"))
 				Expect(configData).Should(ContainSubstring("local_metadata_per_cell = false"))
+				Expect(configData).Should(ContainSubstring("enabled_apis=metadata"))
+				Expect(configData).Should(ContainSubstring("metadata_workers=1"))
 				Expect(configDataMap.Data).Should(HaveKey("02-nova-override.conf"))
 				extraData := string(configDataMap.Data["02-nova-override.conf"])
 				Expect(extraData).To(Equal("foo=bar"))

--- a/test/functional/novaapi_controller_test.go
+++ b/test/functional/novaapi_controller_test.go
@@ -175,6 +175,8 @@ var _ = Describe("NovaAPI controller", func() {
 				// service_user configuration to work to address Bug: #2004555
 				Expect(configData).Should(ContainSubstring("[service_user]"))
 				Expect(configData).Should(ContainSubstring("password = service-password"))
+				Expect(configData).Should(ContainSubstring("enabled_apis=osapi_compute"))
+				Expect(configData).Should(ContainSubstring("osapi_compute_workers=1"))
 				Expect(configDataMap.Data).Should(HaveKey("02-nova-override.conf"))
 				extraData := string(configDataMap.Data["02-nova-override.conf"])
 				Expect(extraData).To(Equal("foo=bar"))


### PR DESCRIPTION
The fix was in 359004c3763cd474cf2de2e419ba3f50b82d9b2f but we missed the test coverage for it.