### PR TITLE
Merge MessageBusSecret into the internal secret

### DIFF
--- a/api/bases/nova.openstack.org_novaapis.yaml
+++ b/api/bases/nova.openstack.org_novaapis.yaml
@@ -57,11 +57,6 @@ spec:
                 description: APIDatabaseUser - username to use when accessing the
                   API DB
                 type: string
-              apiMessageBusSecretName:
-                description: APIMessageBusSecretName - the name of the Secret conntaining
-                  the transport URL information to use when accessing the API message
-                  bus.
-                type: string
               cell0DatabaseHostname:
                 description: APIDatabaseHostname - hostname to use when accessing
                   the cell0 DB
@@ -254,7 +249,6 @@ spec:
                 type: string
             required:
             - apiDatabaseHostname
-            - apiMessageBusSecretName
             - cell0DatabaseHostname
             - keystoneAuthURL
             - registeredCells

--- a/api/bases/nova.openstack.org_novacells.yaml
+++ b/api/bases/nova.openstack.org_novacells.yaml
@@ -55,11 +55,6 @@ spec:
                 description: CellDatabaseUser - username to use when accessing the
                   cell DB
                 type: string
-              cellMessageBusSecretName:
-                description: CellMessageBusSecretName - the name of the Secret containing
-                  the transport URL information to use when accessing the Cell message
-                  bus. For cell0 this should be the Secret for the API message bus.
-                type: string
               cellName:
                 description: CellName is the name of the Nova Cell. The value "cell0"
                   has a special meaning. The "cell0" Cell cannot have compute nodes
@@ -509,7 +504,6 @@ spec:
                 type: string
             required:
             - cellDatabaseHostname
-            - cellMessageBusSecretName
             - cellName
             - conductorServiceTemplate
             - keystoneAuthURL

--- a/api/bases/nova.openstack.org_novaconductors.yaml
+++ b/api/bases/nova.openstack.org_novaconductors.yaml
@@ -68,11 +68,6 @@ spec:
                 description: CellDatabaseUser - username to use when accessing the
                   cell DB
                 type: string
-              cellMessageBusSecretName:
-                description: CellMessageBusSecretName - the name of the Secret containing
-                  the transport URL information to use when accessing the Cell message
-                  bus.
-                type: string
               cellName:
                 description: CellName is the name of the Nova Cell this conductor
                   belongs to.
@@ -210,7 +205,6 @@ spec:
                   to register in keystone
                 type: string
             required:
-            - cellMessageBusSecretName
             - cellName
             - keystoneAuthURL
             - secret

--- a/api/bases/nova.openstack.org_novametadata.yaml
+++ b/api/bases/nova.openstack.org_novametadata.yaml
@@ -58,12 +58,6 @@ spec:
                 description: APIDatabaseUser - username to use when accessing the
                   API DB
                 type: string
-              apiMessageBusSecretName:
-                description: 'APIMessageBusSecretName - the name of the Secret containing
-                  the transport URL information to use when accessing the API message
-                  bus. TODO(ksambor): add a validation webhook to enforce that it
-                  is required for the CellName == ""'
-                type: string
               cellDatabaseHostname:
                 description: 'CellDatabaseHostname - hostname to use when accessing
                   the cell DB This is unused if CellName is not provided. But if it

--- a/api/bases/nova.openstack.org_novanovncproxies.yaml
+++ b/api/bases/nova.openstack.org_novanovncproxies.yaml
@@ -57,11 +57,6 @@ spec:
                 description: CellDatabaseUser - username to use when accessing the
                   cell DB
                 type: string
-              cellMessageBusSecretName:
-                description: CellMessageBusSecretName - the name of the Secret containing
-                  the transport URL information to use when accessing the Cell message
-                  bus.
-                type: string
               cellName:
                 description: CellName is the name of the Nova Cell this novncproxy
                   belongs to.
@@ -242,7 +237,6 @@ spec:
                 type: string
             required:
             - cellDatabaseHostname
-            - cellMessageBusSecretName
             - cellName
             - keystoneAuthURL
             - secret

--- a/api/bases/nova.openstack.org_novaschedulers.yaml
+++ b/api/bases/nova.openstack.org_novaschedulers.yaml
@@ -57,11 +57,6 @@ spec:
                 description: APIDatabaseUser - username to use when accessing the
                   API DB
                 type: string
-              apiMessageBusSecretName:
-                description: APIMessageBusSecretName - the name of the Secret containing
-                  the transport URL information to use when accessing the API message
-                  bus.
-                type: string
               cell0DatabaseHostname:
                 description: Cell0DatabaseHostname - hostname to use when accessing
                   the cell0 DB
@@ -214,7 +209,6 @@ spec:
                 type: string
             required:
             - apiDatabaseHostname
-            - apiMessageBusSecretName
             - cell0DatabaseHostname
             - keystoneAuthURL
             - registeredCells

