### PR TITLE
Validate cell0 existence in webhook

### DIFF
--- a/api/v1beta1/nova_webhook.go
+++ b/api/v1beta1/nova_webhook.go
@@ -112,6 +112,14 @@ var _ webhook.Validator = &Nova{}
 func (r *NovaSpec) ValidateCellTemplates(basePath *field.Path) field.ErrorList {
 	var errors field.ErrorList
 
+	if _, ok := r.CellTemplates[Cell0Name]; !ok {
+		errors = append(
+			errors,
+			field.Required(basePath.Child("cellTemplates"),
+				"cell0 specification is missing, cell0 key is required in cellTemplates"),
+		)
+	}
+
 	for name, cell := range r.CellTemplates {
 		cellPath := basePath.Child("cellTemplates").Key(name)
 		errors = append(

--- a/controllers/nova_controller.go
+++ b/controllers/nova_controller.go
@@ -183,12 +183,9 @@ func (r *NovaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 		return rbacResult, nil
 	}
 
-	// TODO(gibi): This should be checked in a webhook and reject the CR
-	// creation instead of setting its status.
-	cell0Template, err := r.getCell0Template(instance)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
+	// There is a webhook validation that ensures that there is always cell0 in
+	// the cellTemplates
+	cell0Template := instance.Spec.CellTemplates[novav1.Cell0Name]
 
 	expectedSelectors := []string{
 		instance.Spec.PasswordSelectors.Service,
@@ -656,26 +653,6 @@ func (r *NovaReconciler) ensureDB(
 	}
 
 	return nova.DBCompleted, nil
-}
-
-func (r *NovaReconciler) getCell0Template(instance *novav1.Nova) (novav1.NovaCellTemplate, error) {
-	var cell0Template novav1.NovaCellTemplate
-	var ok bool
-
-	if cell0Template, ok = instance.Spec.CellTemplates[novav1.Cell0Name]; !ok {
-		err := fmt.Errorf("missing cell0 specification from Spec.CellTemplates")
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			novav1.NovaAllCellsReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityError,
-			novav1.NovaAllCellsReadyErrorMessage,
-			fmt.Sprintf("%s(%v)", novav1.Cell0Name, err.Error()),
-		))
-
-		return cell0Template, err
-	}
-
-	return cell0Template, nil
 }
 
 func (r *NovaReconciler) ensureAPIDB(

--- a/test/functional/nova_controller_test.go
+++ b/test/functional/nova_controller_test.go
@@ -31,40 +31,6 @@ import (
 )
 
 var _ = Describe("Nova controller", func() {
-	When("Nova CR instance is created without cell0", func() {
-		BeforeEach(func() {
-			DeferCleanup(th.DeleteInstance, CreateNovaWithoutCell0(novaNames.NovaName))
-		})
-
-		It("is not Ready", func() {
-			th.ExpectCondition(
-				novaNames.NovaName,
-				ConditionGetterFunc(NovaConditionGetter),
-				condition.ReadyCondition,
-				corev1.ConditionFalse,
-			)
-		})
-
-		It("has no hash and no services ready", func() {
-			instance := GetNova(novaNames.NovaName)
-			Expect(instance.Status.Hash).To(BeEmpty())
-			Expect(instance.Status.APIServiceReadyCount).To(Equal(int32(0)))
-			Expect(instance.Status.SchedulerServiceReadyCount).To(Equal(int32(0)))
-			Expect(instance.Status.MetadataServiceReadyCount).To(Equal(int32(0)))
-		})
-
-		It("reports that cell0 is missing from the spec", func() {
-			th.ExpectConditionWithDetails(
-				novaNames.NovaName,
-				ConditionGetterFunc(NovaConditionGetter),
-				novav1.NovaAllCellsReadyCondition,
-				corev1.ConditionFalse,
-				condition.ErrorReason,
-				"NovaCell creation failed for cell0(missing cell0 specification from Spec.CellTemplates)",
-			)
-		})
-	})
-
 	When("Nova CR instance is created without a proper secret", func() {
 		BeforeEach(func() {
 			DeferCleanup(


### PR DESCRIPTION
We had a long running TODO to move the validation of cell0 definition to the validation webhook instead of doing that in the Reconciler.

As validation webhook pattern is stabilized it is a good time to move the check there.

Closes: https://issues.redhat.com/browse/OSPRH-141