### PR TITLE
Import nova api as novav1

### DIFF
--- a/controllers/novametadata_controller.go
+++ b/controllers/novametadata_controller.go
@@ -40,7 +40,6 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/statefulset"
 	util "github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	novav1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
-	novav1beta1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/nova-operator/pkg/nova"
 	"github.com/openstack-k8s-operators/nova-operator/pkg/novametadata"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
@@ -74,7 +73,7 @@ func (r *NovaMetadataReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	l := log.FromContext(ctx)
 
 	// Fetch the NovaMetadata instance that needs to be reconciled
-	instance := &novav1beta1.NovaMetadata{}
+	instance := &novav1.NovaMetadata{}
 	err := r.Client.Get(ctx, req.NamespacedName, instance)
 
 	if err != nil {
@@ -204,7 +203,7 @@ func (r *NovaMetadataReconciler) Reconcile(ctx context.Context, req ctrl.Request
 }
 
 func (r *NovaMetadataReconciler) initStatus(
-	ctx context.Context, h *helper.Helper, instance *novav1beta1.NovaMetadata,
+	ctx context.Context, h *helper.Helper, instance *novav1.NovaMetadata,
 ) error {
 	if err := r.initConditions(ctx, h, instance); err != nil {
 		return err
@@ -221,7 +220,7 @@ func (r *NovaMetadataReconciler) initStatus(
 }
 
 func (r *NovaMetadataReconciler) initConditions(
-	ctx context.Context, h *helper.Helper, instance *novav1beta1.NovaMetadata,
+	ctx context.Context, h *helper.Helper, instance *novav1.NovaMetadata,
 ) error {
 	if instance.Status.Conditions == nil {
 		instance.Status.Conditions = condition.Conditions{}
@@ -265,7 +264,7 @@ func (r *NovaMetadataReconciler) initConditions(
 func (r *NovaMetadataReconciler) ensureConfigs(
 	ctx context.Context,
 	h *helper.Helper,
-	instance *novav1beta1.NovaMetadata,
+	instance *novav1.NovaMetadata,
 	hashes *map[string]env.Setter,
 	secret corev1.Secret,
 ) error {
@@ -283,7 +282,7 @@ func (r *NovaMetadataReconciler) ensureConfigs(
 }
 
 func (r *NovaMetadataReconciler) generateConfigs(
-	ctx context.Context, h *helper.Helper, instance *novav1beta1.NovaMetadata, hashes *map[string]env.Setter,
+	ctx context.Context, h *helper.Helper, instance *novav1.NovaMetadata, hashes *map[string]env.Setter,
 	secret corev1.Secret,
 ) error {
 
@@ -346,7 +345,7 @@ func (r *NovaMetadataReconciler) generateConfigs(
 func (r *NovaMetadataReconciler) ensureDeployment(
 	ctx context.Context,
 	h *helper.Helper,
-	instance *novav1beta1.NovaMetadata,
+	instance *novav1.NovaMetadata,
 	inputHash string,
 	annotations map[string]string,
 ) (ctrl.Result, error) {
@@ -420,7 +419,7 @@ func (r *NovaMetadataReconciler) ensureDeployment(
 func (r *NovaMetadataReconciler) ensureServiceExposed(
 	ctx context.Context,
 	h *helper.Helper,
-	instance *novav1beta1.NovaMetadata,
+	instance *novav1.NovaMetadata,
 ) (ctrl.Result, error) {
 	var ports = map[endpoint.Endpoint]endpoint.Data{
 		endpoint.EndpointInternal: {Port: novametadata.APIServicePort},
@@ -479,7 +478,7 @@ func (r *NovaMetadataReconciler) ensureServiceExposed(
 func (r *NovaMetadataReconciler) reconcileDelete(
 	ctx context.Context,
 	h *helper.Helper,
-	instance *novav1beta1.NovaMetadata,
+	instance *novav1.NovaMetadata,
 ) error {
 	util.LogForObject(h, "Reconciling delete", instance)
 	// TODO(ksambor): add cleanup for the service rows in the nova DB
@@ -503,7 +502,7 @@ func getMetadataServiceLabels(cell string) map[string]string {
 // SetupWithManager sets up the controller with the Manager.
 func (r *NovaMetadataReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&novav1beta1.NovaMetadata{}).
+		For(&novav1.NovaMetadata{}).
 		Owns(&v1.StatefulSet{}).
 		Owns(&corev1.Service{}).
 		Owns(&routev1.Route{}).

--- a/controllers/novanovncproxy_controller.go
+++ b/controllers/novanovncproxy_controller.go
@@ -38,7 +38,7 @@ import (
 	nad "github.com/openstack-k8s-operators/lib-common/modules/common/networkattachment"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/statefulset"
 	util "github.com/openstack-k8s-operators/lib-common/modules/common/util"
-	novav1beta1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
+	novav1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/nova-operator/pkg/nova"
 	"github.com/openstack-k8s-operators/nova-operator/pkg/novncproxy"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
@@ -73,7 +73,7 @@ func (r *NovaNoVNCProxyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	l := log.FromContext(ctx)
 
 	// Fetch the NovaNoVNCProxy instance that needs to be reconciled
-	instance := &novav1beta1.NovaNoVNCProxy{}
+	instance := &novav1.NovaNoVNCProxy{}
 	err := r.Client.Get(ctx, req.NamespacedName, instance)
 
 	if err != nil {
@@ -192,7 +192,7 @@ func (r *NovaNoVNCProxyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 }
 
 func (r *NovaNoVNCProxyReconciler) initStatus(
-	ctx context.Context, h *helper.Helper, instance *novav1beta1.NovaNoVNCProxy,
+	ctx context.Context, h *helper.Helper, instance *novav1.NovaNoVNCProxy,
 ) error {
 	if err := r.initConditions(ctx, h, instance); err != nil {
 		return err
@@ -212,7 +212,7 @@ func (r *NovaNoVNCProxyReconciler) initStatus(
 func (r *NovaNoVNCProxyReconciler) ensureConfigs(
 	ctx context.Context,
 	h *helper.Helper,
-	instance *novav1beta1.NovaNoVNCProxy,
+	instance *novav1.NovaNoVNCProxy,
 	hashes *map[string]env.Setter,
 	apiEndpoints map[string]string,
 	secret corev1.Secret,
@@ -231,7 +231,7 @@ func (r *NovaNoVNCProxyReconciler) ensureConfigs(
 }
 
 func (r *NovaNoVNCProxyReconciler) initConditions(
-	ctx context.Context, h *helper.Helper, instance *novav1beta1.NovaNoVNCProxy,
+	ctx context.Context, h *helper.Helper, instance *novav1.NovaNoVNCProxy,
 ) error {
 	if instance.Status.Conditions == nil {
 		instance.Status.Conditions = condition.Conditions{}
@@ -273,7 +273,7 @@ func (r *NovaNoVNCProxyReconciler) initConditions(
 }
 
 func (r *NovaNoVNCProxyReconciler) generateConfigs(
-	ctx context.Context, h *helper.Helper, instance *novav1beta1.NovaNoVNCProxy, hashes *map[string]env.Setter,
+	ctx context.Context, h *helper.Helper, instance *novav1.NovaNoVNCProxy, hashes *map[string]env.Setter,
 	apiEndpoints map[string]string,
 	secret corev1.Secret,
 ) error {
@@ -332,7 +332,7 @@ func (r *NovaNoVNCProxyReconciler) generateConfigs(
 func (r *NovaNoVNCProxyReconciler) ensureDeployment(
 	ctx context.Context,
 	h *helper.Helper,
-	instance *novav1beta1.NovaNoVNCProxy,
+	instance *novav1.NovaNoVNCProxy,
 	inputHash string,
 	annotations map[string]string,
 ) (ctrl.Result, error) {
@@ -407,7 +407,7 @@ func (r *NovaNoVNCProxyReconciler) ensureDeployment(
 func (r *NovaNoVNCProxyReconciler) ensureServiceExposed(
 	ctx context.Context,
 	h *helper.Helper,
-	instance *novav1beta1.NovaNoVNCProxy,
+	instance *novav1.NovaNoVNCProxy,
 ) (map[string]string, ctrl.Result, error) {
 	var ports = map[endpoint.Endpoint]endpoint.Data{
 		endpoint.EndpointPublic:   {Port: novncproxy.NoVNCProxyPort},
@@ -464,7 +464,7 @@ func (r *NovaNoVNCProxyReconciler) ensureServiceExposed(
 func (r *NovaNoVNCProxyReconciler) reconcileDelete(
 	ctx context.Context,
 	h *helper.Helper,
-	instance *novav1beta1.NovaNoVNCProxy,
+	instance *novav1.NovaNoVNCProxy,
 ) error {
 	util.LogForObject(h, "Reconciling delete", instance)
 	// TODO(ksambor): add cleanups
@@ -482,12 +482,12 @@ func getNoVNCProxyServiceLabels(cell string) map[string]string {
 // SetupWithManager sets up the controller with the Manager.
 func (r *NovaNoVNCProxyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&novav1beta1.NovaNoVNCProxy{}).
+		For(&novav1.NovaNoVNCProxy{}).
 		Owns(&v1.StatefulSet{}).
 		Owns(&corev1.Service{}).
 		Owns(&routev1.Route{}).
 		Owns(&corev1.Secret{}).
 		Watches(&source.Kind{Type: &corev1.Secret{}},
-			handler.EnqueueRequestsFromMapFunc(r.GetSecretMapperFor(&novav1beta1.NovaNoVNCProxyList{}))).
+			handler.EnqueueRequestsFromMapFunc(r.GetSecretMapperFor(&novav1.NovaNoVNCProxyList{}))).
 		Complete(r)
 }

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ import (
 	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
 	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 
-	novav1beta1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
+	novav1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
 
 	"github.com/openstack-k8s-operators/nova-operator/controllers"
 	//+kubebuilder:scaffold:imports
@@ -58,7 +58,7 @@ var (
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(novav1beta1.AddToScheme(scheme))
+	utilruntime.Must(novav1.AddToScheme(scheme))
 	utilruntime.Must(mariadbv1.AddToScheme(scheme))
 	utilruntime.Must(keystonev1.AddToScheme(scheme))
 	utilruntime.Must(corev1.AddToScheme(scheme))
@@ -130,36 +130,36 @@ func main() {
 	}
 
 	// Acquire environmental defaults and initialize operator defaults with them
-	novav1beta1.SetupDefaults()
+	novav1.SetupDefaults()
 
 	checker := healthz.Ping
 	// Setup webhooks if requested
 	if strings.ToLower(os.Getenv("ENABLE_WEBHOOKS")) != "false" {
-		if err = (&novav1beta1.Nova{}).SetupWebhookWithManager(mgr); err != nil {
+		if err = (&novav1.Nova{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "Nova")
 			os.Exit(1)
 		}
-		if err = (&novav1beta1.NovaAPI{}).SetupWebhookWithManager(mgr); err != nil {
+		if err = (&novav1.NovaAPI{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "NovaAPI")
 			os.Exit(1)
 		}
-		if err = (&novav1beta1.NovaCell{}).SetupWebhookWithManager(mgr); err != nil {
+		if err = (&novav1.NovaCell{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "NovaCell")
 			os.Exit(1)
 		}
-		if err = (&novav1beta1.NovaConductor{}).SetupWebhookWithManager(mgr); err != nil {
+		if err = (&novav1.NovaConductor{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "NovaConductor")
 			os.Exit(1)
 		}
-		if err = (&novav1beta1.NovaMetadata{}).SetupWebhookWithManager(mgr); err != nil {
+		if err = (&novav1.NovaMetadata{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "NovaMetadata")
 			os.Exit(1)
 		}
-		if err = (&novav1beta1.NovaNoVNCProxy{}).SetupWebhookWithManager(mgr); err != nil {
+		if err = (&novav1.NovaNoVNCProxy{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "NovaNoVNCProxy")
 			os.Exit(1)
 		}
-		if err = (&novav1beta1.NovaScheduler{}).SetupWebhookWithManager(mgr); err != nil {
+		if err = (&novav1.NovaScheduler{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "NovaScheduler")
 			os.Exit(1)
 		}


### PR DESCRIPTION
Most of our files import nova api as novav1 but some used the novav1beta1 name. This PR now normalized that.