--- a/api/v1beta1/novaapi_types.go
+++ b/api/v1beta1/novaapi_types.go
@@ -103,12 +103,6 @@ type NovaAPISpec struct {
 	// APIDatabaseHostname - hostname to use when accessing the API DB
 	APIDatabaseHostname string `json:"apiDatabaseHostname"`
 
-	// +kubebuilder:validation:Required
-	// APIMessageBusSecretName - the name of the Secret conntaining the
-	// transport URL information to use when accessing the API message
-	// bus.
-	APIMessageBusSecretName string `json:"apiMessageBusSecretName"`
-
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="nova_cell0"
 	// APIDatabaseUser - username to use when accessing the cell0 DB

--- a/api/v1beta1/novacell_types.go
+++ b/api/v1beta1/novacell_types.go
@@ -141,12 +141,6 @@ type NovaCellSpec struct {
 	// CellDatabaseHostname - hostname to use when accessing the cell DB
 	CellDatabaseHostname string `json:"cellDatabaseHostname"`
 
-	// +kubebuilder:validation:Required
-	// CellMessageBusSecretName - the name of the Secret containing the
-	// transport URL information to use when accessing the Cell message
-	// bus. For cell0 this should be the Secret for the API message bus.
-	CellMessageBusSecretName string `json:"cellMessageBusSecretName"`
-
 	// +kubebuilder:validation:Optional
 	// Debug - enable debug for different deploy stages. If an init container
 	// is used, it runs and the actual action pod gets started with sleep

--- a/api/v1beta1/novaconductor_types.go
+++ b/api/v1beta1/novaconductor_types.go
@@ -114,12 +114,6 @@ type NovaConductorSpec struct {
 	// CellDatabaseHostname - hostname to use when accessing the cell DB
 	CellDatabaseHostname string `json:"cellDatabaseHostname"`
 
-	// +kubebuilder:validation:Required
-	// CellMessageBusSecretName - the name of the Secret containing the
-	// transport URL information to use when accessing the Cell message
-	// bus.
-	CellMessageBusSecretName string `json:"cellMessageBusSecretName"`
-
 	// +kubebuilder:validation:Optional
 	// Debug - enable debug for different deploy stages. If an init container
 	// is used, it runs and the actual action pod gets started with sleep
@@ -191,18 +185,17 @@ func NewNovaConductorSpec(
 	novaCell NovaCellSpec,
 ) NovaConductorSpec {
 	conductorSpec := NovaConductorSpec{
-		CellName:                 novaCell.CellName,
-		Secret:                   novaCell.Secret,
-		CellDatabaseHostname:     novaCell.CellDatabaseHostname,
-		CellDatabaseUser:         novaCell.CellDatabaseUser,
-		APIDatabaseHostname:      novaCell.APIDatabaseHostname,
-		APIDatabaseUser:          novaCell.APIDatabaseUser,
-		CellMessageBusSecretName: novaCell.CellMessageBusSecretName,
-		Debug:                    novaCell.Debug,
-		NovaServiceBase:          NovaServiceBase(novaCell.ConductorServiceTemplate),
-		KeystoneAuthURL:          novaCell.KeystoneAuthURL,
-		ServiceUser:              novaCell.ServiceUser,
-		ServiceAccount:           novaCell.ServiceAccount,
+		CellName:             novaCell.CellName,
+		Secret:               novaCell.Secret,
+		CellDatabaseHostname: novaCell.CellDatabaseHostname,
+		CellDatabaseUser:     novaCell.CellDatabaseUser,
+		APIDatabaseHostname:  novaCell.APIDatabaseHostname,
+		APIDatabaseUser:      novaCell.APIDatabaseUser,
+		Debug:                novaCell.Debug,
+		NovaServiceBase:      NovaServiceBase(novaCell.ConductorServiceTemplate),
+		KeystoneAuthURL:      novaCell.KeystoneAuthURL,
+		ServiceUser:          novaCell.ServiceUser,
+		ServiceAccount:       novaCell.ServiceAccount,
 	}
 	return conductorSpec
 }

--- a/api/v1beta1/novametadata_types.go
+++ b/api/v1beta1/novametadata_types.go
@@ -138,14 +138,6 @@ type NovaMetadataSpec struct {
 	CellDatabaseHostname string `json:"cellDatabaseHostname"`
 
 	// +kubebuilder:validation:Optional
-	// APIMessageBusSecretName - the name of the Secret containing the
-	// transport URL information to use when accessing the API message
-	// bus.
-	// TODO(ksambor): add a validation webhook to enforce that it is required
-	// for the CellName == ""
-	APIMessageBusSecretName string `json:"apiMessageBusSecretName"`
-
-	// +kubebuilder:validation:Optional
 	// Debug - enable debug for different deploy stages. If an init container
 	// is used, it runs and the actual action pod gets started with sleep
 	// infinity
@@ -230,14 +222,13 @@ func NewNovaMetadataSpec(
 	novaCell NovaCellSpec,
 ) NovaMetadataSpec {
 	metadataSpec := NovaMetadataSpec{
-		CellName:                novaCell.CellName,
-		Secret:                  novaCell.Secret,
-		CellDatabaseHostname:    novaCell.CellDatabaseHostname,
-		CellDatabaseUser:        novaCell.CellDatabaseUser,
-		APIDatabaseHostname:     novaCell.APIDatabaseHostname,
-		APIDatabaseUser:         novaCell.APIDatabaseUser,
-		APIMessageBusSecretName: novaCell.CellMessageBusSecretName,
-		Debug:                   novaCell.Debug,
+		CellName:             novaCell.CellName,
+		Secret:               novaCell.Secret,
+		CellDatabaseHostname: novaCell.CellDatabaseHostname,
+		CellDatabaseUser:     novaCell.CellDatabaseUser,
+		APIDatabaseHostname:  novaCell.APIDatabaseHostname,
+		APIDatabaseUser:      novaCell.APIDatabaseUser,
+		Debug:                novaCell.Debug,
 		NovaServiceBase: NovaServiceBase{
 			ContainerImage:         novaCell.MetadataServiceTemplate.ContainerImage,
 			Replicas:               novaCell.MetadataServiceTemplate.Replicas,

--- a/api/v1beta1/novanovncproxy_types.go
+++ b/api/v1beta1/novanovncproxy_types.go
@@ -134,12 +134,6 @@ type NovaNoVNCProxySpec struct {
 	// +kubebuilder:validation:Required
 	// ServiceAccount - service account name used internally to provide Nova services the default SA name
 	ServiceAccount string `json:"serviceAccount"`
-
-	// +kubebuilder:validation:Required
-	// CellMessageBusSecretName - the name of the Secret containing the
-	// transport URL information to use when accessing the Cell message
-	// bus.
-	CellMessageBusSecretName string `json:"cellMessageBusSecretName"`
 }
 
 // NovaNoVNCProxyStatus defines the observed state of NovaNoVNCProxy
@@ -198,12 +192,11 @@ func NewNovaNoVNCProxySpec(
 	novaCell NovaCellSpec,
 ) NovaNoVNCProxySpec {
 	noVNCProxSpec := NovaNoVNCProxySpec{
-		CellName:                 novaCell.CellName,
-		Secret:                   novaCell.Secret,
-		CellDatabaseHostname:     novaCell.CellDatabaseHostname,
-		CellDatabaseUser:         novaCell.CellDatabaseUser,
-		Debug:                    novaCell.Debug,
-		CellMessageBusSecretName: novaCell.CellMessageBusSecretName,
+		CellName:             novaCell.CellName,
+		Secret:               novaCell.Secret,
+		CellDatabaseHostname: novaCell.CellDatabaseHostname,
+		CellDatabaseUser:     novaCell.CellDatabaseUser,
+		Debug:                novaCell.Debug,
 		NovaServiceBase: NovaServiceBase{
 			ContainerImage:         novaCell.NoVNCProxyServiceTemplate.ContainerImage,
 			Replicas:               novaCell.NoVNCProxyServiceTemplate.Replicas,

--- a/api/v1beta1/novascheduler_types.go
+++ b/api/v1beta1/novascheduler_types.go
@@ -97,12 +97,6 @@ type NovaSchedulerSpec struct {
 	// APIDatabaseHostname - hostname to use when accessing the API DB
 	APIDatabaseHostname string `json:"apiDatabaseHostname"`
 
-	// +kubebuilder:validation:Required
-	// APIMessageBusSecretName - the name of the Secret containing the
-	// transport URL information to use when accessing the API message
-	// bus.
-	APIMessageBusSecretName string `json:"apiMessageBusSecretName"`
-
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="nova_cell0"
 	// Cell0DatabaseUser - username to use when accessing the cell0 DB

--- a/config/crd/bases/nova.openstack.org_novaapis.yaml
+++ b/config/crd/bases/nova.openstack.org_novaapis.yaml
@@ -57,11 +57,6 @@ spec:
                 description: APIDatabaseUser - username to use when accessing the
                   API DB
                 type: string
-              apiMessageBusSecretName:
-                description: APIMessageBusSecretName - the name of the Secret conntaining
-                  the transport URL information to use when accessing the API message
-                  bus.
-                type: string
               cell0DatabaseHostname:
                 description: APIDatabaseHostname - hostname to use when accessing
                   the cell0 DB
@@ -254,7 +249,6 @@ spec:
                 type: string
             required:
             - apiDatabaseHostname
-            - apiMessageBusSecretName
             - cell0DatabaseHostname
             - keystoneAuthURL
             - registeredCells

--- a/config/crd/bases/nova.openstack.org_novacells.yaml
+++ b/config/crd/bases/nova.openstack.org_novacells.yaml
@@ -55,11 +55,6 @@ spec:
                 description: CellDatabaseUser - username to use when accessing the
                   cell DB
                 type: string
-              cellMessageBusSecretName:
-                description: CellMessageBusSecretName - the name of the Secret containing
-                  the transport URL information to use when accessing the Cell message
-                  bus. For cell0 this should be the Secret for the API message bus.
-                type: string
               cellName:
                 description: CellName is the name of the Nova Cell. The value "cell0"
                   has a special meaning. The "cell0" Cell cannot have compute nodes
@@ -509,7 +504,6 @@ spec:
                 type: string
             required:
             - cellDatabaseHostname
-            - cellMessageBusSecretName
             - cellName
             - conductorServiceTemplate
             - keystoneAuthURL

--- a/config/crd/bases/nova.openstack.org_novaconductors.yaml
+++ b/config/crd/bases/nova.openstack.org_novaconductors.yaml
@@ -68,11 +68,6 @@ spec:
                 description: CellDatabaseUser - username to use when accessing the
                   cell DB
                 type: string
-              cellMessageBusSecretName:
-                description: CellMessageBusSecretName - the name of the Secret containing
-                  the transport URL information to use when accessing the Cell message
-                  bus.
-                type: string
               cellName:
                 description: CellName is the name of the Nova Cell this conductor
                   belongs to.
@@ -210,7 +205,6 @@ spec:
                   to register in keystone
                 type: string
             required:
-            - cellMessageBusSecretName
             - cellName
             - keystoneAuthURL
             - secret

--- a/config/crd/bases/nova.openstack.org_novametadata.yaml
+++ b/config/crd/bases/nova.openstack.org_novametadata.yaml
@@ -58,12 +58,6 @@ spec:
                 description: APIDatabaseUser - username to use when accessing the
                   API DB
                 type: string
-              apiMessageBusSecretName:
-                description: 'APIMessageBusSecretName - the name of the Secret containing
-                  the transport URL information to use when accessing the API message
-                  bus. TODO(ksambor): add a validation webhook to enforce that it
-                  is required for the CellName == ""'
-                type: string
               cellDatabaseHostname:
                 description: 'CellDatabaseHostname - hostname to use when accessing
                   the cell DB This is unused if CellName is not provided. But if it

--- a/config/crd/bases/nova.openstack.org_novanovncproxies.yaml
+++ b/config/crd/bases/nova.openstack.org_novanovncproxies.yaml
@@ -57,11 +57,6 @@ spec:
                 description: CellDatabaseUser - username to use when accessing the
                   cell DB
                 type: string
-              cellMessageBusSecretName:
-                description: CellMessageBusSecretName - the name of the Secret containing
-                  the transport URL information to use when accessing the Cell message
-                  bus.
-                type: string
               cellName:
                 description: CellName is the name of the Nova Cell this novncproxy
                   belongs to.
@@ -242,7 +237,6 @@ spec:
                 type: string
             required:
             - cellDatabaseHostname
-            - cellMessageBusSecretName
             - cellName
             - keystoneAuthURL
             - secret

--- a/config/crd/bases/nova.openstack.org_novaschedulers.yaml
+++ b/config/crd/bases/nova.openstack.org_novaschedulers.yaml
@@ -57,11 +57,6 @@ spec:
                 description: APIDatabaseUser - username to use when accessing the
                   API DB
                 type: string
-              apiMessageBusSecretName:
-                description: APIMessageBusSecretName - the name of the Secret containing
-                  the transport URL information to use when accessing the API message
-                  bus.
-                type: string
               cell0DatabaseHostname:
                 description: Cell0DatabaseHostname - hostname to use when accessing
                   the cell0 DB
@@ -214,7 +209,6 @@ spec:
                 type: string
             required:
             - apiDatabaseHostname
-            - apiMessageBusSecretName
             - cell0DatabaseHostname
             - keystoneAuthURL
             - registeredCells

--- a/config/samples/nova_v1beta1_novaapi.yaml
+++ b/config/samples/nova_v1beta1_novaapi.yaml
@@ -4,7 +4,6 @@ metadata:
   name: novaapi-sample
 spec:
   apiDatabaseHostname: openstack
-  apiMessageBusSecretName: rabbitmq-transport-url-nova-api-transport
   cell0DatabaseHostname: openstack
   containerImage: quay.io/podified-antelope-centos9/openstack-nova-api:current-podified
   keystoneAuthURL: http://keystone-public-openstack.apps-crc.testing

--- a/config/samples/nova_v1beta1_novacell0.yaml
+++ b/config/samples/nova_v1beta1_novacell0.yaml
@@ -6,7 +6,6 @@ spec:
   # cell0 always needs API DB access
   apiDatabaseHostname: openstack
   cellDatabaseHostname: openstack
-  cellMessageBusSecretName: rabbitmq-transport-url-nova-api-transport
   cellName: cell0
   keystoneAuthURL: http://keystone-public-openstack.apps-crc.testing
   secret: osp-secret

--- a/config/samples/nova_v1beta1_novacell1-upcall.yaml
+++ b/config/samples/nova_v1beta1_novacell1-upcall.yaml
@@ -6,7 +6,6 @@ spec:
   # By having access to the API DB this cell has upcall support
   apiDatabaseHostname: openstack
   cellDatabaseHostname: openstack
-  cellMessageBusSecretName: rabbitmq-transport-url-cell1-transport
   cellName: cell1
   keystoneAuthURL: http://keystone-public-openstack.apps-crc.testing
   secret: osp-secret

--- a/config/samples/nova_v1beta1_novacell2-without-upcall.yaml
+++ b/config/samples/nova_v1beta1_novacell2-without-upcall.yaml
@@ -4,7 +4,6 @@ metadata:
   name: novacell2-without-upcall-sample
 spec:
   cellDatabaseHostname: openstack
-  cellMessageBusSecretName: rabbitmq-transport-url-cell2-transport
   cellName: cell2
   keystoneAuthURL: http://keystone-public-openstack.apps-crc.testing
   secret: osp-secret

--- a/config/samples/nova_v1beta1_novaconductor-cell.yaml
+++ b/config/samples/nova_v1beta1_novaconductor-cell.yaml
@@ -3,7 +3,6 @@ kind: NovaConductor
 metadata:
   name: novaconductor-sample
 spec:
-  cellMessageBusSecretName: rabbitmq-transport-url-cell1-transport
   cellName: cell1
   containerImage: quay.io/podified-antelope-centos9/openstack-nova-conductor:current-podified
   keystoneAuthURL: http://keystone-public-openstack.apps-crc.testing

--- a/config/samples/nova_v1beta1_novaconductor-super.yaml
+++ b/config/samples/nova_v1beta1_novaconductor-super.yaml
@@ -4,7 +4,6 @@ metadata:
   name: novaconductor-sample
 spec:
   apiDatabaseHostname: openstack
-  cellMessageBusSecretName: rabbitmq-transport-url-nova-api-transport
   cellName: cell0
   containerImage: quay.io/podified-antelope-centos9/openstack-nova-conductor:current-podified
   keystoneAuthURL: http://keystone-public-openstack.apps-crc.testing

--- a/config/samples/nova_v1beta1_novametadata.yaml
+++ b/config/samples/nova_v1beta1_novametadata.yaml
@@ -4,7 +4,6 @@ metadata:
   name: novametadata-sample
 spec:
   apiDatabaseHostname: openstack
-  apiMessageBusSecretName: rabbitmq-transport-url-nova-api-transport
   cellDatabaseHostname: openstack
   cellDatabaseUser: nova_cell0
   containerImage: quay.io/podified-antelope-centos9/openstack-nova-api:current-podified

--- a/config/samples/nova_v1beta1_novascheduler.yaml
+++ b/config/samples/nova_v1beta1_novascheduler.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   secret: osp-secret
   apiDatabaseHostname: openstack
-  apiMessageBusSecretName: rabbitmq-transport-url-nova-api-transport
   cell0DatabaseHostname: openstack
   containerImage: quay.io/podified-antelope-centos9/openstack-nova-scheduler:current-podified
   keystoneAuthURL: http://keystone-public-openstack.apps-crc.testing

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -81,9 +81,12 @@ const (
 	// APIDatabasePasswordSelector is the name of key in the internal Secret
 	// for the API database
 	APIDatabasePasswordSelector = "APIDatabasePassword"
-	// APIDatabasePasswordSelector is the name of key in the internal cell
+	// CellDatabasePasswordSelector is the name of key in the internal cell
 	// Secret for the cell database of the given cell
 	CellDatabasePasswordSelector = "CellDatabasePassword"
+	// TransportURLSelector is the name of key in the internal cell
+	// Secret for the cell message bus transport URL
+	TransportURLSelector = "transport_url"
 )
 
 type conditionsGetter interface {

--- a/controllers/nova_controller.go
+++ b/controllers/nova_controller.go
@@ -1170,7 +1170,7 @@ func (r *NovaReconciler) ensureMQ(
 		return "", nova.MQFailed, err
 	}
 
-	url, ok := secret.Data["transport_url"]
+	url, ok := secret.Data[TransportURLSelector]
 	if !ok {
 		return "", nova.MQFailed, fmt.Errorf(
 			"the TransportURL secret %s does not have 'transport_url' field", transportURL.Status.SecretName)
@@ -1457,11 +1457,10 @@ func (r *NovaReconciler) ensureCellSecret(
 
 	// NOTE(gibi): We can move other sensitive data to the internal Secret from
 	// the NovaCellSpec fields, possibly hostnames or usernames.
-	// XXX(gibi): Move the transport_url from from the MQ secret to the internal secret
 	data := map[string]string{
 		ServicePasswordSelector:      string(externalSecret.Data[instance.Spec.PasswordSelectors.Service]),
 		CellDatabasePasswordSelector: string(externalSecret.Data[cellTemplate.PasswordSelectors.Database]),
-		"transport_url":              cellTransportURL,
+		TransportURLSelector:         cellTransportURL,
 	}
 
 	if cellTemplate.HasAPIAccess {
@@ -1515,7 +1514,7 @@ func (r *NovaReconciler) ensureTopLevelSecret(
 		APIDatabasePasswordSelector:  string(externalSecret.Data[instance.Spec.PasswordSelectors.APIDatabase]),
 		CellDatabasePasswordSelector: string(externalSecret.Data[cell0Template.PasswordSelectors.Database]),
 		MetadataSecretSelector:       string(externalSecret.Data[instance.Spec.PasswordSelectors.MetadataSecret]),
-		"transport_url":              apiTransportURL,
+		TransportURLSelector:         apiTransportURL,
 	}
 
 	// NOTE(gibi): When we switch to immutable secrets then we need to include

--- a/controllers/novaapi_controller.go
+++ b/controllers/novaapi_controller.go
@@ -166,6 +166,7 @@ func (r *NovaAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 			APIDatabasePasswordSelector,
 			ServicePasswordSelector,
 			CellDatabasePasswordSelector,
+			"transport_url",
 		},
 		h.GetClient(),
 		&instance.Status.Conditions,
@@ -327,19 +328,6 @@ func (r *NovaAPIReconciler) generateConfigs(
 	ctx context.Context, h *helper.Helper, instance *novav1.NovaAPI, hashes *map[string]env.Setter, secret corev1.Secret,
 ) error {
 
-	apiMessageBusSecret := &corev1.Secret{}
-	secretName := types.NamespacedName{
-		Namespace: instance.Namespace,
-		Name:      instance.Spec.APIMessageBusSecretName,
-	}
-	err := h.GetClient().Get(ctx, secretName, apiMessageBusSecret)
-	if err != nil {
-		util.LogForObject(
-			h, "Failed reading Secret", instance,
-			"APIMessageBusSecretName", instance.Spec.APIMessageBusSecretName)
-		return err
-	}
-
 	templateParameters := map[string]interface{}{
 		"service_name":           "nova-api",
 		"keystone_internal_url":  instance.Spec.KeystoneAuthURL,
@@ -359,7 +347,7 @@ func (r *NovaAPIReconciler) generateConfigs(
 		"openstack_region_name":  "regionOne", // fixme
 		"default_project_domain": "Default",   // fixme
 		"default_user_domain":    "Default",   // fixme
-		"transport_url":          string(apiMessageBusSecret.Data["transport_url"]),
+		"transport_url":          string(secret.Data["transport_url"]),
 		"log_file":               "/var/log/nova/nova-api.log",
 	}
 	extraData := map[string]string{}
@@ -374,7 +362,7 @@ func (r *NovaAPIReconciler) generateConfigs(
 		instance, labels.GetGroupLabel(NovaAPILabelPrefix), map[string]string{},
 	)
 
-	err = r.GenerateConfigs(
+	err := r.GenerateConfigs(
 		ctx, h, instance, nova.GetServiceConfigSecretName(instance.GetName()),
 		hashes, templateParameters, extraData, cmLabels, map[string]string{},
 	)

--- a/controllers/novaapi_controller.go
+++ b/controllers/novaapi_controller.go
@@ -166,7 +166,7 @@ func (r *NovaAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 			APIDatabasePasswordSelector,
 			ServicePasswordSelector,
 			CellDatabasePasswordSelector,
-			"transport_url",
+			TransportURLSelector,
 		},
 		h.GetClient(),
 		&instance.Status.Conditions,
@@ -347,7 +347,7 @@ func (r *NovaAPIReconciler) generateConfigs(
 		"openstack_region_name":  "regionOne", // fixme
 		"default_project_domain": "Default",   // fixme
 		"default_user_domain":    "Default",   // fixme
-		"transport_url":          string(secret.Data["transport_url"]),
+		"transport_url":          string(secret.Data[TransportURLSelector]),
 		"log_file":               "/var/log/nova/nova-api.log",
 	}
 	extraData := map[string]string{}

--- a/controllers/novacell_controller.go
+++ b/controllers/novacell_controller.go
@@ -123,7 +123,7 @@ func (r *NovaCellReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 		types.NamespacedName{Namespace: instance.Namespace, Name: instance.Spec.Secret},
 		[]string{
 			ServicePasswordSelector,
-			"transport_url",
+			TransportURLSelector,
 		},
 		h.GetClient(),
 		&instance.Status.Conditions,
@@ -579,7 +579,7 @@ func (r *NovaCellReconciler) generateComputeConfigs(
 		"openstack_region_name":  "regionOne", // fixme
 		"default_project_domain": "Default",   // fixme
 		"default_user_domain":    "Default",   // fixme
-		"transport_url":          string(secret.Data["transport_url"]),
+		"transport_url":          string(secret.Data[TransportURLSelector]),
 		"log_file":               "/var/log/containers/nova/nova-compute.log",
 	}
 	// vnc is optional so we only need to configure it for the compute

--- a/controllers/novaconductor_controller.go
+++ b/controllers/novaconductor_controller.go
@@ -134,7 +134,7 @@ func (r *NovaConductorReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	required_secret_fields := []string{
 		ServicePasswordSelector,
 		CellDatabasePasswordSelector,
-		"transport_url",
+		TransportURLSelector,
 	}
 	if len(instance.Spec.APIDatabaseHostname) > 0 {
 		required_secret_fields = append(required_secret_fields, APIDatabasePasswordSelector)
@@ -293,7 +293,7 @@ func (r *NovaConductorReconciler) generateConfigs(
 		"openstack_region_name":  "regionOne", // fixme
 		"default_project_domain": "Default",   // fixme
 		"default_user_domain":    "Default",   // fixme
-		"transport_url":          string(secret.Data["transport_url"]),
+		"transport_url":          string(secret.Data[TransportURLSelector]),
 	}
 	if len(instance.Spec.APIDatabaseHostname) > 0 && len(instance.Spec.APIDatabaseUser) > 0 {
 		templateParameters["api_db_name"] = instance.Spec.APIDatabaseUser // fixme

--- a/controllers/novametadata_controller.go
+++ b/controllers/novametadata_controller.go
@@ -139,7 +139,7 @@ func (r *NovaMetadataReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		ServicePasswordSelector,
 		CellDatabasePasswordSelector,
 		MetadataSecretSelector,
-		"transport_url",
+		TransportURLSelector,
 	}
 	if instance.Spec.CellName == "" {
 		expectedSelectors = append(expectedSelectors, APIDatabasePasswordSelector)
@@ -305,7 +305,7 @@ func (r *NovaMetadataReconciler) generateConfigs(
 		"default_user_domain":    "Default",   // fixme
 		"metadata_secret":        string(secret.Data[MetadataSecretSelector]),
 		"log_file":               "/var/log/nova/nova-metadata.log",
-		"transport_url":          string(secret.Data["transport_url"]),
+		"transport_url":          string(secret.Data[TransportURLSelector]),
 	}
 
 	if instance.Spec.CellName == "" {

--- a/controllers/novanovncproxy_controller.go
+++ b/controllers/novanovncproxy_controller.go
@@ -142,7 +142,7 @@ func (r *NovaNoVNCProxyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		[]string{
 			ServicePasswordSelector,
 			CellDatabasePasswordSelector,
-			"transport_url",
+			TransportURLSelector,
 		},
 		h.GetClient(),
 		&instance.Status.Conditions,
@@ -291,7 +291,7 @@ func (r *NovaNoVNCProxyReconciler) generateConfigs(
 		"cell_db_port":           3306,
 		"api_interface_address":  "",     // fixme
 		"public_protocol":        "http", // fixme
-		"transport_url":          string(secret.Data["transport_url"]),
+		"transport_url":          string(secret.Data[TransportURLSelector]),
 		"openstack_cacert":       "",          // fixme
 		"openstack_region_name":  "regionOne", // fixme
 		"default_project_domain": "Default",   // fixme

--- a/controllers/novascheduler_controller.go
+++ b/controllers/novascheduler_controller.go
@@ -140,7 +140,7 @@ func (r *NovaSchedulerReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			ServicePasswordSelector,
 			APIDatabasePasswordSelector,
 			CellDatabasePasswordSelector,
-			"transport_url",
+			TransportURLSelector,
 		},
 		h.GetClient(),
 		&instance.Status.Conditions,
@@ -303,7 +303,7 @@ func (r *NovaSchedulerReconciler) generateConfigs(
 		"openstack_region_name":  "regionOne", // fixme
 		"default_project_domain": "Default",   // fixme
 		"default_user_domain":    "Default",   // fixme
-		"transport_url":          string(secret.Data["transport_url"]),
+		"transport_url":          string(secret.Data[TransportURLSelector]),
 	}
 	extraData := map[string]string{}
 	if instance.Spec.CustomServiceConfig != "" {

--- a/pkg/nova/common.go
+++ b/pkg/nova/common.go
@@ -99,6 +99,6 @@ type Database struct {
 
 // MessageBus -
 type MessageBus struct {
-	SecretName string
-	Status     MessageBusStatus
+	TransportURL string
+	Status       MessageBusStatus
 }

--- a/test/functional/novacell_controller_test.go
+++ b/test/functional/novacell_controller_test.go
@@ -69,11 +69,7 @@ var _ = Describe("NovaCell controller", func() {
 
 	When("A NovaCell/cell0 CR instance is created", func() {
 		BeforeEach(func() {
-			DeferCleanup(
-				k8sClient.Delete,
-				ctx,
-				CreateNovaConductorSecret(cell0.CellCRName.Namespace, cell0.InternalCellSecretName.Name),
-			)
+			DeferCleanup(k8sClient.Delete, ctx, CreateCellInternalSecret(cell0))
 			DeferCleanup(th.DeleteInstance, CreateNovaCell(cell0.CellCRName, GetDefaultNovaCellSpec(cell0)))
 		})
 
@@ -711,11 +707,7 @@ var _ = Describe("NovaCell controller", func() {
 	})
 	When("NovaCell/cell0 is reconfigured", func() {
 		BeforeEach(func() {
-			DeferCleanup(
-				k8sClient.Delete,
-				ctx,
-				CreateNovaConductorSecret(cell0.CellCRName.Namespace, cell0.InternalCellSecretName.Name),
-			)
+			DeferCleanup(k8sClient.Delete, ctx, CreateCellInternalSecret(cell0))
 			DeferCleanup(th.DeleteInstance, CreateNovaCell(cell0.CellCRName, GetDefaultNovaCellSpec(cell0)))
 			th.SimulateJobSuccess(cell0.DBSyncJobName)
 
@@ -900,8 +892,7 @@ var _ = Describe("NovaCell controller", func() {
 var _ = Describe("NovaCell controller webhook", func() {
 	It("name is too long", func() {
 		cell := GetCellNames(novaNames.NovaName, uuid.New().String())
-		DeferCleanup(
-			k8sClient.Delete, ctx, CreateNovaConductorSecret(cell.CellCRName.Namespace, cell.InternalCellSecretName.Name))
+		DeferCleanup(k8sClient.Delete, ctx, CreateCellInternalSecret(cell))
 
 		spec := GetDefaultNovaCellSpec(cell)
 		rawObj := map[string]interface{}{

--- a/test/functional/sample_test.go
+++ b/test/functional/sample_test.go
@@ -102,31 +102,31 @@ var _ = Describe("Samples", func() {
 	})
 	When("nova_v1beta1_novacell0.yaml sample is applied", func() {
 		It("NovaCell is created", func() {
-			name := CreateNovaCellFromSample("nova_v1beta1_novacell0.yaml", cell0.CellName)
+			name := CreateNovaCellFromSample("nova_v1beta1_novacell0.yaml", cell0.CellCRName)
 			GetNovaCell(name)
 		})
 	})
 	When("nova_v1beta1_novacell1-upcall.yaml sample is applied", func() {
 		It("NovaCell is created", func() {
-			name := CreateNovaCellFromSample("nova_v1beta1_novacell1-upcall.yaml", cell1.CellName)
+			name := CreateNovaCellFromSample("nova_v1beta1_novacell1-upcall.yaml", cell1.CellCRName)
 			GetNovaCell(name)
 		})
 	})
 	When("nova_v1beta1_novacell2-without-upcall.yaml sample is applied", func() {
 		It("NovaCell is created", func() {
-			name := CreateNovaCellFromSample("nova_v1beta1_novacell2-without-upcall.yaml", cell2.CellName)
+			name := CreateNovaCellFromSample("nova_v1beta1_novacell2-without-upcall.yaml", cell2.CellCRName)
 			GetNovaCell(name)
 		})
 	})
 	When("nova_v1beta1_novaconductor-super.yaml sample is applied", func() {
 		It("NovaConductor is created", func() {
-			name := CreateNovaConductorFromSample("nova_v1beta1_novaconductor-super.yaml", novaNames.ConductorName)
+			name := CreateNovaConductorFromSample("nova_v1beta1_novaconductor-super.yaml", cell0.ConductorName)
 			GetNovaConductor(name)
 		})
 	})
 	When("nova_v1beta1_novaconductor-cell.yaml sample is applied", func() {
 		It("NovaConductor is created", func() {
-			name := CreateNovaConductorFromSample("nova_v1beta1_novaconductor-cell.yaml", novaNames.ConductorName)
+			name := CreateNovaConductorFromSample("nova_v1beta1_novaconductor-cell.yaml", cell1.ConductorName)
 			GetNovaConductor(name)
 		})
 	})

--- a/test/functional/validation_webhook_test.go
+++ b/test/functional/validation_webhook_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Nova validation", func() {
 		)
 	})
 	It("rejects NovaCell with metadata in cell0", func() {
-		spec := GetDefaultNovaCellSpec("cell0")
+		spec := GetDefaultNovaCellSpec(cell0)
 		spec["metadataServiceTemplate"] = map[string]interface{}{
 			"enabled": true,
 		}
@@ -77,7 +77,7 @@ var _ = Describe("Nova validation", func() {
 			"apiVersion": "nova.openstack.org/v1beta1",
 			"kind":       "NovaCell",
 			"metadata": map[string]interface{}{
-				"name":      cell0.CellName.Name,
+				"name":      cell0.CellCRName.Name,
 				"namespace": novaNames.Namespace,
 			},
 			"spec": spec,
@@ -135,7 +135,7 @@ var _ = Describe("Nova validation", func() {
 		)
 	})
 	It("rejects NovaCell with NoVNCProxy in cell0", func() {
-		spec := GetDefaultNovaCellSpec("cell0")
+		spec := GetDefaultNovaCellSpec(cell0)
 		spec["noVNCProxyServiceTemplate"] = map[string]interface{}{
 			"enabled": true,
 		}
@@ -143,7 +143,7 @@ var _ = Describe("Nova validation", func() {
 			"apiVersion": "nova.openstack.org/v1beta1",
 			"kind":       "NovaCell",
 			"metadata": map[string]interface{}{
-				"name":      cell0.CellName.Name,
+				"name":      cell0.CellCRName.Name,
 				"namespace": novaNames.Namespace,
 			},
 			"spec": spec,
@@ -197,12 +197,13 @@ var _ = Describe("Nova validation", func() {
 		)
 	})
 	It("rejects NovaCell with too long cell name", func() {
-		spec := GetDefaultNovaCellSpec("cell1" + strings.Repeat("x", 31))
+		cell := GetCellNames(novaNames.NovaName, "cell1"+strings.Repeat("x", 31))
+		spec := GetDefaultNovaCellSpec(cell)
 		raw := map[string]interface{}{
 			"apiVersion": "nova.openstack.org/v1beta1",
 			"kind":       "NovaCell",
 			"metadata": map[string]interface{}{
-				"name":      cell0.CellName.Name,
+				"name":      cell0.CellCRName.Name,
 				"namespace": novaNames.Namespace,
 			},
 			"spec": spec,

--- a/test/kuttl/test-suites/default/scale-tests/02-assert.yaml
+++ b/test/kuttl/test-suites/default/scale-tests/02-assert.yaml
@@ -31,7 +31,6 @@ metadata:
 spec:
   apiDatabaseHostname: openstack
   apiDatabaseUser: nova_api
-  apiMessageBusSecretName: rabbitmq-transport-url-nova-kuttl-api-transport
   cell0DatabaseHostname: openstack
   cell0DatabaseUser: nova_cell0
   replicas: 3
@@ -46,7 +45,6 @@ metadata:
 spec:
   apiDatabaseHostname: openstack
   apiDatabaseUser: nova_api
-  apiMessageBusSecretName: rabbitmq-transport-url-nova-kuttl-api-transport
   cellDatabaseHostname: openstack
   cellDatabaseUser: nova_cell0
   replicas: 3
@@ -69,7 +67,6 @@ spec:
   apiDatabaseUser: nova_api
   cellDatabaseHostname: openstack
   cellDatabaseUser: nova_cell0
-  cellMessageBusSecretName: rabbitmq-transport-url-nova-kuttl-api-transport
   cellName: cell0
   containerImage: quay.io/podified-antelope-centos9/openstack-nova-conductor:current-podified
   replicas: 3
@@ -92,7 +89,6 @@ spec:
   apiDatabaseUser: nova_api
   cellDatabaseHostname: openstack-cell1
   cellDatabaseUser: nova_cell1
-  cellMessageBusSecretName: rabbitmq-transport-url-nova-kuttl-cell1-transport
   cellName: cell1
   containerImage: quay.io/podified-antelope-centos9/openstack-nova-conductor:current-podified
   replicas: 3

--- a/test/kuttl/test-suites/default/scale-tests/03-assert.yaml
+++ b/test/kuttl/test-suites/default/scale-tests/03-assert.yaml
@@ -31,7 +31,6 @@ metadata:
 spec:
   apiDatabaseHostname: openstack
   apiDatabaseUser: nova_api
-  apiMessageBusSecretName: rabbitmq-transport-url-nova-kuttl-api-transport
   cell0DatabaseHostname: openstack
   cell0DatabaseUser: nova_cell0
   replicas: 1
@@ -46,7 +45,6 @@ metadata:
 spec:
   apiDatabaseHostname: openstack
   apiDatabaseUser: nova_api
-  apiMessageBusSecretName: rabbitmq-transport-url-nova-kuttl-api-transport
   cellDatabaseHostname: openstack
   cellDatabaseUser: nova_cell0
   replicas: 1
@@ -69,7 +67,6 @@ spec:
   apiDatabaseUser: nova_api
   cellDatabaseHostname: openstack
   cellDatabaseUser: nova_cell0
-  cellMessageBusSecretName: rabbitmq-transport-url-nova-kuttl-api-transport
   cellName: cell0
   containerImage: quay.io/podified-antelope-centos9/openstack-nova-conductor:current-podified
   replicas: 1
@@ -92,7 +89,6 @@ spec:
   apiDatabaseUser: nova_api
   cellDatabaseHostname: openstack-cell1
   cellDatabaseUser: nova_cell1
-  cellMessageBusSecretName: rabbitmq-transport-url-nova-kuttl-cell1-transport
   cellName: cell1
   containerImage: quay.io/podified-antelope-centos9/openstack-nova-conductor:current-podified
   replicas: 1

--- a/test/kuttl/test-suites/default/scale-tests/04-assert.yaml
+++ b/test/kuttl/test-suites/default/scale-tests/04-assert.yaml
@@ -75,7 +75,6 @@ metadata:
 spec:
   apiDatabaseHostname: openstack
   apiDatabaseUser: nova_api
-  apiMessageBusSecretName: rabbitmq-transport-url-nova-kuttl-api-transport
   cell0DatabaseHostname: openstack
   cell0DatabaseUser: nova_cell0
   replicas: 0
@@ -88,7 +87,6 @@ metadata:
 spec:
   apiDatabaseHostname: openstack
   apiDatabaseUser: nova_api
-  apiMessageBusSecretName: rabbitmq-transport-url-nova-kuttl-api-transport
   cellDatabaseHostname: openstack
   cellDatabaseUser: nova_cell0
   replicas: 0
@@ -109,7 +107,6 @@ spec:
   apiDatabaseUser: nova_api
   cellDatabaseHostname: openstack
   cellDatabaseUser: nova_cell0
-  cellMessageBusSecretName: rabbitmq-transport-url-nova-kuttl-api-transport
   cellName: cell0
   containerImage: quay.io/podified-antelope-centos9/openstack-nova-conductor:current-podified
   replicas: 0
@@ -130,7 +127,6 @@ spec:
   apiDatabaseUser: nova_api
   cellDatabaseHostname: openstack-cell1
   cellDatabaseUser: nova_cell1
-  cellMessageBusSecretName: rabbitmq-transport-url-nova-kuttl-cell1-transport
   cellName: cell1
   containerImage: quay.io/podified-antelope-centos9/openstack-nova-conductor:current-podified
   replicas: 0


### PR DESCRIPTION
This is a follow up of the work that created a scoped down internal
secrets for our sub CRs. Instead of passing down the internal secret and
the message bus secret separately this patch moves the content
(transport_url) from the message bus secret to the internal secret and
only passes down the internal secret. So we have one less secret per sub
CR to handle.

Note that this is a backwards incompatible CRD change as we deleted the
MessageBusSecret fields from our sub CRDs.

Closes: https://issues.redhat.com/browse/OSPRH-223
Closes: https://github.com/openstack-k8s-operators/nova-operator/issues/143 (makes it unnecessary)
Closes: https://github.com/openstack-k8s-operators/nova-operator/issues/79