### PR TITLE
update nova/libvirt bindmounts

### DIFF
--- a/templates/libvirt_virtlogd/libvirt_virtlogd.json
+++ b/templates/libvirt_virtlogd/libvirt_virtlogd.json
@@ -14,7 +14,7 @@
         "/var/log/containers/qemu:/var/log/libvirt/qemu",
         "/var/log/containers/libvirt:/var/log/containers/libvirt",
         "/var/lib/libvirt:/var/lib/libvirt",
-        "/var/lib/nova:/var/lib/nova",
-        "/run/libvirt:/run/libvirt"
+        "/var/lib/nova:/var/lib/nova:shared,z",
+        "/run/libvirt:/run/libvirt:shared,z"
     ]
   }

--- a/templates/libvirt_virtnodedevd/libvirt_virtnodedevd.json
+++ b/templates/libvirt_virtnodedevd/libvirt_virtnodedevd.json
@@ -13,7 +13,7 @@
         "/etc/localtime:/etc/localtime:ro",
         "/var/log/containers/libvirt:/var/log/containers/libvirt",
         "/var/lib/libvirt:/var/lib/libvirt",
-        "/run/libvirt:/run/libvirt",
+        "/run/libvirt:/run/libvirt:shared,z",
         "/dev:/dev"
     ]
   }

--- a/templates/libvirt_virtproxyd/libvirt_virtproxyd.json
+++ b/templates/libvirt_virtproxyd/libvirt_virtproxyd.json
@@ -13,6 +13,6 @@
         "/etc/localtime:/etc/localtime:ro",
         "/var/log/containers/libvirt:/var/log/containers/libvirt",
         "/var/lib/libvirt:/var/lib/libvirt",
-        "/run/libvirt:/run/libvirt"
+        "/run/libvirt:/run/libvirt:shared,z"
     ]
   }

--- a/templates/libvirt_virtqemud/libvirt_virtqemud.json
+++ b/templates/libvirt_virtqemud/libvirt_virtqemud.json
@@ -15,8 +15,8 @@
         "/etc/localtime:/etc/localtime:ro",
         "/var/log/containers/libvirt:/var/log/containers/libvirt",
         "/var/lib/libvirt:/var/lib/libvirt",
-        "/var/lib/nova:/var/lib/nova",
-        "/run/libvirt:/run/libvirt",
+        "/var/lib/nova:/var/lib/nova:shared,z",
+        "/run/libvirt:/run/libvirt:shared,z",
         "/dev:/dev",
         "/etc/ceph:/var/lib/openstack/config/ceph:ro"
     ]

--- a/templates/libvirt_virtsecretd/libvirt_virtsecretd.json
+++ b/templates/libvirt_virtsecretd/libvirt_virtsecretd.json
@@ -13,6 +13,6 @@
         "/etc/localtime:/etc/localtime:ro",
         "/var/log/containers/libvirt:/var/log/containers/libvirt",
         "/var/lib/libvirt:/var/lib/libvirt",
-        "/run/libvirt:/run/libvirt"
+        "/run/libvirt:/run/libvirt:shared,z"
     ]
   }

--- a/templates/novacompute/nova_compute.json
+++ b/templates/novacompute/nova_compute.json
@@ -15,10 +15,10 @@
         "/lib/modules:/lib/modules:ro",
         "/dev:/dev",
         "/run/openvswitch:/run/openvswitch",
-        "/run/libvirt:/run/libvirt",
         "/var/log/containers/nova:/var/log/containers/nova",
         "/var/lib/libvirt:/var/lib/libvirt",
-        "/var/lib/nova/:/var/lib/nova/",
+        "/var/lib/nova:/var/lib/nova:shared,z",
+        "/run/libvirt:/run/libvirt:shared,z",
         "/var/lib/iscsi:/var/lib/iscsi",
         "/etc/iscsi:/etc/iscsi:ro",
         "/etc/ceph:/var/lib/openstack/config/ceph:ro"


### PR DESCRIPTION
This change adds :shared to ensure submounts propagate to the host.
This change add :z to enable selinux labeling to allow shared mounts
to be shared properly between multiple containers.
