### PR TITLE
Replace ansible execution with compute config generation

### DIFF
--- a/api/v1beta1/conditions.go
+++ b/api/v1beta1/conditions.go
@@ -47,6 +47,9 @@ const (
 	NovaMetadataReadyCondition condition.Type = "NovaMetadataReady"
 	// NovaNoVNCProxyReadyCondition indicates when the given NoVNCProxy instance is Ready
 	NovaNoVNCProxyReadyCondition condition.Type = "NovaNoVNCProxyReady"
+	// NovaComputeServiceConfigReady indicates when the compute service config
+	// is ready for the given NovaCell
+	NovaComputeServiceConfigReady condition.Type = "NovaComputeServiceConfigReady"
 )
 
 // Common Messages used by API objects.
@@ -149,4 +152,10 @@ const (
 
 	//NovaNoVNCProxyReadyErrorMessage
 	NovaNoVNCProxyReadyErrorMessage = "NovaNoVNCProxy error occurred %s"
+
+	//NovaComputeServiceConfigInitMessage
+	NovaComputeServiceConfigInitMessage = "Compute service config generation is not started"
+
+	//NovaComputeServiceConfigErrorMessage
+	NovaComputeServiceConfigErrorMessage = "Compute service config generation error occurred %s"
 )

--- a/api/v1beta1/novacell_types.go
+++ b/api/v1beta1/novacell_types.go
@@ -223,3 +223,8 @@ func (s NovaCellStatus) GetConditions() condition.Conditions {
 func (instance NovaCell) IsReady() bool {
 	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)
 }
