### PR TITLE
[EnvTest]Remove config deletion test cases

### DIFF
--- a/test/functional/nova_metadata_controller_test.go
+++ b/test/functional/nova_metadata_controller_test.go
@@ -182,23 +182,6 @@ var _ = Describe("NovaMetadata controller", func() {
 				}, timeout, interval).Should(Succeed())
 
 			})
-
-			When("the NovaMetadata is deleted", func() {
-				It("deletes the generated ConfigMaps", func() {
-					th.ExpectCondition(
-						novaNames.MetadataName,
-						ConditionGetterFunc(NovaMetadataConditionGetter),
-						condition.ServiceConfigReadyCondition,
-						corev1.ConditionTrue,
-					)
-
-					th.DeleteInstance(GetNovaMetadata(novaNames.MetadataName))
-
-					Eventually(func() []corev1.ConfigMap {
-						return th.ListConfigMaps(novaNames.MetadataName.Name).Items
-					}, timeout, interval).Should(BeEmpty())
-				})
-			})
 		})
 
 		When("NovaMetadata is created with a proper Secret", func() {

--- a/test/functional/nova_novncproxy_test.go
+++ b/test/functional/nova_novncproxy_test.go
@@ -182,23 +182,6 @@ var _ = Describe("NovaNoVNCProxy controller", func() {
 				}, timeout, interval).Should(Succeed())
 
 			})
-
-			When("the NoVNCProxy is deleted", func() {
-				It("deletes the generated ConfigMaps", func() {
-					th.ExpectCondition(
-						novaNames.NoVNCProxyName,
-						ConditionGetterFunc(NoVNCProxyConditionGetter),
-						condition.ServiceConfigReadyCondition,
-						corev1.ConditionTrue,
-					)
-
-					th.DeleteInstance(GetNovaNoVNCProxy(novaNames.NoVNCProxyName))
-
-					Eventually(func() []corev1.ConfigMap {
-						return th.ListConfigMaps(novaNames.NoVNCProxyName.Name).Items
-					}, timeout, interval).Should(BeEmpty())
-				})
-			})
 		})
 		When("NoVNCProxy is created with a proper Secret", func() {
 			BeforeEach(func() {

--- a/test/functional/nova_scheduler_test.go
+++ b/test/functional/nova_scheduler_test.go
@@ -182,27 +182,6 @@ var _ = Describe("NovaScheduler controller", func() {
 		})
 	})
 
-	When("the NovaScheduler is deleted", func() {
-		BeforeEach(func() {
-			DeferCleanup(
-				k8sClient.Delete, ctx, CreateNovaAPISecret(novaNames.SchedulerName.Namespace, SecretName))
-		})
-		It("deletes the generated ConfigMaps", func() {
-			th.ExpectCondition(
-				novaNames.SchedulerName,
-				ConditionGetterFunc(NovaSchedulerConditionGetter),
-				condition.ServiceConfigReadyCondition,
-				corev1.ConditionTrue,
-			)
-
-			th.DeleteInstance(GetNovaScheduler(novaNames.SchedulerName))
-
-			Eventually(func() []corev1.ConfigMap {
-				return th.ListConfigMaps(novaNames.SchedulerName.Name).Items
-			}, timeout, interval).Should(BeEmpty())
-		})
-	})
-
 	When("the NovaScheduler is created with a proper Secret", func() {
 
 		BeforeEach(func() {

--- a/test/functional/novaapi_controller_test.go
+++ b/test/functional/novaapi_controller_test.go
@@ -187,23 +187,6 @@ var _ = Describe("NovaAPI controller", func() {
 				}, timeout, interval).Should(Succeed())
 
 			})
-
-			When("the NovaAPI is deleted", func() {
-				It("deletes the generated ConfigMaps", func() {
-					th.ExpectCondition(
-						novaNames.APIName,
-						ConditionGetterFunc(NovaAPIConditionGetter),
-						condition.ServiceConfigReadyCondition,
-						corev1.ConditionTrue,
-					)
-
-					th.DeleteInstance(GetNovaAPI(novaNames.APIName))
-
-					Eventually(func() []corev1.ConfigMap {
-						return th.ListConfigMaps(novaNames.APIName.Name).Items
-					}, timeout, interval).Should(BeEmpty())
-				})
-			})
 		})
 	})
 

--- a/test/functional/novaconductor_controller_test.go
+++ b/test/functional/novaconductor_controller_test.go
@@ -189,22 +189,6 @@ var _ = Describe("NovaConductor controller", func() {
 				}, timeout, interval).Should(Succeed())
 
 			})
-
-			When("the NovaConductor is deleted", func() {
-				It("deletes the generated ConfigMaps", func() {
-					th.ExpectCondition(
-						novaNames.ConductorName,
-						ConditionGetterFunc(NovaConductorConditionGetter),
-						condition.ServiceConfigReadyCondition,
-						corev1.ConditionTrue,
-					)
-
-					th.DeleteInstance(GetNovaConductor(novaNames.ConductorName))
-					Eventually(func() []corev1.ConfigMap {
-						return th.ListConfigMaps(novaNames.ConductorName.Name).Items
-					}, timeout, interval).Should(BeEmpty())
-				})
-			})
 		})
 	})
 


### PR DESCRIPTION
We had envtest case where the sub CR is deleted and asserted that the ConfigMap containing the generated service config is deleted. These cases only passed as they are checked the list of ConfigMaps in an non existing namespace. The test code wrongly passed the Name instead of the Namespace of the instance to the ListConfigMap call.

The ConfigMaps since replaced with Secrets but these testcases was missed in that commit.

The Secrets generated by the operator are all having a controller reference set. This way k8s automatically cleans up these resources after the CR parent is deleted. However this cleanup happens as part of a k8s controller which is not running in EnvTest therefore in EnvTest these resources are not deleted.

Therefore these false test cases now removed.

The resources we left behind in EnvTest are not causing any interaction between test cases as each test case runs in its own namespace.