### PR TITLE
[scheduler]Disable periodic host discovery

### DIFF
--- a/templates/nova.conf
+++ b/templates/nova.conf
@@ -75,8 +75,6 @@ shuffle_best_same_weighed_hosts = true
 
 [scheduler]
 max_attempts = 10
-{{/*We should turn this off but for now 60 will work*/}}
-discover_hosts_in_cells_interval = 60
 # scaling should be done by running more pods
 workers = 1
 limit_tenants_to_placement_aggregate=true


### PR DESCRIPTION
The explicit `[scheduler]discover_hosts_in_cells_interval` configuration is removed to disable the periodic. This periodic job is not intended for production use as it generates a constant load on the DB by periodically scanning for new computes. Instead when new compute is added to the deployment (i.e. during scale-out) the human operator needs to manually trigger the host discovery via
```
  oc rsh nova-cell0-conductor-0 nova-manage cell_v2 discover_hosts --verbose
```

Related: https://issues.redhat.com/browse/OSPRH-319
Closes: #487
Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/507 (merged)
Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/518 (merged)
Related-To: https://github.com/openstack-k8s-operators/dataplane-operator/pull/390 (documentation) (merged)