### PR TITLE
[validation]Reject metadata both in cell and on top

### DIFF
--- a/api/v1beta1/nova_webhook.go
+++ b/api/v1beta1/nova_webhook.go
@@ -150,6 +150,19 @@ func (r *NovaSpec) ValidateCellTemplates(basePath *field.Path) field.ErrorList {
 			errors,
 			ValidateCellName(cellPath, name)...,
 		)
+
+		if *cell.MetadataServiceTemplate.Enabled && *r.MetadataServiceTemplate.Enabled {
+			errors = append(
+				errors,
+				field.Invalid(
+					cellPath.Child("metadataServiceTemplate").Child("enabled"),
+					*cell.MetadataServiceTemplate.Enabled,
+					"should be false as metadata is enabled on the top level too. "+
+						"The metadata service can be either enabled on top "+
+						"or in the cells but not in both places at the same time."),
+			)
+		}
+
 		if name == Cell0Name {
 			errors = append(
 				errors,

--- a/config/samples/nova_v1beta1_nova-multi-cell.yaml
+++ b/config/samples/nova_v1beta1_nova-multi-cell.yaml
@@ -70,10 +70,6 @@ spec:
           # my custom logging configuration
         containerImage: quay.io/podified-antelope-centos9/openstack-nova-conductor:current-podified
         nodeSelector: {}
-      # we never need a metadata service in cell0 as there are no computes there
-      metadataServiceTemplate: null
-      # we never need novncproxy service in cell0
-      noVNCProxyServiceTemplate: null
     cell1:
       cellDatabaseInstance: mariadb-cell1
       cellDatabaseUser: nova_cell1
@@ -91,9 +87,6 @@ spec:
           # my custom logging configuration
         containerImage: quay.io/podified-antelope-centos9/openstack-nova-conductor:current-podified
         nodeSelector: {}
-      # we could decide not to add metadata service to this cell as there
-      # is metadata at the top
-      metadataServiceTemplate: null
       noVNCProxyServiceTemplate:
         customServiceConfig: |
           # service config customization
@@ -119,15 +112,6 @@ spec:
           logging.conf: |
           # my custom logging configuration
         containerImage: quay.io/podified-antelope-centos9/openstack-nova-conductor:current-podified
-        nodeSelector: {}
-      metadataServiceTemplate:
-        enabled: true
-        customServiceConfig: |
-          # service config customization
-        defaultConfigOverwrite:
-          logging.conf: |
-            # my custom logging configuration
-        containerImage: quay.io/podified-antelope-centos9/openstack-nova-api:current-podified
         nodeSelector: {}
       noVNCProxyServiceTemplate:
         customServiceConfig: |


### PR DESCRIPTION
This adds a validation to prevent metadata to be enabled both on the top
level and in the cells.

This will be needed to avoid ambiguity about the nova_metadata_host
config in neutron.

Depends-on: #460 