### PR TITLE
Use inventory as a secret instead of configmap

### DIFF
--- a/api/bases/nova.openstack.org_novaexternalcomputes.yaml
+++ b/api/bases/nova.openstack.org_novaexternalcomputes.yaml
@@ -104,9 +104,9 @@ spec:
                       type: string
                     type: array
                 type: object
-              inventoryConfigMapName:
-                description: InventoryConfigMapName is the name of the k8s config
-                  map that contains the ansible inventory information for this node
+              inventorySecretName:
+                description: InventorySecretName is the name of the k8s secret that
+                  contains the ansible inventory information for this node
                 type: string
               networkAttachments:
                 description: NetworkAttachments is a list of NetworkAttachment resource
@@ -134,7 +134,7 @@ spec:
                   the ssh keys to access the node
                 type: string
             required:
-            - inventoryConfigMapName
+            - inventorySecretName
             - sshKeySecretName
             type: object
           status:

--- a/api/v1beta1/novaexternalcompute_types.go
+++ b/api/v1beta1/novaexternalcompute_types.go
@@ -51,9 +51,9 @@ type NovaExternalComputeSpec struct {
 	DefaultConfigOverwrite map[string]string `json:"defaultConfigOverwrite,omitempty"`
 
 	// +kubebuilder:validation:Required
-	// InventoryConfigMapName is the name of the k8s config map that contains the ansible inventory information
+	// InventorySecretName is the name of the k8s secret that contains the ansible inventory information
 	// for this node
-	InventoryConfigMapName string `json:"inventoryConfigMapName"`
+	InventorySecretName string `json:"inventorySecretName"`
 
 	// +kubebuilder:validation:Required
 	// SSHKeySecretName is the name of the k8s Secret that contains the ssh keys to access the node
@@ -140,7 +140,7 @@ func (instance NovaExternalCompute) IsReady() bool {
 
 // NewNovaExternalComputeSpec returns a NovaExternalComputeSpec where the fields are defaulted according
 // to the CRD definition
-func NewNovaExternalComputeSpec(inventoryConfigMapName string, sshKeySecretName string) NovaExternalComputeSpec {
+func NewNovaExternalComputeSpec(inventorySecretName string, sshKeySecretName string) NovaExternalComputeSpec {
 	trueVar := true
 
 	spec := NovaExternalComputeSpec{
@@ -148,7 +148,7 @@ func NewNovaExternalComputeSpec(inventoryConfigMapName string, sshKeySecretName 
 		CellName:               "cell1",
 		CustomServiceConfig:    "",
 		DefaultConfigOverwrite: nil,
-		InventoryConfigMapName: inventoryConfigMapName,
+		InventorySecretName:    inventorySecretName,
 		SSHKeySecretName:       sshKeySecretName,
 		Deploy:                 &trueVar,
 		NetworkAttachments:     nil,

--- a/config/crd/bases/nova.openstack.org_novaexternalcomputes.yaml
+++ b/config/crd/bases/nova.openstack.org_novaexternalcomputes.yaml
@@ -104,9 +104,9 @@ spec:
                       type: string
                     type: array
                 type: object
-              inventoryConfigMapName:
-                description: InventoryConfigMapName is the name of the k8s config
-                  map that contains the ansible inventory information for this node
+              inventorySecretName:
+                description: InventorySecretName is the name of the k8s secret that
+                  contains the ansible inventory information for this node
                 type: string
               networkAttachments:
                 description: NetworkAttachments is a list of NetworkAttachment resource
@@ -134,7 +134,7 @@ spec:
                   the ssh keys to access the node
                 type: string
             required:
-            - inventoryConfigMapName
+            - inventorySecretName
             - sshKeySecretName
             type: object
           status:

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -368,10 +368,10 @@ func NovaSchedulerNotExists(name types.NamespacedName) {
 
 func GetDefaultNovaExternalComputeSpec(novaName string, computeName string) map[string]interface{} {
 	return map[string]interface{}{
-		"novaInstance":           novaName,
-		"inventoryConfigMapName": computeName + "-inventory-configmap",
-		"sshKeySecretName":       computeName + "-ssh-key-secret",
-		"networkAttachments":     []string{"internalapi"},
+		"novaInstance":        novaName,
+		"InventorySecretName": computeName + "-inventory-secret",
+		"sshKeySecretName":    computeName + "-ssh-key-secret",
+		"networkAttachments":  []string{"internalapi"},
 	}
 }
 
@@ -402,10 +402,10 @@ func NovaExternalComputeConditionGetter(name types.NamespacedName) condition.Con
 	return instance.Status.Conditions
 }
 
-func CreateNovaExternalComputeInventoryConfigMap(name types.NamespacedName) client.Object {
+func CreateNovaExternalComputeInventorySecret(name types.NamespacedName) client.Object {
 
-	return th.CreateConfigMap(
-		name, map[string]interface{}{"inventory": "an ansible inventory"})
+	return th.CreateSecret(
+		name, map[string][]byte{"inventory": []byte("an ansible inventory")})
 }
 
 func CreateNovaExternalComputeSSHSecret(name types.NamespacedName) *corev1.Secret {


### PR DESCRIPTION
Changing it into secret, as the inventory may require secret values.
ref: https://github.com/openstack-k8s-operators/dataplane-operator/pull/330