### PR TITLE
Do not set transport_url for cell0 mapping

### DIFF
--- a/controllers/nova_controller.go
+++ b/controllers/nova_controller.go
@@ -1324,7 +1324,15 @@ func (r *NovaReconciler) ensureCellMapped(
 		"openstack_region_name":  "regionOne", // fixme
 		"default_project_domain": "Default",   // fixme
 		"default_user_domain":    "Default",   // fixme
-		"transport_url":          string(mqSecret.Data["transport_url"]),
+	}
+
+	// NOTE(gibi): cell mapping for cell0 should not have transport_url
+	// configured. As the nova-manage command used to create the mapping
+	// uses the transport_url from the nova.conf provided to the job
+	// we need to make sure that transport_url is only configured for the job
+	// if it is mapping other than cell0.
+	if cell.Spec.CellName != novav1.Cell0Name {
+		templateParameters["transport_url"] = string(mqSecret.Data["transport_url"])
 	}
 
 	cms := []util.Template{

--- a/templates/nova.conf
+++ b/templates/nova.conf
@@ -25,7 +25,9 @@ initial_disk_allocation_ratio=0.9
 {{end}}
 {{/*using a config drive will void issues with ovn and metadata*/}}
 force_config_drive=True
-{{if .transport_url}}transport_url={{.transport_url}}{{end}}
+{{ if (index . "transport_url") }}
+transport_url={{.transport_url}}
+{{end}}
 
 {{if eq .service_name "nova-api"}}
 # scaling should be done by running more pods

--- a/test/functional/nova_controller_test.go
+++ b/test/functional/nova_controller_test.go
@@ -322,6 +322,12 @@ var _ = Describe("Nova controller", func() {
 			Expect(configData).To(
 				ContainSubstring("[api_database]\nconnection = mysql+pymysql://nova_api:api-database-password@hostname-for-openstack/nova_api"),
 			)
+			// NOTE(gibi): cell mapping for cell0 should not have transport_url
+			// configured. As the nova-manage command used to create the mapping
+			// uses the transport_url from the nova.conf provided to the job
+			// we need to make sure that it is empty.
+			Expect(configData).NotTo(ContainSubstring("transport_url"))
+
 			mappingJobScript := th.GetSecret(
 				types.NamespacedName{
 					Namespace: cell0.CellName.Namespace,


### PR DESCRIPTION
The cell0 mapping should never have transport_url set as there are no computes in cell0 that would use such message bus.

When we introduced a separate cell mapping job for each cell we regressed the cell mapping setup and cell0 is mapped with the API message bus transport_url. This causes that in a collapsed cell setup where only a single MQ is used for both API and cell1 the cell1 mapping job fails as the transport_url for cell1 is already used for cell0.

Closes: https://issues.redhat.com/browse/OSPRH-233