### PR TITLE
[envtest]Pull out NoVNCProxy Route Ingress simulation

### DIFF
--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	routev1 "github.com/openshift/api/route/v1"
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	novav1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
 	aee "github.com/openstack-k8s-operators/openstack-ansibleee-operator/api/v1alpha1"
@@ -816,4 +817,27 @@ func AssertNoVNCProxyDoesNotExist(name types.NamespacedName) {
 		err := k8sClient.Get(ctx, name, instance)
 		g.Expect(k8s_errors.IsNotFound(err)).To(BeTrue())
 	}, timeout, interval).Should(Succeed())
+}
+
+func SimulateNoVNCProxyRouteIngress(cellName string, namespace string) {
+	vncRouteName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      fmt.Sprintf("nova-novncproxy-%s-public", cellName),
+	}
+	ingress := routev1.RouteIngress{
+		Host: fmt.Sprintf(
+			"nova-novncproxy-%s-public-openstack.apps-crc.testing", cellName),
+		RouterName: "name",
+	}
+	Eventually(func(g Gomega) {
+		vncRoute := &routev1.Route{}
+		g.Expect(k8sClient.Get(ctx, vncRouteName, vncRoute)).Should(Succeed())
+
+		vncRoute.Status.Ingress = append(vncRoute.Status.Ingress, ingress)
+		// NOTE(gibi): Here we intentionally not using the Status client even
+		// though we are updating the Status. While this is strange but it
+		// does not work otherwise. (The status client will return 404)
+		g.Expect(k8sClient.Update(ctx, vncRoute)).Should(Succeed())
+	}, timeout, interval).Should(Succeed())
+	logger.Info("Simulated Ingress for the NovaNoVncProxy Route", "on", vncRouteName)
 }

--- a/test/functional/novaexternalcompute_controller_test.go
+++ b/test/functional/novaexternalcompute_controller_test.go
@@ -19,7 +19,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	routev1 "github.com/openshift/api/route/v1"
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
 	corev1 "k8s.io/api/core/v1"
@@ -28,11 +27,6 @@ import (
 
 	novav1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
 )
-
-var globalRoute routev1.RouteIngress = routev1.RouteIngress{
-	Host:       "nova-novncproxy-cell1-public-openstack.apps-crc.testing",
-	RouterName: "name",
-}
 
 func CreateNovaCellAndEnsureReady(cell CellNames) {
 	DeferCleanup(
@@ -85,15 +79,7 @@ var _ = Describe("NovaExternalCompute", func() {
 			}
 			CreateNovaExternalComputeSSHSecret(sshSecretName)
 
-			vncRouteName := fmt.Sprintf("nova-novncproxy-%s-public", cell1.CellName.Name)
-			vncRoute := &routev1.Route{}
-			k8sClient.Get(ctx, types.NamespacedName{
-				Namespace: novaNames.ComputeName.Namespace,
-				Name:      vncRouteName,
-			}, vncRoute)
-			vncRoute.Spec.Host = "nova-novncproxy-cell1-public-openstack.apps-crc.testing"
-			vncRoute.Status.Ingress = append(vncRoute.Status.Ingress, globalRoute)
-			Expect(k8sClient.Update(ctx, vncRoute)).Should(Succeed())
+			SimulateNoVNCProxyRouteIngress(cell1.CellName.Name, cell1.CellName.Namespace)
 
 			DeferCleanup(th.DeleteSecret, sshSecretName)
 			libvirtAEEName = types.NamespacedName{
@@ -383,15 +369,7 @@ var _ = Describe("NovaExternalCompute", func() {
 			}
 			CreateNovaExternalComputeSSHSecret(sshSecretName)
 
-			vncRouteName := fmt.Sprintf("nova-novncproxy-%s-public", cell1.CellName.Name)
-			vncRoute := &routev1.Route{}
-			k8sClient.Get(ctx, types.NamespacedName{
-				Namespace: novaNames.ComputeName.Namespace,
-				Name:      vncRouteName,
-			}, vncRoute)
-			vncRoute.Spec.Host = "nova-novncproxy-cell1-public-openstack.apps-crc.testing"
-			vncRoute.Status.Ingress = append(vncRoute.Status.Ingress, globalRoute)
-			Expect(k8sClient.Update(ctx, vncRoute)).Should(Succeed())
+			SimulateNoVNCProxyRouteIngress(cell1.CellName.Name, cell1.CellName.Namespace)
 
 			DeferCleanup(th.DeleteSecret, sshSecretName)
 


### PR DESCRIPTION
Create an envtest helper that does the Route manipulation.

I intentionally dropped
```golang
			vncRoute.Spec.Host = "nova-novncproxy-cell1-public-openstack.apps-crc.testing"
```
from the helper. Changing the Spec of the Route from envtest triggers reconcile on the nova-operator that in turn changes things back. It should be enough to simulate the Ingress in the Status.