### PR TITLE
Propagate NetworkAttachments to AnsibleEE

### DIFF
--- a/controllers/novaexternalcompute_controller.go
+++ b/controllers/novaexternalcompute_controller.go
@@ -699,8 +699,7 @@ func initAEE(
 ) {
 	ansibleEE.Spec.Image = instance.Spec.AnsibleEEContainerImage
 	ansibleEE.Spec.DNSConfig = instance.Spec.DNSConfig
-	// TODO we don't currently have this on the NovaExternalComputeCR
-	// ansibleEE.Spec.NetworkAttachments = instance.Spec.NetworkAttachments
+	ansibleEE.Spec.NetworkAttachments = instance.Spec.NetworkAttachments
 	ansibleEE.Spec.Playbook = playbook
 	ansibleEE.Spec.Env = []corev1.EnvVar{
 		{Name: "ANSIBLE_FORCE_COLOR", Value: "True"},

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -371,6 +371,7 @@ func GetDefaultNovaExternalComputeSpec(novaName string, computeName string) map[
 		"novaInstance":           novaName,
 		"inventoryConfigMapName": computeName + "-inventory-configmap",
 		"sshKeySecretName":       computeName + "-ssh-key-secret",
+		"networkAttachments":     []string{"internalapi"},
 	}
 }
 

--- a/test/functional/novaexternalcompute_controller_test.go
+++ b/test/functional/novaexternalcompute_controller_test.go
@@ -138,6 +138,7 @@ var _ = Describe("NovaExternalCompute", func() {
 		})
 
 		It("creates AnsibleEE for libvirt", func() {
+			compute := GetNovaExternalCompute(novaNames.ComputeName)
 			// TODO(gibi): assert more fields on AnsibleEE
 			libvirtAEE := GetAEE(libvirtAEEName)
 			Expect(libvirtAEE.Spec.ExtraMounts).To(HaveLen(1))
@@ -145,9 +146,11 @@ var _ = Describe("NovaExternalCompute", func() {
 			configVol := &corev1.Volume{}
 			Expect(extraMounts.Volumes).To(ContainElement(HaveField("Name", "compute-configs"), configVol))
 			Expect(configVol.VolumeSource.Secret.SecretName).To(Equal(novaNames.ComputeName.Name + "-config-data"))
+			Expect(libvirtAEE.Spec.NetworkAttachments).To(Equal(compute.Spec.NetworkAttachments))
 		})
 
 		It("creates AnsibleEE for nova", func() {
+			compute := GetNovaExternalCompute(novaNames.ComputeName)
 			// TODO(gibi): assert more fields on AnsibleEE
 			novaAEE := GetAEE(novaAEEName)
 			Expect(novaAEE.Spec.ExtraMounts).To(HaveLen(1))
@@ -155,6 +158,7 @@ var _ = Describe("NovaExternalCompute", func() {
 			configVol := &corev1.Volume{}
 			Expect(extraMounts.Volumes).To(ContainElement(HaveField("Name", "compute-configs"), configVol))
 			Expect(configVol.VolumeSource.Secret.SecretName).To(Equal(novaNames.ComputeName.Name + "-config-data"))
+			Expect(novaAEE.Spec.NetworkAttachments).To(Equal(compute.Spec.NetworkAttachments))
 		})
 
 		It("is Ready", func() {


### PR DESCRIPTION
In a real network isolation environment the AnsibleEE CR needs to have a properly set up NetworkAttachment fields to be able to talk to the EDPM node. The dataplane-operator provides the necessary attachments info to the NovaExternalCompute CR but the nova-operator did not propagated it to the AnsibleEE CRs it creates.

This is fixed now.