### PR TITLE
Fix *ReadyCount propagation

### DIFF
--- a/controllers/nova_controller.go
+++ b/controllers/nova_controller.go
@@ -1260,7 +1260,7 @@ func (r *NovaReconciler) ensureMetadata(
 	if c != nil {
 		instance.Status.Conditions.Set(c)
 	}
-	instance.Status.APIServiceReadyCount = metadata.Status.ReadyCount
+	instance.Status.MetadataServiceReadyCount = metadata.Status.ReadyCount
 
 	return ctrl.Result{}, nil
 }

--- a/controllers/novacell_controller.go
+++ b/controllers/novacell_controller.go
@@ -308,6 +308,8 @@ func (r *NovaCellReconciler) ensureConductor(
 		util.LogForObject(h, fmt.Sprintf("NovaConductor %s.", string(op)), instance, "NovaConductor.Name", conductor.Name)
 	}
 
+	instance.Status.ConductorServiceReadyCount = conductor.Status.ReadyCount
+
 	c := conductor.Status.Conditions.Mirror(novav1.NovaConductorReadyCondition)
 	// NOTE(gibi): it can be nil if the NovaConductor CR is created but no
 	// reconciliation is run on it to initialize the ReadyCondition yet.
@@ -359,6 +361,8 @@ func (r *NovaCellReconciler) ensureNoVNCProxy(
 		util.LogForObject(h, fmt.Sprintf("NovaNoVNCProxy %s.", string(op)), instance, "NovaNoVNCProxy.Name", novncproxy.Name)
 	}
 
+	instance.Status.NoVNCPRoxyServiceReadyCount = novncproxy.Status.ReadyCount
+
 	c := novncproxy.Status.Conditions.Mirror(novav1.NovaNoVNCProxyReadyCondition)
 
 	if c != nil {
@@ -408,6 +412,8 @@ func (r *NovaCellReconciler) ensureMetadata(
 	if op != controllerutil.OperationResultNone {
 		util.LogForObject(h, fmt.Sprintf("NovaMetadata %s.", string(op)), instance, "NovaMetadata.Name", metadata.Name)
 	}
+
+	instance.Status.MetadataServiceReadyCount = metadata.Status.ReadyCount
 
 	c := metadata.Status.Conditions.Mirror(novav1.NovaMetadataReadyCondition)
 	// NOTE(gibi): it can be nil if the NovaMetadata CR is created but no

--- a/test/functional/nova_controller_test.go
+++ b/test/functional/nova_controller_test.go
@@ -415,6 +415,7 @@ var _ = Describe("Nova controller", func() {
 				condition.ReadyCondition,
 				corev1.ConditionTrue,
 			)
+			Expect(GetNova(novaNames.NovaName).Status.APIServiceReadyCount).To(Equal(int32(1)))
 		})
 
 		It("creates NovaScheduler", func() {
@@ -454,6 +455,7 @@ var _ = Describe("Nova controller", func() {
 				condition.ReadyCondition,
 				corev1.ConditionTrue,
 			)
+			Expect(GetNova(novaNames.NovaName).Status.SchedulerServiceReadyCount).To(Equal(int32(1)))
 		})
 
 		It("creates NovaMetadata", func() {
@@ -493,6 +495,7 @@ var _ = Describe("Nova controller", func() {
 				condition.ReadyCondition,
 				corev1.ConditionTrue,
 			)
+			Expect(GetNova(novaNames.NovaName).Status.MetadataServiceReadyCount).To(Equal(int32(1)))
 		})
 	})
 

--- a/test/functional/novacell_controller_test.go
+++ b/test/functional/novacell_controller_test.go
@@ -121,9 +121,8 @@ var _ = Describe("NovaCell controller", func() {
 					novav1.NovaConductorReadyCondition,
 					corev1.ConditionTrue,
 				)
-				// TODO(gibi): this is a bug in the cell controller
-				// novaCell = GetNovaCell(cell0.CellName)
-				// Expect(novaCell.Status.ConductorServiceReadyCount).To(Equal(int32(1)))
+				novaCell := GetNovaCell(cell0.CellName)
+				Expect(novaCell.Status.ConductorServiceReadyCount).To(Equal(int32(1)))
 			})
 
 			It("does not create Metadata or NoVNCProxy services in cell0", func() {
@@ -200,9 +199,8 @@ var _ = Describe("NovaCell controller", func() {
 				novav1.NovaConductorReadyCondition,
 				corev1.ConditionTrue,
 			)
-			// TODO(gibi): this is a bug in the cell controller
-			// novaCell = GetNovaCell(cell1.CellName)
-			// Expect(novaCell.Status.ConductorServiceReadyCount).To(Equal(int32(1)))
+			novaCell = GetNovaCell(cell1.CellName)
+			Expect(novaCell.Status.ConductorServiceReadyCount).To(Equal(int32(1)))
 		})
 
 		It("creates the NovaNoVNCProxy and tracks its readiness", func() {
@@ -226,9 +224,8 @@ var _ = Describe("NovaCell controller", func() {
 				novav1.NovaNoVNCProxyReadyCondition,
 				corev1.ConditionTrue,
 			)
-			// TODO(gibi): this is a bug in the cell controller
-			// novaCell = GetNovaCell(cell1.CellName)
-			// Expect(novaCell.Status.NoVNCPRoxyServiceReadyCount).To(Equal(int32(1)))
+			novaCell = GetNovaCell(cell1.CellName)
+			Expect(novaCell.Status.NoVNCPRoxyServiceReadyCount).To(Equal(int32(1)))
 		})
 
 		It("creates the NovaMetadata and tracks its readiness", func() {
@@ -251,9 +248,8 @@ var _ = Describe("NovaCell controller", func() {
 				novav1.NovaMetadataReadyCondition,
 				corev1.ConditionTrue,
 			)
-			// TODO(gibi): this is a bug in the cell controller
-			// novaCell = GetNovaCell(cell1.CellName)
-			// Expect(novaCell.Status.MetadataServiceReadyCount).To(Equal(int32(1)))
+			novaCell = GetNovaCell(cell1.CellName)
+			Expect(novaCell.Status.MetadataServiceReadyCount).To(Equal(int32(1)))
 		})
 
 		It("creates the compute config secret", func() {


### PR DESCRIPTION
There was a bug in the NovaCell controller, it did not propagated the
ReadyCount from the cell service CRs to the NovaCell CR status.

Also the NovaMetadata.Status.ReadyCount wrongly propagated to the
Nova.Status.APIReadyCount. 

These are fixed now and the test coverage is extended to cover these fields.