### PR TITLE
[envtest]Drop invalid test

### DIFF
--- a/test/functional/novaconductor_controller_test.go
+++ b/test/functional/novaconductor_controller_test.go
@@ -22,7 +22,6 @@ import (
 	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
 	novav1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
 
-	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -255,25 +254,6 @@ var _ = Describe("NovaConductor controller", func() {
 				novaConductor := GetNovaConductor(novaNames.ConductorName)
 				Expect(novaConductor.Status.Hash).ShouldNot(HaveKey("dbsync"))
 
-			})
-
-			When("NovaConductor is deleted", func() {
-				It("deletes the failed job", func() {
-					th.ExpectConditionWithDetails(
-						novaNames.ConductorName,
-						ConditionGetterFunc(NovaConductorConditionGetter),
-						condition.DBSyncReadyCondition,
-						corev1.ConditionFalse,
-						condition.ErrorReason,
-						"DBsync job error occurred Internal error occurred: Job Failed. Check job logs",
-					)
-
-					th.DeleteInstance(GetNovaConductor(novaNames.ConductorName))
-
-					Eventually(func() []batchv1.Job {
-						return th.ListJobs(novaNames.ConductorName.Name).Items
-					}, timeout, interval).Should(BeEmpty())
-				})
 			})
 		})
 


### PR DESCRIPTION
This test did not assert that the job was deleted as it looked for jobs in a wrong namespace. I.e. th.ListJobs() takes the name of the namespace to list the jobs in, but the test passed in the conductor CR name.

It is not possible to fix the test case as the Job is not deleted in envtest. In a real deployment when the CR owning the Job is deleted some k8s controller does an async garbage collection and deletes the Job. But this controller does not run in envtest.

So the test is deleted.

We don't really use test coverage as job handling is implemented in lib-common and it has its own test suite that covers job deletion too https://github.com/openstack-k8s-operators/lib-common/blob/main/modules/common/test/functional/job_test.go