### PR TITLE
[metadata]Generate metadata external secret for neutron

### DIFF
--- a/templates/neutron-metadata.conf
+++ b/templates/neutron-metadata.conf
@@ -1,0 +1,3 @@
+[DEFAULT]
+nova_metadata_host = {{.nova_metadata_host}}
+metadata_proxy_shared_secret = {{.metadata_proxy_shared_secret}}

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -331,6 +331,8 @@ type CellNames struct {
 	CellMappingJobName               types.NamespacedName
 	MetadataName                     types.NamespacedName
 	MetadataStatefulSetName          types.NamespacedName
+	MetadataConfigDataName           types.NamespacedName
+	MetadataNeutronConfigDataName    types.NamespacedName
 	NoVNCProxyName                   types.NamespacedName
 	NoVNCProxyStatefulSetName        types.NamespacedName
 	CellNoVNCProxyNameConfigDataName types.NamespacedName
@@ -386,8 +388,16 @@ func GetCellNames(novaName types.NamespacedName, cell string) CellNames {
 			Namespace: novaName.Namespace,
 			Name:      cellConductor.Name + "-scripts",
 		},
-		MetadataName:              metadataName,
-		MetadataStatefulSetName:   metadataName,
+		MetadataName:            metadataName,
+		MetadataStatefulSetName: metadataName,
+		MetadataConfigDataName: types.NamespacedName{
+			Namespace: metadataName.Namespace,
+			Name:      metadataName.Name + "-config-data",
+		},
+		MetadataNeutronConfigDataName: types.NamespacedName{
+			Namespace: metadataName.Namespace,
+			Name:      metadataName.Name + "-neutron-config",
+		},
 		NoVNCProxyName:            novncproxyName,
 		NoVNCProxyStatefulSetName: novncproxyName,
 		CellNoVNCProxyNameConfigDataName: types.NamespacedName{
@@ -437,6 +447,7 @@ type NovaNames struct {
 	SchedulerConfigDataName         types.NamespacedName
 	MetadataName                    types.NamespacedName
 	MetadataStatefulSetName         types.NamespacedName
+	MetadataNeutronConfigDataName   types.NamespacedName
 	ServiceAccountName              types.NamespacedName
 	RoleName                        types.NamespacedName
 	RoleBindingName                 types.NamespacedName
@@ -534,6 +545,10 @@ func GetNovaNames(novaName types.NamespacedName, cellNames []string) NovaNames {
 		MetadataConfigDataName: types.NamespacedName{
 			Namespace: novaMetadata.Namespace,
 			Name:      novaMetadata.Name + "-config-data",
+		},
+		MetadataNeutronConfigDataName: types.NamespacedName{
+			Namespace: novaMetadata.Namespace,
+			Name:      novaMetadata.Name + "-neutron-config",
 		},
 		InternalNovaMetadataServiceName: types.NamespacedName{
 			Namespace: novaMetadata.Namespace,


### PR DESCRIPTION
The neutron metadata agent running on EDPM compute nodes needs to connect to the nova metadata service running in k8s. To be able to do that the neutron metadata agent needs to know the secret shared between neutron and nova, and the nova metadata service hostname.

The nova metadata service can be deployed either centrally or per cell. So the above information depends on the nova metadata deployment mode.

To ease the neutron configuration on the EDPM node, nova-operator now exposes the above information in Secret objects per NovaMetadata CR. If a single nova metadata service is deployed on the top level then the name of the secret is `<Nova/name>-metadata-neutron-config` (i.e. nova-metadata-neutron-config in the default deployment). If the nova metadata service is deployed per cell then the name of the Secrets are `<Nova/name>-<cell name>-metadata-neutron-config` (i.e in cell1 in the default deployment nova-cell1-metadata-neutron-config).

These secretes contains a single oslo config snippet that can be added to the neutron conf.d directory to extend the existing neutron metadata configuration with the nova specific parameters. The single key in the secret is named 05-nova-metadata.conf

* [x] Test coverage
  * [x] Metadata shared secret changes reflected in the generated config
* [x] Documentation
