### PR TITLE
This change fixes binding mounting for virtlogd and qemud

### DIFF
--- a/playbooks/deploy-libvirt.yaml
+++ b/playbooks/deploy-libvirt.yaml
@@ -48,6 +48,7 @@
       with_items:
       - { "path": /var/lib/libvirt}
       - { "path": /var/log/containers/libvirt, "mode": "0750" }
+      - { "path": /var/log/containers/qemu, "mode": "0750" }
       - { "path": /var/log/containers/stdouts, "mode": "0750" }
       # we could proably just assume tha this has been precreated by the dataplane operator.
       - { "path": /etc/ceph, "mode": "0750", "owner": "root", "group": "root"}

--- a/templates/libvirt_virtlogd/libvirt-virtlogd.json
+++ b/templates/libvirt_virtlogd/libvirt-virtlogd.json
@@ -15,6 +15,11 @@
             "recurse": true
         },
         {
+            "path": "/var/log/libvirt/qemu",
+            "owner": "libvirt:libvirt",
+            "recurse": true
+        },
+        {
             "path": "/var/lib/libvirt",
             "owner": "libvirt:libvirt",
             "recurse": true

--- a/templates/libvirt_virtlogd/libvirt_virtlogd.json
+++ b/templates/libvirt_virtlogd/libvirt_virtlogd.json
@@ -11,6 +11,7 @@
     "volumes": [
         "/var/lib/openstack/config/libvirt:/var/lib/openstack/config:ro",
         "/etc/localtime:/etc/localtime:ro",
+        "/var/log/containers/qemu:/var/log/libvirt/qemu",
         "/var/log/containers/libvirt:/var/log/containers/libvirt",
         "/var/lib/libvirt:/var/lib/libvirt",
         "/var/lib/nova:/var/lib/nova",

--- a/templates/libvirt_virtqemud/libvirt-virtqemud.json
+++ b/templates/libvirt_virtqemud/libvirt-virtqemud.json
@@ -8,6 +8,12 @@
             "perm": "0600"
         },
         {
+            "source": "/var/lib/openstack/config/qemu.conf",
+            "dest": "/etc/libvirt/qemu.conf",
+            "owner": "libvirt:qemu",
+            "perm": "0660"
+        },
+        {
             "source": "/var/lib/openstack/config/ceph",
             "dest": "/etc/ceph",
             "owner": "libvirt:qemu",

--- a/templates/libvirt_virtqemud/qemu.conf
+++ b/templates/libvirt_virtqemud/qemu.conf
@@ -2,8 +2,8 @@ max_files = 32768
 max_processes = 131072
 vnc_tls = 0
 vnc_tls_x509_verify = 0
-vnc_listen = 0.0.0.0
 default_tls_x509_verify = 1
 nbd_tls = 0
-migration_port_min = 61152
-migration_port_max = 61215
+# reasses if we need to set these when we add supprot for migration.
+#migration_port_min = 61152
+#migration_port_max = 61215


### PR DESCRIPTION
This change fixes two issues with how the virtlogd and qemud
contaienrs were run.

First /var/log/libvirt/qemu is now
bindmoutned form virtlogd to /var/log/containers/qemu to expose
the qemu instances logs and persit them across reboots.

Second teh qemu.conf that is generated for the qemud contaienr
is now actully copied into place and used. As part of fixing this
i also fix a syntax error in the vnc_listen option as 0.0.0.0 was
invalid. This vnc_listen is not required as that is contoled
by nova and it works without this option being set so it is
simply removed.

i have also commented out the configuration of the migration port
range but left it in the file since we currently dont supprot
migration and we do not open any ports for it in the firewall.
We will adress this end to end in the future.
