### PR TITLE
Fix missing condition update

### DIFF
--- a/controllers/nova_controller.go
+++ b/controllers/nova_controller.go
@@ -855,13 +855,12 @@ func (r *NovaReconciler) ensureAPI(
 	})
 
 	if err != nil {
-		condition.FalseCondition(
+		instance.Status.Conditions.Set(condition.FalseCondition(
 			novav1.NovaAPIReadyCondition,
 			condition.ErrorReason,
 			condition.SeverityError,
 			novav1.NovaAPIReadyErrorMessage,
-			err.Error(),
-		)
+			err.Error()))
 		return ctrl.Result{}, err
 	}
 
@@ -931,13 +930,12 @@ func (r *NovaReconciler) ensureScheduler(
 	})
 
 	if err != nil {
-		condition.FalseCondition(
+		instance.Status.Conditions.Set(condition.FalseCondition(
 			novav1.NovaSchedulerReadyCondition,
 			condition.ErrorReason,
 			condition.SeverityError,
 			novav1.NovaSchedulerReadyErrorMessage,
-			err.Error(),
-		)
+			err.Error()))
 		return ctrl.Result{}, err
 	}
 
@@ -1218,13 +1216,12 @@ func (r *NovaReconciler) ensureMetadata(
 	})
 
 	if err != nil {
-		condition.FalseCondition(
+		instance.Status.Conditions.Set(condition.FalseCondition(
 			novav1.NovaMetadataReadyCondition,
 			condition.ErrorReason,
 			condition.SeverityError,
 			novav1.NovaMetadataReadyErrorMessage,
-			err.Error(),
-		)
+			err.Error()))
 		return ctrl.Result{}, err
 	}
 

--- a/controllers/novacell_controller.go
+++ b/controllers/novacell_controller.go
@@ -294,13 +294,12 @@ func (r *NovaCellReconciler) ensureConductor(
 	})
 
 	if err != nil {
-		condition.FalseCondition(
+		instance.Status.Conditions.Set(condition.FalseCondition(
 			novav1.NovaConductorReadyCondition,
 			condition.ErrorReason,
 			condition.SeverityError,
 			novav1.NovaConductorReadyErrorMessage,
-			err.Error(),
-		)
+			err.Error()))
 		return ctrl.Result{}, err
 	}
 
@@ -347,13 +346,12 @@ func (r *NovaCellReconciler) ensureNoVNCProxy(
 	})
 
 	if err != nil {
-		condition.FalseCondition(
+		instance.Status.Conditions.Set(condition.FalseCondition(
 			novav1.NovaNoVNCProxyReadyCondition,
 			condition.ErrorReason,
 			condition.SeverityError,
 			novav1.NovaNoVNCProxyReadyErrorMessage,
-			err.Error(),
-		)
+			err.Error()))
 		return ctrl.Result{}, err
 	}
 
@@ -399,13 +397,12 @@ func (r *NovaCellReconciler) ensureMetadata(
 	})
 
 	if err != nil {
-		condition.FalseCondition(
+		instance.Status.Conditions.Set(condition.FalseCondition(
 			novav1.NovaMetadataReadyCondition,
 			condition.ErrorReason,
 			condition.SeverityError,
 			novav1.NovaMetadataReadyErrorMessage,
-			err.Error(),
-		)
+			err.Error()))
 		return ctrl.Result{}, err
 	}
 


### PR DESCRIPTION
In multiple places if createOrPatch on a sub CR fails the error is not propagated to the higher level CR (Nova or NovaCell) as the call `condition.FalseCondition` only generates a condition locally but without its result passed to `instance.Status.Conditions.Set` the instance Status is not update.

These places are hard to test in envtest as it would require to break the running kube-apiserver to generate an error at that point. So they slip through.

Now this is fixed based on grepping for
  `grep -P '^\t*condition.FalseCondition' -R`