### PR TITLE
Fix /var/lib/nova permissions in libvirt playbook

### DIFF
--- a/playbooks/deploy-libvirt.yaml
+++ b/playbooks/deploy-libvirt.yaml
@@ -9,7 +9,7 @@
         setype: "{{ item.setype | default('container_file_t') }}"
         owner: "{{ item.owner | default(ansible_user) }}"
         group: "{{ item.group | default(ansible_user) }}"
-        mode: "{{ item.mode | default('750') }}"
+        mode: "{{ item.mode | default(omit) }}"
         recurse: true
       with_items:
       - { "path": /var/lib/openstack/config/libvirt}


### PR DESCRIPTION
Both nova-compute and libvirt depends on the existence of /var/lib/nova so we added the creation of it to the libvirt playbook too (it was in the nova-compute playbook from the start), as in some tests the libvirt playbook reached this point before the nova-compute one. However the fix in bf18bbe5d5ac1bb836ae6ad1df99bcecd7b49540 was incomplete as it set the directory permission to 0750 if it was created by the libvirt playbook. This caused that the VM boot failed with permission error as the dir should have 0755 access.