+
+// GetSecret returns the value of the NovaCell.Spec.Secret
+func (n NovaCell) GetSecret() string {
+	return n.Spec.Secret
+}

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -57,6 +57,9 @@ const (
 	// NovaExternalComputeLabelPrefix - a unique, prefix used for the AEE CR
 	// and other children objects created to mange external computes
 	NovaExternalComputeLabelPrefix = "nova-external-compute"
+	// NovaCellLabelPrefix - a unique, prefix used for the compute config
+	// Secret
+	NovaCellLabelPrefix = "nova-cell"
 	// NovaLabelPrefix - a unique, prefix used for the playbooks owned by
 	// the nova operator
 	NovaLabelPrefix = "nova"

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -384,7 +384,7 @@ func (r *Reconcilers) OverrideRequeueTimeout(timeout time.Duration) {
 // generateConfigsGeneric helper function to generate config maps
 func (r *ReconcilerBase) generateConfigsGeneric(
 	ctx context.Context, h *helper.Helper,
-	instance client.Object, envVars *map[string]env.Setter,
+	instance client.Object, configName string, envVars *map[string]env.Setter,
 	templateParameters map[string]interface{},
 	extraData map[string]string, cmLabels map[string]string,
 	additionalTemplates map[string]string,
@@ -402,7 +402,7 @@ func (r *ReconcilerBase) generateConfigsGeneric(
 	cms := []util.Template{
 		// ConfigMap
 		{
-			Name:               nova.GetServiceConfigSecretName(instance.GetName()),
+			Name:               configName,
 			Namespace:          instance.GetNamespace(),
 			Type:               util.TemplateTypeConfig,
 			InstanceType:       instance.GetObjectKind().GroupVersionKind().Kind,
@@ -430,13 +430,13 @@ func (r *ReconcilerBase) generateConfigsGeneric(
 // GenerateConfigs helper function to generate config maps
 func (r *ReconcilerBase) GenerateConfigs(
 	ctx context.Context, h *helper.Helper,
-	instance client.Object, envVars *map[string]env.Setter,
+	instance client.Object, configName string, envVars *map[string]env.Setter,
 	templateParameters map[string]interface{},
 	extraData map[string]string, cmLabels map[string]string,
 	additionalTemplates map[string]string,
 ) error {
 	return r.generateConfigsGeneric(
-		ctx, h, instance, envVars, templateParameters, extraData,
+		ctx, h, instance, configName, envVars, templateParameters, extraData,
 		cmLabels, additionalTemplates, false,
 	)
 }
@@ -451,7 +451,8 @@ func (r *ReconcilerBase) GenerateConfigsWithScripts(
 	additionalTemplates map[string]string,
 ) error {
 	return r.generateConfigsGeneric(
-		ctx, h, instance, envVars, templateParameters, extraData,
+		ctx, h, instance, nova.GetServiceConfigSecretName(instance.GetName()),
+		envVars, templateParameters, extraData,
 		cmLabels, additionalTemplates, true,
 	)
 }

--- a/controllers/novaapi_controller.go
+++ b/controllers/novaapi_controller.go
@@ -43,6 +43,7 @@ import (
 
 	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
 	novav1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
+	"github.com/openstack-k8s-operators/nova-operator/pkg/nova"
 	"github.com/openstack-k8s-operators/nova-operator/pkg/novaapi"
 
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
@@ -375,7 +376,8 @@ func (r *NovaAPIReconciler) generateConfigs(
 	)
 
 	err = r.GenerateConfigs(
-		ctx, h, instance, hashes, templateParameters, extraData, cmLabels, map[string]string{},
+		ctx, h, instance, nova.GetServiceConfigSecretName(instance.GetName()),
+		hashes, templateParameters, extraData, cmLabels, map[string]string{},
 	)
 	return err
 }

--- a/controllers/novacell_controller.go
+++ b/controllers/novacell_controller.go
@@ -472,8 +472,9 @@ func (r *NovaCellReconciler) generateComputeConfigs(
 
 	hashes := make(map[string]env.Setter)
 
+	configName := instance.GetName() + "-compute-config"
 	return r.GenerateConfigs(
-		ctx, h, instance, &hashes, templateParameters, map[string]string{}, cmLabels, map[string]string{},
+		ctx, h, instance, configName, &hashes, templateParameters, map[string]string{}, cmLabels, map[string]string{},
 	)
 }
 

--- a/controllers/novacell_controller.go
+++ b/controllers/novacell_controller.go
@@ -26,7 +26,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
@@ -512,5 +514,10 @@ func (r *NovaCellReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&novav1.NovaConductor{}).
 		Owns(&novav1.NovaMetadata{}).
 		Owns(&novav1.NovaNoVNCProxy{}).
+		// It generates and therefor owns the compute config secret
+		Owns(&corev1.Secret{}).
+		// and it needs to watch the input secrets
+		Watches(&source.Kind{Type: &corev1.Secret{}},
+			handler.EnqueueRequestsFromMapFunc(r.GetSecretMapperFor(&novav1.NovaCellList{}))).
 		Complete(r)
 }

--- a/controllers/novaexternalcompute_controller.go
+++ b/controllers/novaexternalcompute_controller.go
@@ -41,6 +41,7 @@ import (
 	aee "github.com/openstack-k8s-operators/openstack-ansibleee-operator/api/v1alpha1"
 
 	novav1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
+	"github.com/openstack-k8s-operators/nova-operator/pkg/nova"
 )
 
 // NovaExternalComputeReconciler reconciles a NovaExternalCompute object
@@ -527,7 +528,8 @@ func (r *NovaExternalComputeReconciler) generateConfigs(
 		"firewall.yaml":                                   "/firewall.goyaml",
 	}
 	return r.GenerateConfigs(
-		ctx, h, instance, hashes, templateParameters, extraData, cmLabels, addtionalTemplates,
+		ctx, h, instance, nova.GetServiceConfigSecretName(instance.GetName()),
+		hashes, templateParameters, extraData, cmLabels, addtionalTemplates,
 	)
 }
 

--- a/controllers/novametadata_controller.go
+++ b/controllers/novametadata_controller.go
@@ -41,6 +41,7 @@ import (
 	util "github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	novav1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
 	novav1beta1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
+	"github.com/openstack-k8s-operators/nova-operator/pkg/nova"
 	"github.com/openstack-k8s-operators/nova-operator/pkg/novametadata"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 )
@@ -337,7 +338,8 @@ func (r *NovaMetadataReconciler) generateConfigs(
 	)
 
 	err = r.GenerateConfigs(
-		ctx, h, instance, hashes, templateParameters, extraData, cmLabels, map[string]string{},
+		ctx, h, instance, nova.GetServiceConfigSecretName(instance.GetName()),
+		hashes, templateParameters, extraData, cmLabels, map[string]string{},
 	)
 	return err
 }

--- a/controllers/novanovncproxy_controller.go
+++ b/controllers/novanovncproxy_controller.go
@@ -39,6 +39,7 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/statefulset"
 	util "github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	novav1beta1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
+	"github.com/openstack-k8s-operators/nova-operator/pkg/nova"
 	"github.com/openstack-k8s-operators/nova-operator/pkg/novncproxy"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 )
@@ -323,7 +324,8 @@ func (r *NovaNoVNCProxyReconciler) generateConfigs(
 	)
 
 	err = r.GenerateConfigs(
-		ctx, h, instance, hashes, templateParameters, extraData, cmLabels, map[string]string{},
+		ctx, h, instance, nova.GetServiceConfigSecretName(instance.GetName()),
+		hashes, templateParameters, extraData, cmLabels, map[string]string{},
 	)
 	return err
 }

--- a/controllers/novascheduler_controller.go
+++ b/controllers/novascheduler_controller.go
@@ -39,6 +39,7 @@ import (
 	util "github.com/openstack-k8s-operators/lib-common/modules/common/util"
 
 	novav1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
+	"github.com/openstack-k8s-operators/nova-operator/pkg/nova"
 	"github.com/openstack-k8s-operators/nova-operator/pkg/novascheduler"
 )
 
@@ -330,7 +331,8 @@ func (r *NovaSchedulerReconciler) generateConfigs(
 	)
 
 	return r.GenerateConfigs(
-		ctx, h, instance, hashes, templateParameters, extraData, cmLabels, map[string]string{},
+		ctx, h, instance, nova.GetServiceConfigSecretName(instance.GetName()),
+		hashes, templateParameters, extraData, cmLabels, map[string]string{},
 	)
 }
 

--- a/templates/nova.conf
+++ b/templates/nova.conf
@@ -131,7 +131,9 @@ server_listen = {{ if (index . "novncproxy_service_host") }}{{ .novncproxy_servi
 # dns currently so we need to use my_ip for now.
 # https://docs.openstack.org/nova/latest/configuration/config.html#DEFAULT.console_host
 server_proxyclient_address = "$my_ip"
+{{if (index . "novncproxy_base_url")}}
 novncproxy_base_url = {{ .novncproxy_base_url }}/vnc_lite.html
+{{ end }}
 {{ end }}
 {{ end }}
 

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -513,7 +513,7 @@ func GetCellNames(novaName types.NamespacedName, cell string) CellNames {
 		},
 		ComputeConfigSecretName: types.NamespacedName{
 			Namespace: novaName.Namespace,
-			Name:      cellName.Name + "-config-data",
+			Name:      cellName.Name + "-compute-config",
 		},
 	}
 

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -21,13 +21,13 @@ import (
 
 	"github.com/google/uuid"
 	. "github.com/onsi/gomega"
+	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	routev1 "github.com/openshift/api/route/v1"
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	novav1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
 	aee "github.com/openstack-k8s-operators/openstack-ansibleee-operator/api/v1alpha1"
@@ -453,6 +453,7 @@ type CellNames struct {
 	CellNoVNCProxyNameConfigDataName types.NamespacedName
 	InternalCellSecretName           types.NamespacedName
 	InternalAPINetworkNADName        types.NamespacedName
+	ComputeConfigSecretName          types.NamespacedName
 }
 
 func GetCellNames(novaName types.NamespacedName, cell string) CellNames {
@@ -509,6 +510,10 @@ func GetCellNames(novaName types.NamespacedName, cell string) CellNames {
 		InternalAPINetworkNADName: types.NamespacedName{
 			Namespace: novaName.Namespace,
 			Name:      "internalapi",
+		},
+		ComputeConfigSecretName: types.NamespacedName{
+			Namespace: novaName.Namespace,
+			Name:      cellName.Name + "-config-data",
 		},
 	}
 
@@ -819,7 +824,7 @@ func AssertNoVNCProxyDoesNotExist(name types.NamespacedName) {
 	}, timeout, interval).Should(Succeed())
 }
 
-func SimulateNoVNCProxyRouteIngress(cellName string, namespace string) {
+func SimulateNoVNCProxyRouteIngress(cellName string, namespace string) string {
 	vncRouteName := types.NamespacedName{
 		Namespace: namespace,
 		Name:      fmt.Sprintf("nova-novncproxy-%s-public", cellName),
@@ -840,4 +845,5 @@ func SimulateNoVNCProxyRouteIngress(cellName string, namespace string) {
 		g.Expect(k8sClient.Update(ctx, vncRoute)).Should(Succeed())
 	}, timeout, interval).Should(Succeed())
 	logger.Info("Simulated Ingress for the NovaNoVncProxy Route", "on", vncRouteName)
+	return ingress.Host
 }

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	routev1 "github.com/openshift/api/route/v1"
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	novav1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
 	aee "github.com/openstack-k8s-operators/openstack-ansibleee-operator/api/v1alpha1"
@@ -816,4 +817,27 @@ func AssertNoVNCProxyDoesNotExist(name types.NamespacedName) {
 		err := k8sClient.Get(ctx, name, instance)
 		g.Expect(k8s_errors.IsNotFound(err)).To(BeTrue())
 	}, timeout, interval).Should(Succeed())
+}
+
+func SimulateNoVNCProxyRouteIngress(cellName string, namespace string) {
+	vncRouteName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      fmt.Sprintf("nova-novncproxy-%s-public", cellName),
+	}
+	ingress := routev1.RouteIngress{
+		Host: fmt.Sprintf(
+			"nova-novncproxy-%s-public-openstack.apps-crc.testing", cellName),
+		RouterName: "name",
+	}
+	Eventually(func(g Gomega) {
+		vncRoute := &routev1.Route{}
+		g.Expect(k8sClient.Get(ctx, vncRouteName, vncRoute)).Should(Succeed())
+
+		vncRoute.Status.Ingress = append(vncRoute.Status.Ingress, ingress)
+		// NOTE(gibi): Here we intentionally not using the Status client even
+		// though we are updating the Status. While this is strange but it
+		// does not work otherwise. (The status client will return 404)
+		g.Expect(k8sClient.Update(ctx, vncRoute)).Should(Succeed())
+	}, timeout, interval).Should(Succeed())
+	logger.Info("Simulated Ingress for the NovaNoVncProxy Route", "on", vncRouteName)
 }

