### PR TITLE
[kuttl]Assert that compute config Secret is generated

### DIFF
--- a/test/kuttl/test-suites/default/scale-tests/01-assert.yaml
+++ b/test/kuttl/test-suites/default/scale-tests/01-assert.yaml
@@ -391,6 +391,19 @@ metadata:
     kind: NovaScheduler
     name: nova-kuttl-scheduler
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    nova-cell.openstack.org/name: nova-kuttl-cell1
+  name: nova-kuttl-cell1-compute-config
+  ownerReferences:
+  - apiVersion: nova.openstack.org/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: NovaCell
+    name: nova-kuttl-cell1
+---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:


### PR DESCRIPTION
This is a follow up for
https://github.com/openstack-k8s-operators/nova-operator/pull/452#discussion_r1287426956