### PR TITLE
switch to structured logging

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -287,7 +287,6 @@ func ensureConfigMap(
 type ReconcilerBase struct {
 	Client         client.Client
 	Kclient        kubernetes.Interface
-	Log            logr.Logger
 	Scheme         *runtime.Scheme
 	RequeueTimeout time.Duration
 }

--- a/controllers/nova_controller.go
+++ b/controllers/nova_controller.go
@@ -1391,7 +1391,7 @@ func (r *NovaReconciler) ensureCellMapped(
 	// information to the top level services so that each service can restart
 	// their Pods if a new cell is registered or an existing cell is updated.
 	instance.Status.RegisteredCells[cell.Name] = job.GetHash()
-	l.Info(fmt.Sprintf("Job %s hash added - %s", jobDef.Name, instance.Status.RegisteredCells[cell.Name]))
+	l.Info("Job hash added ", "job", jobDef.Name, "hash", instance.Status.RegisteredCells[cell.Name])
 
 	return nova.CellMappingReady, nil
 }

--- a/controllers/nova_controller.go
+++ b/controllers/nova_controller.go
@@ -93,7 +93,7 @@ func GetLog(ctx context.Context, controller string) logr.Logger {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.12.2/pkg/reconcile
 func (r *NovaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {
-	l := GetLog(ctx, "nova")
+	log := GetLog(ctx, "nova")
 
 	// Fetch the NovaAPI instance that needs to be reconciled
 	instance := &novav1.Nova{}
@@ -103,11 +103,11 @@ func (r *NovaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 			// Request object not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected.
 			// For additional cleanup logic use finalizers. Return and don't requeue.
-			l.Info("Nova instance not found, probably deleted before reconciled. Nothing to do.")
+			log.Info("Nova instance not found, probably deleted before reconciled. Nothing to do.")
 			return ctrl.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
-		l.Error(err, "Failed to read the Nova instance.")
+		log.Error(err, "Failed to read the Nova instance.")
 		return ctrl.Result{}, err
 	}
 
@@ -116,10 +116,10 @@ func (r *NovaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 		r.Client,
 		r.Kclient,
 		r.Scheme,
-		l,
+		log,
 	)
 	if err != nil {
-		l.Error(err, "Failed to create lib-common Helper")
+		log.Error(err, "Failed to create lib-common Helper")
 		return ctrl.Result{}, err
 	}
 	util.LogForObject(h, "Reconciling", instance)
@@ -1262,7 +1262,7 @@ func (r *NovaReconciler) ensureCellMapped(
 	cellTemplate novav1.NovaCellTemplate,
 	apiDBHostname string,
 ) (nova.CellDeploymentStatus, error) {
-	l := GetLog(ctx, "nova")
+	log := GetLog(ctx, "nova")
 
 	ospSecret, _, err := secret.GetSecret(ctx, h, instance.Spec.Secret, instance.Namespace)
 	if err != nil {
@@ -1391,7 +1391,7 @@ func (r *NovaReconciler) ensureCellMapped(
 	// information to the top level services so that each service can restart
 	// their Pods if a new cell is registered or an existing cell is updated.
 	instance.Status.RegisteredCells[cell.Name] = job.GetHash()
-	l.Info("Job hash added ", "job", jobDef.Name, "hash", instance.Status.RegisteredCells[cell.Name])
+	log.Info("Job hash added ", "job", jobDef.Name, "hash", instance.Status.RegisteredCells[cell.Name])
 
 	return nova.CellMappingReady, nil
 }

--- a/controllers/nova_controller.go
+++ b/controllers/nova_controller.go
@@ -60,9 +60,9 @@ type NovaReconciler struct {
 	ReconcilerBase
 }
 
-// getlog returns a logger object with a prefix of "conroller.name" and aditional controller context fields
-func GetLog(ctx context.Context, controller string) logr.Logger {
-	return log.FromContext(ctx).WithName("Controllers").WithName(controller)
+// getlogger returns a logger object with a prefix of "conroller.name" and aditional controller context fields
+func (r *NovaReconciler) GetLogger(ctx context.Context) logr.Logger {
+	return log.FromContext(ctx).WithName("Controllers").WithName("Nova")
 }
 
 //+kubebuilder:rbac:groups=nova.openstack.org,resources=nova,verbs=get;list;watch;create;update;patch;delete
@@ -93,7 +93,7 @@ func GetLog(ctx context.Context, controller string) logr.Logger {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.12.2/pkg/reconcile
 func (r *NovaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {
-	log := GetLog(ctx, "nova")
+	Log := r.GetLogger(ctx)
 
 	// Fetch the NovaAPI instance that needs to be reconciled
 	instance := &novav1.Nova{}
@@ -103,11 +103,11 @@ func (r *NovaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 			// Request object not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected.
 			// For additional cleanup logic use finalizers. Return and don't requeue.
-			log.Info("Nova instance not found, probably deleted before reconciled. Nothing to do.")
+			Log.Info("Nova instance not found, probably deleted before reconciled. Nothing to do.")
 			return ctrl.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
-		log.Error(err, "Failed to read the Nova instance.")
+		Log.Error(err, "Failed to read the Nova instance.")
 		return ctrl.Result{}, err
 	}
 
@@ -116,10 +116,10 @@ func (r *NovaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 		r.Client,
 		r.Kclient,
 		r.Scheme,
-		log,
+		Log,
 	)
 	if err != nil {
-		log.Error(err, "Failed to create lib-common Helper")
+		Log.Error(err, "Failed to create lib-common Helper")
 		return ctrl.Result{}, err
 	}
 	util.LogForObject(h, "Reconciling", instance)
@@ -1262,7 +1262,7 @@ func (r *NovaReconciler) ensureCellMapped(
 	cellTemplate novav1.NovaCellTemplate,
 	apiDBHostname string,
 ) (nova.CellDeploymentStatus, error) {
-	log := GetLog(ctx, "nova")
+	Log := r.GetLogger(ctx)
 
 	ospSecret, _, err := secret.GetSecret(ctx, h, instance.Spec.Secret, instance.Namespace)
 	if err != nil {
@@ -1391,7 +1391,7 @@ func (r *NovaReconciler) ensureCellMapped(
 	// information to the top level services so that each service can restart
 	// their Pods if a new cell is registered or an existing cell is updated.
 	instance.Status.RegisteredCells[cell.Name] = job.GetHash()
-	log.Info("Job hash added ", "job", jobDef.Name, "hash", instance.Status.RegisteredCells[cell.Name])
+	Log.Info("Job hash added ", "job", jobDef.Name, "hash", instance.Status.RegisteredCells[cell.Name])
 
 	return nova.CellMappingReady, nil
 }

--- a/controllers/novaapi_controller.go
+++ b/controllers/novaapi_controller.go
@@ -75,7 +75,7 @@ type NovaAPIReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.12.2/pkg/reconcile
 func (r *NovaAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {
-	l := GetLog(ctx, "novaapi")
+	log := GetLog(ctx, "novaapi")
 
 	// Fetch the NovaAPI instance that needs to be reconciled
 	instance := &novav1.NovaAPI{}
@@ -85,11 +85,11 @@ func (r *NovaAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 			// Request object not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected.
 			// For additional cleanup logic use finalizers. Return and don't requeue.
-			l.Info("NovaAPI instance not found, probably deleted before reconciled. Nothing to do.")
+			log.Info("NovaAPI instance not found, probably deleted before reconciled. Nothing to do.")
 			return ctrl.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
-		l.Error(err, "Failed to read the NovaAPI instance.")
+		log.Error(err, "Failed to read the NovaAPI instance.")
 		return ctrl.Result{}, err
 	}
 
@@ -98,13 +98,13 @@ func (r *NovaAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		r.Client,
 		r.Kclient,
 		r.Scheme,
-		l,
+		log,
 	)
 	if err != nil {
-		l.Error(err, "Failed to create lib-common Helper")
+		log.Error(err, "Failed to create lib-common Helper")
 		return ctrl.Result{}, err
 	}
-	l.Info("Reconciling")
+	log.Info("Reconciling")
 
 	// initialize status fields
 	if err = r.initStatus(ctx, h, instance); err != nil {
@@ -142,7 +142,7 @@ func (r *NovaAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 	// the our KeystoneEndpoint so that is also deleted.
 	updated := controllerutil.AddFinalizer(instance, h.GetFinalizer())
 	if updated {
-		l.Info("Added finalizer to ourselves")
+		log.Info("Added finalizer to ourselves")
 		// we intentionally return immediately to force the deferred function
 		// to persist the Instance with the finalizer. We need to have our own
 		// finalizer persisted before we try to create the KeystoneEndpoint with
@@ -215,7 +215,7 @@ func (r *NovaAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 
 	// Only expose the service is the deployment succeeded
 	if !instance.Status.Conditions.IsTrue(condition.DeploymentReadyCondition) {
-		l.Info("Waiting for the Deployment to become Ready before exposing the sevice in Keystone")
+		log.Info("Waiting for the Deployment to become Ready before exposing the sevice in Keystone")
 		return ctrl.Result{}, nil
 	}
 
@@ -232,7 +232,7 @@ func (r *NovaAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		return ctrl.Result{}, err
 	}
 
-	l.Info("Successfully reconciled")
+	log.Info("Successfully reconciled")
 	return ctrl.Result{}, nil
 }
 
@@ -325,7 +325,7 @@ func (r *NovaAPIReconciler) ensureConfigs(
 func (r *NovaAPIReconciler) generateConfigs(
 	ctx context.Context, h *helper.Helper, instance *novav1.NovaAPI, hashes *map[string]env.Setter, secret corev1.Secret,
 ) error {
-	l := GetLog(ctx, "novaapi")
+	log := GetLog(ctx, "novaapi")
 
 	apiMessageBusSecret := &corev1.Secret{}
 	secretName := types.NamespacedName{
@@ -334,7 +334,7 @@ func (r *NovaAPIReconciler) generateConfigs(
 	}
 	err := h.GetClient().Get(ctx, secretName, apiMessageBusSecret)
 	if err != nil {
-		l.Info("Failed reading Secret", "APIMessageBusSecretName", instance, " instance.Spec", instance.Spec.APIMessageBusSecretName)
+		log.Info("Failed reading Secret", "APIMessageBusSecretName", instance, " instance.Spec", instance.Spec.APIMessageBusSecretName)
 		return err
 	}
 
@@ -386,12 +386,12 @@ func (r *NovaAPIReconciler) ensureDeployment(
 	inputHash string,
 	annotations map[string]string,
 ) (ctrl.Result, error) {
-	l := GetLog(ctx, "novaapi")
+	log := GetLog(ctx, "novaapi")
 
 	ss := statefulset.NewStatefulSet(novaapi.StatefulSet(instance, inputHash, getAPIServiceLabels(), annotations), r.RequeueTimeout)
 	ctrlResult, err := ss.CreateOrPatch(ctx, h)
 	if err != nil && !k8s_errors.IsNotFound(err) {
-		l.Error(err, "Deployment failed")
+		log.Error(err, "Deployment failed")
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.DeploymentReadyCondition,
 			condition.ErrorReason,
@@ -400,7 +400,7 @@ func (r *NovaAPIReconciler) ensureDeployment(
 			err.Error()))
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{} || k8s_errors.IsNotFound(err)) {
-		l.Info("Deployment in progress")
+		log.Info("Deployment in progress")
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.DeploymentReadyCondition,
 			condition.RequestedReason,
@@ -439,10 +439,10 @@ func (r *NovaAPIReconciler) ensureDeployment(
 	}
 
 	if instance.Status.ReadyCount > 0 {
-		l.Info("Deployment is ready")
+		log.Info("Deployment is ready")
 		instance.Status.Conditions.MarkTrue(condition.DeploymentReadyCondition, condition.DeploymentReadyMessage)
 	} else {
-		l.Info("Deployment is not ready", "Status", ss.GetStatefulSet().Status)
+		log.Info("Deployment is not ready", "Status", ss.GetStatefulSet().Status)
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.DeploymentReadyCondition,
 			condition.RequestedReason,
@@ -551,7 +551,7 @@ func (r *NovaAPIReconciler) ensureKeystoneEndpointDeletion(
 	// Remove the finalizer from our KeystoneEndpoint CR
 	// This is oddly added automatically when we created KeystoneEndpoint but
 	// we need to remove it manually
-	l := GetLog(ctx, "novaapi")
+	log := GetLog(ctx, "novaapi")
 
 	endpoint, err := keystonev1.GetKeystoneEndpointWithName(ctx, h, novaapi.ServiceName, instance.Namespace)
 	if err != nil && !k8s_errors.IsNotFound(err) {
@@ -572,7 +572,7 @@ func (r *NovaAPIReconciler) ensureKeystoneEndpointDeletion(
 	if err = h.GetClient().Update(ctx, endpoint); err != nil && !k8s_errors.IsNotFound(err) {
 		return err
 	}
-	l.Info("Removed finalizer from nova KeystoneEndpoint")
+	log.Info("Removed finalizer from nova KeystoneEndpoint")
 
 	return nil
 }
@@ -582,9 +582,9 @@ func (r *NovaAPIReconciler) reconcileDelete(
 	h *helper.Helper,
 	instance *novav1.NovaAPI,
 ) error {
-	l := GetLog(ctx, "novaapi")
+	log := GetLog(ctx, "novaapi")
 
-	l.Info("Reconciling delete")
+	log.Info("Reconciling delete")
 
 	err := r.ensureKeystoneEndpointDeletion(ctx, h, instance)
 	if err != nil {
@@ -595,10 +595,10 @@ func (r *NovaAPIReconciler) reconcileDelete(
 	// finalizer from ourselves to allow the deletion of NovaAPI CR itself
 	updated := controllerutil.RemoveFinalizer(instance, h.GetFinalizer())
 	if updated {
-		l.Info("Removed finalizer from ourselves")
+		log.Info("Removed finalizer from ourselves")
 	}
 
-	l.Info("Reconciled delete successfully")
+	log.Info("Reconciled delete successfully")
 	return nil
 }
 

--- a/controllers/novaapi_controller.go
+++ b/controllers/novaapi_controller.go
@@ -26,7 +26,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	routev1 "github.com/openshift/api/route/v1"
@@ -76,7 +75,7 @@ type NovaAPIReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.12.2/pkg/reconcile
 func (r *NovaAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {
-	l := log.FromContext(ctx)
+	l := GetLog(ctx, "novaapi")
 
 	// Fetch the NovaAPI instance that needs to be reconciled
 	instance := &novav1.NovaAPI{}
@@ -99,13 +98,13 @@ func (r *NovaAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		r.Client,
 		r.Kclient,
 		r.Scheme,
-		r.Log,
+		l,
 	)
 	if err != nil {
 		l.Error(err, "Failed to create lib-common Helper")
 		return ctrl.Result{}, err
 	}
-	util.LogForObject(h, "Reconciling", instance)
+	l.Info("Reconciling")
 
 	// initialize status fields
 	if err = r.initStatus(ctx, h, instance); err != nil {
@@ -143,7 +142,7 @@ func (r *NovaAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 	// the our KeystoneEndpoint so that is also deleted.
 	updated := controllerutil.AddFinalizer(instance, h.GetFinalizer())
 	if updated {
-		util.LogForObject(h, "Added finalizer to ourselves", instance)
+		l.Info("Added finalizer to ourselves")
 		// we intentionally return immediately to force the deferred function
 		// to persist the Instance with the finalizer. We need to have our own
 		// finalizer persisted before we try to create the KeystoneEndpoint with
@@ -216,7 +215,7 @@ func (r *NovaAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 
 	// Only expose the service is the deployment succeeded
 	if !instance.Status.Conditions.IsTrue(condition.DeploymentReadyCondition) {
-		util.LogForObject(h, "Waiting for the Deployment to become Ready before exposing the sevice in Keystone", instance)
+		l("Waiting for the Deployment to become Ready before exposing the sevice in Keystone")
 		return ctrl.Result{}, nil
 	}
 
@@ -233,7 +232,7 @@ func (r *NovaAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		return ctrl.Result{}, err
 	}
 
-	util.LogForObject(h, "Successfully reconciled", instance)
+	l.Info("Successfully reconciled")
 	return ctrl.Result{}, nil
 }
 
@@ -326,6 +325,7 @@ func (r *NovaAPIReconciler) ensureConfigs(
 func (r *NovaAPIReconciler) generateConfigs(
 	ctx context.Context, h *helper.Helper, instance *novav1.NovaAPI, hashes *map[string]env.Setter, secret corev1.Secret,
 ) error {
+	l := GetLog(ctx, "novaapi")
 
 	apiMessageBusSecret := &corev1.Secret{}
 	secretName := types.NamespacedName{
@@ -334,9 +334,7 @@ func (r *NovaAPIReconciler) generateConfigs(
 	}
 	err := h.GetClient().Get(ctx, secretName, apiMessageBusSecret)
 	if err != nil {
-		util.LogForObject(
-			h, "Failed reading Secret", instance,
-			"APIMessageBusSecretName", instance.Spec.APIMessageBusSecretName)
+		l.Info("Failed reading Secret", "APIMessageBusSecretName", instance, " instance.Spec", instance.Spec.APIMessageBusSecretName)
 		return err
 	}
 
@@ -388,10 +386,12 @@ func (r *NovaAPIReconciler) ensureDeployment(
 	inputHash string,
 	annotations map[string]string,
 ) (ctrl.Result, error) {
+	l := GetLog(ctx, "novaapi")
+
 	ss := statefulset.NewStatefulSet(novaapi.StatefulSet(instance, inputHash, getAPIServiceLabels(), annotations), r.RequeueTimeout)
 	ctrlResult, err := ss.CreateOrPatch(ctx, h)
 	if err != nil && !k8s_errors.IsNotFound(err) {
-		util.LogErrorForObject(h, err, "Deployment failed", instance)
+		l.Error(err, "Deployment failed", "instance", instance)
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.DeploymentReadyCondition,
 			condition.ErrorReason,
@@ -400,7 +400,7 @@ func (r *NovaAPIReconciler) ensureDeployment(
 			err.Error()))
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{} || k8s_errors.IsNotFound(err)) {
-		util.LogForObject(h, "Deployment in progress", instance)
+		l.Info("Deployment in progress", "instance", instance)
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.DeploymentReadyCondition,
 			condition.RequestedReason,
@@ -439,10 +439,10 @@ func (r *NovaAPIReconciler) ensureDeployment(
 	}
 
 	if instance.Status.ReadyCount > 0 {
-		util.LogForObject(h, "Deployment is ready", instance)
+		l.Info("Deployment is ready", "instance", instance)
 		instance.Status.Conditions.MarkTrue(condition.DeploymentReadyCondition, condition.DeploymentReadyMessage)
 	} else {
-		util.LogForObject(h, "Deployment is not ready", instance, "Status", ss.GetStatefulSet().Status)
+		l.Info("Deployment is not ready", "instance", instance, "Status", ss.GetStatefulSet().Status)
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.DeploymentReadyCondition,
 			condition.RequestedReason,
@@ -551,6 +551,8 @@ func (r *NovaAPIReconciler) ensureKeystoneEndpointDeletion(
 	// Remove the finalizer from our KeystoneEndpoint CR
 	// This is oddly added automatically when we created KeystoneEndpoint but
 	// we need to remove it manually
+	l := GetLog(ctx, "novaapi")
+
 	endpoint, err := keystonev1.GetKeystoneEndpointWithName(ctx, h, novaapi.ServiceName, instance.Namespace)
 	if err != nil && !k8s_errors.IsNotFound(err) {
 		return err
@@ -570,7 +572,7 @@ func (r *NovaAPIReconciler) ensureKeystoneEndpointDeletion(
 	if err = h.GetClient().Update(ctx, endpoint); err != nil && !k8s_errors.IsNotFound(err) {
 		return err
 	}
-	util.LogForObject(h, "Removed finalizer from nova KeystoneEndpoint", instance)
+	l.Info("Removed finalizer from nova KeystoneEndpoint", "instance", instance)
 
 	return nil
 }
@@ -580,7 +582,9 @@ func (r *NovaAPIReconciler) reconcileDelete(
 	h *helper.Helper,
 	instance *novav1.NovaAPI,
 ) error {
-	util.LogForObject(h, "Reconciling delete", instance)
+	l := GetLog(ctx, "novaapi")
+
+	l.Info("Reconciling delete", "instance", instance)
 
 	err := r.ensureKeystoneEndpointDeletion(ctx, h, instance)
 	if err != nil {
@@ -591,10 +595,10 @@ func (r *NovaAPIReconciler) reconcileDelete(
 	// finalizer from ourselves to allow the deletion of NovaAPI CR itself
 	updated := controllerutil.RemoveFinalizer(instance, h.GetFinalizer())
 	if updated {
-		util.LogForObject(h, "Removed finalizer from ourselves", instance)
+		l.Info("Removed finalizer from ourselves", "instance", instance)
 	}
 
-	util.LogForObject(h, "Reconciled delete successfully", instance)
+	l.Info("Reconciled delete successfully", "instance", instance)
 	return nil
 }
 

--- a/controllers/novacell_controller.go
+++ b/controllers/novacell_controller.go
@@ -86,7 +86,7 @@ func (r *NovaCellReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 		l.Error(err, "Failed to create lib-common Helper")
 		return ctrl.Result{}, err
 	}
-	l.Info("Reconciling", "instance", instance)
+	l.Info("Reconciling")
 
 	// initialize status fields
 	if err = r.initStatus(ctx, h, instance); err != nil {
@@ -181,7 +181,7 @@ func (r *NovaCellReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 	// However NovaNoVNCProxy is never deployed in cell0, and optional in other
 	// cells too.
 	if cellHasVNCService && !instance.Status.Conditions.IsTrue(novav1.NovaNoVNCProxyReadyCondition) {
-		l.Info("Waiting for the NovaNoVNCProxyService to become Ready before generating the compute config", "instance", instance)
+		l.Info("Waiting for the NovaNoVNCProxyService to become Ready before generating the compute config")
 		return ctrl.Result{}, nil
 	}
 
@@ -203,7 +203,7 @@ func (r *NovaCellReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 		instance.Status.Conditions.Remove(novav1.NovaComputeServiceConfigReady)
 	}
 
-	l.Info("Successfully reconciled", "instance", instance)
+	l.Info("Successfully reconciled")
 	return ctrl.Result{}, nil
 }
 
@@ -301,7 +301,7 @@ func (r *NovaCellReconciler) ensureConductor(
 	}
 
 	if op != controllerutil.OperationResultNone {
-		l.Info("", "NovaConductor", string(op), "instance", instance, "NovaConductor.Name", conductor.Name)
+		l.Info(fmt.Sprintf("NovaConductor %s.", string(op)))
 	}
 
 	instance.Status.ConductorServiceReadyCount = conductor.Status.ReadyCount
@@ -356,7 +356,7 @@ func (r *NovaCellReconciler) ensureNoVNCProxy(
 	}
 
 	if op != controllerutil.OperationResultNone {
-		l.Info("", "NovaNoVNCProxy", string(op), "instance", instance, "NovaNoVNCProxy.Name", novncproxy.Name)
+		l.Info(fmt.Sprintf("NovaNoVNCProxy %s.", string(op)))
 	}
 
 	instance.Status.NoVNCPRoxyServiceReadyCount = novncproxy.Status.ReadyCount
@@ -410,7 +410,7 @@ func (r *NovaCellReconciler) ensureMetadata(
 	}
 
 	if op != controllerutil.OperationResultNone {
-		l.Info("", "NovaMetadata", string(op), "instance", instance, "NovaMetadata.Name", metadata.Name)
+		l.Info(fmt.Sprintf("NovaMetadata %s.", string(op)))
 	}
 
 	instance.Status.MetadataServiceReadyCount = metadata.Status.ReadyCount

--- a/controllers/novaconductor_controller.go
+++ b/controllers/novaconductor_controller.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	common "github.com/openstack-k8s-operators/lib-common/modules/common"
@@ -67,7 +66,7 @@ type NovaConductorReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.12.2/pkg/reconcile
 func (r *NovaConductorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {
-	l := log.FromContext(ctx)
+	l := GetLog(ctx, "novaconductor")
 
 	// Fetch our instance that needs to be reconciled
 	instance := &novav1.NovaConductor{}
@@ -90,13 +89,13 @@ func (r *NovaConductorReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		r.Client,
 		r.Kclient,
 		r.Scheme,
-		r.Log,
+		l,
 	)
 	if err != nil {
 		l.Error(err, "Failed to create lib-common Helper")
 		return ctrl.Result{}, err
 	}
-	util.LogForObject(h, "Reconciling", instance)
+	l.Info("Reconciling", "instance", instance)
 
 	// initialize status fields
 	if err = r.initStatus(ctx, h, instance); err != nil {
@@ -186,7 +185,7 @@ func (r *NovaConductorReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return result, err
 	}
 
-	util.LogForObject(h, "Successfully reconciled", instance)
+	l.Info("Successfully reconciled", "instance", instance)
 	return ctrl.Result{}, nil
 }
 
@@ -278,6 +277,8 @@ func (r *NovaConductorReconciler) generateConfigs(
 	hashes *map[string]env.Setter,
 	secret corev1.Secret,
 ) error {
+	l := GetLog(ctx, "novaconductor")
+
 	messageBusSecret := &corev1.Secret{}
 	secretName := types.NamespacedName{
 		Namespace: instance.Namespace,
@@ -285,8 +286,7 @@ func (r *NovaConductorReconciler) generateConfigs(
 	}
 	err := h.GetClient().Get(ctx, secretName, messageBusSecret)
 	if err != nil {
-		util.LogForObject(
-			h, "Failed reading Secret", instance,
+		l.Info("Failed reading Secret", "instance", instance,
 			"CellMessageBusSecretName", instance.Spec.CellMessageBusSecretName)
 		return err
 	}
@@ -364,7 +364,7 @@ func (r *NovaConductorReconciler) ensureCellDBSynced(
 	}
 	if dbSyncJob.HasChanged() {
 		instance.Status.Hash[DbSyncHash] = dbSyncJob.GetHash()
-		r.Log.Info(fmt.Sprintf("Job %s hash added - %s", jobDef.Name, instance.Status.Hash[DbSyncHash]))
+		l.Info("Job" , jobDef.Name, "hash added", instance.Status.Hash[DbSyncHash]))
 	}
 	instance.Status.Conditions.MarkTrue(condition.DBSyncReadyCondition, condition.DBSyncReadyMessage)
 
@@ -386,7 +386,7 @@ func (r *NovaConductorReconciler) ensureDeployment(
 	ss := statefulset.NewStatefulSet(novaconductor.StatefulSet(instance, inputHash, serviceLabels, annotations), r.RequeueTimeout)
 	ctrlResult, err := ss.CreateOrPatch(ctx, h)
 	if err != nil && !k8s_errors.IsNotFound(err) {
-		util.LogErrorForObject(h, err, "Deployment failed", instance)
+		l.Info(err, "Deployment failed","instance", instance)
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.DeploymentReadyCondition,
 			condition.ErrorReason,
@@ -395,7 +395,7 @@ func (r *NovaConductorReconciler) ensureDeployment(
 			err.Error()))
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{} || k8s_errors.IsNotFound(err)) {
-		util.LogForObject(h, "Deployment in progress", instance)
+		l.Info("Deployment in progress","instance", instance)
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.DeploymentReadyCondition,
 			condition.RequestedReason,
@@ -434,13 +434,13 @@ func (r *NovaConductorReconciler) ensureDeployment(
 	}
 
 	if instance.Status.ReadyCount > 0 {
-		util.LogForObject(h, "Deployment is ready", instance)
+		l.Info("Deployment is ready","instance" ,instance)
 		instance.Status.Conditions.MarkTrue(condition.DeploymentReadyCondition, condition.DeploymentReadyMessage)
 	} else if *instance.Spec.Replicas == 0 {
-		util.LogForObject(h, "Deployment with 0 replicas is ready", instance)
+		l.Info("Deployment with 0 replicas is ready", "instance",instance)
 		instance.Status.Conditions.MarkTrue(condition.DeploymentReadyCondition, condition.DeploymentReadyMessage)
 	} else {
-		util.LogForObject(h, "Deployment is not ready", instance, "Status", ss.GetStatefulSet().Status)
+		l.Info("Deployment is not ready","instance", instance, "Status", ss.GetStatefulSet().Status)
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.DeploymentReadyCondition,
 			condition.RequestedReason,

--- a/controllers/novaconductor_controller.go
+++ b/controllers/novaconductor_controller.go
@@ -95,7 +95,7 @@ func (r *NovaConductorReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		l.Error(err, "Failed to create lib-common Helper")
 		return ctrl.Result{}, err
 	}
-	l.Info("Reconciling", "instance", instance)
+	l.Info("Reconciling",)
 
 	// initialize status fields
 	if err = r.initStatus(ctx, h, instance); err != nil {
@@ -185,7 +185,7 @@ func (r *NovaConductorReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return result, err
 	}
 
-	l.Info("Successfully reconciled", "instance", instance)
+	l.Info("Successfully reconciled")
 	return ctrl.Result{}, nil
 }
 
@@ -286,8 +286,7 @@ func (r *NovaConductorReconciler) generateConfigs(
 	}
 	err := h.GetClient().Get(ctx, secretName, messageBusSecret)
 	if err != nil {
-		l.Info("Failed reading Secret", "instance", instance,
-			"CellMessageBusSecretName", instance.Spec.CellMessageBusSecretName)
+		l.Info("Failed reading Secret","CellMessageBusSecretName", instance.Spec.CellMessageBusSecretName)
 		return err
 	}
 

--- a/controllers/novascheduler_controller.go
+++ b/controllers/novascheduler_controller.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	common "github.com/openstack-k8s-operators/lib-common/modules/common"
@@ -67,7 +66,7 @@ type NovaSchedulerReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.12.2/pkg/reconcile
 func (r *NovaSchedulerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {
-	l := log.FromContext(ctx)
+	l := GetLog(ctx, "novascheduler")
 
 	// Fetch the NovaScheduler instance that needs to be reconciled
 	instance := &novav1.NovaScheduler{}
@@ -90,13 +89,13 @@ func (r *NovaSchedulerReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		r.Client,
 		r.Kclient,
 		r.Scheme,
-		r.Log,
+		l,
 	)
 	if err != nil {
 		l.Error(err, "Failed to create lib-common Helper")
 		return ctrl.Result{}, err
 	}
-	util.LogForObject(h, "Reconciling", instance)
+	l.Info("Reconciling", "instance", instance)
 
 	// initialize status fields
 	if err = r.initStatus(ctx, h, instance); err != nil {
@@ -282,6 +281,7 @@ func (r *NovaSchedulerReconciler) generateConfigs(
 	ctx context.Context, h *helper.Helper, instance *novav1.NovaScheduler, hashes *map[string]env.Setter,
 	secret corev1.Secret,
 ) error {
+	l := GetLog(ctx, "novascheduler")
 
 	apiMessageBusSecret := &corev1.Secret{}
 	secretName := types.NamespacedName{
@@ -290,8 +290,7 @@ func (r *NovaSchedulerReconciler) generateConfigs(
 	}
 	err := h.GetClient().Get(ctx, secretName, apiMessageBusSecret)
 	if err != nil {
-		util.LogForObject(
-			h, "Failed reading Secret", instance,
+		l.Info("Failed reading Secret", "instance", instance,
 			"APIMessageBusSecretName", instance.Spec.APIMessageBusSecretName)
 		return err
 	}
@@ -345,12 +344,12 @@ func (r *NovaSchedulerReconciler) ensureDeployment(
 	serviceLabels := map[string]string{
 		common.AppSelector: NovaSchedulerLabelPrefix,
 	}
-
+	l := GetLog(ctx, "novascheduler")
 	ss := statefulset.NewStatefulSet(novascheduler.StatefulSet(instance, inputHash, serviceLabels, annotations), r.RequeueTimeout)
 
 	ctrlResult, err := ss.CreateOrPatch(ctx, h)
 	if err != nil && !k8s_errors.IsNotFound(err) {
-		util.LogErrorForObject(h, err, "Deployment failed", instance)
+		l.Error(err, "Deployment failed", "instance", instance)
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.DeploymentReadyCondition,
 			condition.ErrorReason,
@@ -359,7 +358,7 @@ func (r *NovaSchedulerReconciler) ensureDeployment(
 			err.Error()))
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{} || k8s_errors.IsNotFound(err)) {
-		util.LogForObject(h, "Deployment in progress", instance)
+		l.Info("in progress", "instance", instance)
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.DeploymentReadyCondition,
 			condition.RequestedReason,
@@ -398,10 +397,10 @@ func (r *NovaSchedulerReconciler) ensureDeployment(
 	}
 
 	if instance.Status.ReadyCount > 0 {
-		util.LogForObject(h, "Deployment is ready", instance)
+		l.Info("Deployment is ready", instance)
 		instance.Status.Conditions.MarkTrue(condition.DeploymentReadyCondition, condition.DeploymentReadyMessage)
 	} else {
-		util.LogForObject(h, "Deployment is not ready", instance, "Status", ss.GetStatefulSet().Status)
+		l.Info("Deployment is not ready", "instance", instance, "Status", ss.GetStatefulSet().Status)
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.DeploymentReadyCondition,
 			condition.RequestedReason,


### PR DESCRIPTION
This automatically adds additional fields like reconcile_id etc.. from the controller context.

before :

`2023-05-18T01:53:14+03:00 INFO  controllers.KeystoneAPI Reconciled Service init successfully`

after:

`2023-05-18T02:00:28+03:00       INFO    Controllers.KeystoneAPI Reconciled Service init successfully    {"controller": "keystoneapi", "controllerGroup": "keystone.openstack.org", "controllerKind":"KeystoneAPI", "KeystoneAPI": {"name":"keystone","namespace":"openstack"}, "namespace": "openstack", "name": "keystone", "reconcileID": "512a4d9b-f31d-4fa4-a4cc-cd6c13e4455d"}
`

*by using per reconcile function respective logger objects, the intention is to lay the ground for parallel reconciliation in future and avoid race conditions as ctx objects are reconcile run specific.

*example logs lines  are currently from keystone operator [#220_patch](https://github.com/openstack-k8s-operators/keystone-operator/pull/220) until this operator deployment patch testing  is is done