--- a/test/functional/nova_multicell_test.go
+++ b/test/functional/nova_multicell_test.go
@@ -294,6 +294,7 @@ var _ = Describe("Nova multicell", func() {
 						novaNames.APIMariaDBDatabaseName.Name)),
 			)
 			th.SimulateStatefulSetReplicaReady(cell1.NoVNCProxyStatefulSetName)
+			SimulateNoVNCProxyRouteIngress("cell1", novaNames.Namespace)
 			th.SimulateJobSuccess(cell1.CellDBSyncJobName)
 			th.ExpectCondition(
 				cell1.CellConductorName,
@@ -346,6 +347,7 @@ var _ = Describe("Nova multicell", func() {
 			th.SimulateMariaDBDatabaseCompleted(cell1.MariaDBDatabaseName)
 			th.SimulateTransportURLReady(cell1.TransportURLName)
 			th.SimulateStatefulSetReplicaReady(cell1.NoVNCProxyStatefulSetName)
+			SimulateNoVNCProxyRouteIngress("cell1", novaNames.Namespace)
 			th.SimulateJobSuccess(cell1.CellDBSyncJobName)
 			th.SimulateStatefulSetReplicaReady(cell1.ConductorStatefulSetName)
 			th.SimulateJobSuccess(cell1.CellMappingJobName)
@@ -380,6 +382,7 @@ var _ = Describe("Nova multicell", func() {
 				ContainSubstring("[api_database]"),
 			)
 			th.SimulateStatefulSetReplicaReady(cell2.NoVNCProxyStatefulSetName)
+			SimulateNoVNCProxyRouteIngress("cell2", novaNames.Namespace)
 			th.SimulateJobSuccess(cell2.CellDBSyncJobName)
 			th.ExpectCondition(
 				cell2.CellConductorName,
@@ -463,6 +466,7 @@ var _ = Describe("Nova multicell", func() {
 			GetNovaConductor(cell2.CellConductorName)
 
 			th.SimulateStatefulSetReplicaReady(cell2.NoVNCProxyStatefulSetName)
+			SimulateNoVNCProxyRouteIngress("cell2", novaNames.Namespace)
 			th.SimulateJobSuccess(cell2.CellDBSyncJobName)
 			th.ExpectCondition(
 				cell2.CellConductorName,
@@ -614,6 +618,7 @@ var _ = Describe("Nova multicell", func() {
 
 			// As cell0 is ready cell1 is deployed
 			th.SimulateStatefulSetReplicaReady(cell1.NoVNCProxyStatefulSetName)
+			SimulateNoVNCProxyRouteIngress("cell1", novaNames.Namespace)
 			th.SimulateJobSuccess(cell1.CellDBSyncJobName)
 			th.SimulateStatefulSetReplicaReady(cell1.ConductorStatefulSetName)
 			th.SimulateJobSuccess(cell1.CellMappingJobName)
@@ -781,6 +786,7 @@ var _ = Describe("Nova multicell", func() {
 
 			// As cell0 is ready cell1 is deployed
 			th.SimulateStatefulSetReplicaReady(cell1.NoVNCProxyStatefulSetName)
+			SimulateNoVNCProxyRouteIngress("cell1", cell1.CellName.Namespace)
 			th.SimulateJobSuccess(cell1.CellDBSyncJobName)
 			th.SimulateStatefulSetReplicaReady(cell1.ConductorStatefulSetName)
 			th.SimulateStatefulSetReplicaReady(cell1.MetadataStatefulSetName)

--- a/test/functional/nova_reconfiguration_test.go
+++ b/test/functional/nova_reconfiguration_test.go
@@ -373,12 +373,13 @@ var _ = Describe("Nova reconfiguration", func() {
 		})
 	})
 	When("CellMessageBusInstance is reconfigured for a cell", func() {
-		It("re-runs the cell mapping job and updates the cell hash", func() {
+		It("updates the cell, re-runs the cell mapping job and updates the cell hash", func() {
 			mappingJob := th.GetJob(cell1.CellMappingJobName)
 			oldJobInputHash := GetEnvVarValue(
 				mappingJob.Spec.Template.Spec.Containers[0].Env, "INPUT_HASH", "")
 
 			oldCell1Hash := GetNova(novaNames.NovaName).Status.RegisteredCells[cell1.CellName.Name]
+			oldComputeConfigHash := GetNovaCell(cell1.CellName).Status.Hash[cell1.ComputeConfigSecretName.Name]
 
 			Eventually(func(g Gomega) {
 				nova := GetNova(novaNames.NovaName)
@@ -441,7 +442,7 @@ var _ = Describe("Nova reconfiguration", func() {
 				configData := string(configDataMap.Data["01-nova.conf"])
 				g.Expect(configData).Should(ContainSubstring("transport_url=rabbit://alternate-mq-for-cell1-secret/fake"))
 			}, timeout, interval).Should(Succeed())
-
+			Expect(GetNovaCell(cell1.CellName).Status.Hash[cell1.ComputeConfigSecretName.Name]).NotTo(Equal(oldComputeConfigHash))
 		})
 	})
 

--- a/test/functional/nova_reconfiguration_test.go
+++ b/test/functional/nova_reconfiguration_test.go
@@ -105,11 +105,13 @@ func CreateNovaWith3CellsAndEnsureReady(novaNames NovaNames) {
 	th.SimulateKeystoneEndpointReady(novaNames.APIKeystoneEndpointName)
 
 	th.SimulateStatefulSetReplicaReady(cell1.NoVNCProxyStatefulSetName)
+	SimulateNoVNCProxyRouteIngress("cell1", novaNames.Namespace)
 	th.SimulateJobSuccess(cell1.CellDBSyncJobName)
 	th.SimulateStatefulSetReplicaReady(cell1.ConductorStatefulSetName)
 	th.SimulateJobSuccess(cell1.CellMappingJobName)
 
 	th.SimulateStatefulSetReplicaReady(cell2.NoVNCProxyStatefulSetName)
+	SimulateNoVNCProxyRouteIngress("cell2", novaNames.Namespace)
 	th.SimulateJobSuccess(cell2.CellDBSyncJobName)
 	th.SimulateStatefulSetReplicaReady(cell2.ConductorStatefulSetName)
 	th.SimulateJobSuccess(cell2.CellMappingJobName)

--- a/test/functional/novacell_controller_test.go
+++ b/test/functional/novacell_controller_test.go
@@ -289,6 +289,8 @@ var _ = Describe("NovaCell controller", func() {
 				novav1.NovaComputeServiceConfigReady,
 				corev1.ConditionTrue,
 			)
+
+			Expect(GetNovaCell(cell1.CellName).Status.Hash).To(HaveKey(cell1.ComputeConfigSecretName.Name))
 		})
 
 		It("is Ready when all cell services is ready", func() {
@@ -349,6 +351,8 @@ var _ = Describe("NovaCell controller", func() {
 				novav1.NovaComputeServiceConfigReady,
 				corev1.ConditionTrue,
 			)
+
+			Expect(GetNovaCell(cell2.CellName).Status.Hash).To(HaveKey(cell2.ComputeConfigSecretName.Name))
 		})
 
 		It("is Ready when all cell services is ready", func() {

--- a/test/functional/novaexternalcompute_controller_test.go
+++ b/test/functional/novaexternalcompute_controller_test.go
@@ -41,6 +41,8 @@ func CreateNovaCellAndEnsureReady(cell CellNames) {
 	th.SimulateJobSuccess(cell.CellDBSyncJobName)
 	th.SimulateStatefulSetReplicaReady(cell.ConductorStatefulSetName)
 
+	SimulateNoVNCProxyRouteIngress(cell1.CellName.Name, cell1.CellName.Namespace)
+
 	th.ExpectCondition(
 		cell.CellName,
 		ConditionGetterFunc(NovaCellConditionGetter),
@@ -78,8 +80,6 @@ var _ = Describe("NovaExternalCompute", func() {
 				Name:      compute.Spec.SSHKeySecretName,
 			}
 			CreateNovaExternalComputeSSHSecret(sshSecretName)
-
-			SimulateNoVNCProxyRouteIngress(cell1.CellName.Name, cell1.CellName.Namespace)
 
 			DeferCleanup(th.DeleteSecret, sshSecretName)
 			libvirtAEEName = types.NamespacedName{

--- a/test/functional/novaexternalcompute_controller_test.go
+++ b/test/functional/novaexternalcompute_controller_test.go
@@ -19,7 +19,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	routev1 "github.com/openshift/api/route/v1"
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
 	corev1 "k8s.io/api/core/v1"
@@ -28,11 +27,6 @@ import (
 
 	novav1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
 )
-
-var globalRoute routev1.RouteIngress = routev1.RouteIngress{
-	Host:       "nova-novncproxy-cell1-public-openstack.apps-crc.testing",
-	RouterName: "name",
-}
 
 func CreateNovaCellAndEnsureReady(cell CellNames) {
 	DeferCleanup(
@@ -85,15 +79,7 @@ var _ = Describe("NovaExternalCompute", func() {
 			}
 			CreateNovaExternalComputeSSHSecret(sshSecretName)
 
-			vncRouteName := fmt.Sprintf("nova-novncproxy-%s-public", cell1.CellName.Name)
-			vncRoute := &routev1.Route{}
-			k8sClient.Get(ctx, types.NamespacedName{
-				Namespace: novaNames.ComputeName.Namespace,
-				Name:      vncRouteName,
-			}, vncRoute)
-			vncRoute.Spec.Host = "nova-novncproxy-cell1-public-openstack.apps-crc.testing"
-			vncRoute.Status.Ingress = append(vncRoute.Status.Ingress, globalRoute)
-			Expect(k8sClient.Update(ctx, vncRoute)).Should(Succeed())
+			SimulateNoVNCProxyRouteIngress(cell1.CellName.Name, cell1.CellName.Namespace)
 
 			DeferCleanup(th.DeleteSecret, sshSecretName)
 			libvirtAEEName = types.NamespacedName{
@@ -383,15 +369,7 @@ var _ = Describe("NovaExternalCompute", func() {
 			}
 			CreateNovaExternalComputeSSHSecret(sshSecretName)
 
-			vncRouteName := fmt.Sprintf("nova-novncproxy-%s-public", cell1.CellName.Name)
-			vncRoute := &routev1.Route{}
-			k8sClient.Get(ctx, types.NamespacedName{
-				Namespace: novaNames.ComputeName.Namespace,
-				Name:      vncRouteName,
-			}, vncRoute)
-			vncRoute.Spec.Host = "nova-novncproxy-cell1-public-openstack.apps-crc.testing"
-			vncRoute.Status.Ingress = append(vncRoute.Status.Ingress, globalRoute)
-			Expect(k8sClient.Update(ctx, vncRoute)).Should(Succeed())
+			SimulateNoVNCProxyRouteIngress(cell1.CellName.Name, cell1.CellName.Namespace)
 
 			DeferCleanup(th.DeleteSecret, sshSecretName)
 


### PR DESCRIPTION
Based on the decisions in https://issues.redhat.com/browse/OSP-25812 the sevice-operators (like nova-operator) should not run or trigger ansible execution on the EDPM nodes. Instead each NovaCell should generate a Secret that contains configuration snippets that another operator (dataplane) can use to configure a nova-compute service connected to the given cell. 

Tasks:

- [x] Move compute config generation from `NovaExternalCompute` controller to `NovaCell` controller
- [x] Rename the compute config Secret to `<Nova name>-<NovaCell name>-compute-config` (e.g. `nova-cell1-compute-config`). Do not generate such config to `NovaCell/cell0` as computes cannot be connect to cell0.
- [x] Add a new `InputReady` codition to the `NovaCell.Status.Conditions` to be able to report if the input secrets are missing
- [x] Add a new `ComputeServiceConfig` condition to the `NovaCell.Status.Conditions` and 
    - [x] use it to indicate that the content of the config Secret is reconciled according to the `NovaCell.Spec`. 
    - [x] Also use it to indicate if for some reason (e.g. missing input) the config Secret is not exists / not up to date. 
    - [x] This condition should be part of the Ready condition but the negative state of this condition should not block the creation of the podified cell services.
- [x] Make sure that the compute service Secret is only generated **after** the `NovaNoVNCProxy` CR is ready in the cell as the config needs to contain the route to the service.
- [x] Ensure that if the cell configuration is changed the the content of the Secret is updated
- [x] Store the `hash` of the config Secret in the NovaCell.Status. This can be compared to the hash in the Status of the DataPlaneService (TBD) indicating what version of the configuration is deployed to decide if the latest config is already deployed or not.

Note that the cleanup of the NovaExternalCompute controller and the related pieces (code, test code, yaml definitions and samples, ansible, molecule, templates)  will be handled in a separate PR #476  to decouple this PR from the dataplane-operator work. E.g. we can support both the old and the new deployment procedure and clean up the old code only after dataplane-operator is switched to new deployment procedure.

Questions:
- ~~? Add `NovaCell.Status.ComputeConfig` string field that contains the name of the Secret containing the compute config~~ This is not needed any more as we store the hash of the config Secret in NovaCell.Status.Hash map where the key is the name of the config Secret.
- ~~? Add `NovaCell.Spec.CustomComputeServiceConfig` string field that provides a way for the end user to pass through an oslo.config snippet that will be added to the generated compute config Secret top of the operator generated default config? This would be a cell level config override that applies to each compute in the cell.~~ (agreed that we don't need it)

Closes: https://issues.redhat.com/browse/OSPRH-246