### PR TITLE
Add container volume mounts required for iscsi volumes

### DIFF
--- a/templates/novacompute/nova_compute.json
+++ b/templates/novacompute/nova_compute.json
@@ -19,6 +19,8 @@
         "/var/log/containers/nova:/var/log/containers/nova",
         "/var/lib/libvirt:/var/lib/libvirt",
         "/var/lib/nova/:/var/lib/nova/",
+        "/var/lib/iscsi:/var/lib/iscsi",
+        "/etc/iscsi:/etc/iscsi:ro",
         "/etc/ceph:/var/lib/openstack/config/ceph:ro"
     ]
 }


### PR DESCRIPTION
Add volume mounts to the nova_compute container that are necessary for handling iscsi volumes attachments.