### PR TITLE
Fix: multiple related images with the same image ref

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -157,7 +157,7 @@ func SetupDefaults() {
 	novaDefaults := NovaDefaults{
 		APIContainerImageURL:       util.GetEnvVar("RELATED_IMAGE_NOVA_API_IMAGE_URL_DEFAULT", NovaAPIContainerImage),
 		ConductorContainerImageURL: util.GetEnvVar("RELATED_IMAGE_NOVA_CONDUCTOR_IMAGE_URL_DEFAULT", NovaConductorContainerImage),
-		MetadataContainerImageURL:  util.GetEnvVar("RELATED_IMAGE_NOVA_METADATA_IMAGE_URL_DEFAULT", NovaMetadataContainerImage),
+		MetadataContainerImageURL:  util.GetEnvVar("RELATED_IMAGE_NOVA_API_IMAGE_URL_DEFAULT", NovaMetadataContainerImage),
 		NoVNCContainerImageURL:     util.GetEnvVar("RELATED_IMAGE_NOVA_NOVNC_IMAGE_URL_DEFAULT", NovaNoVNCContainerImage),
 		SchedulerContainerImageURL: util.GetEnvVar("RELATED_IMAGE_NOVA_SCHEDULER_IMAGE_URL_DEFAULT", NovaSchedulerContainerImage),
 	}
@@ -174,7 +174,7 @@ func SetupDefaults() {
 	// Acquire environmental defaults and initialize NovaCell defaults with them
 	novaCellDefaults := NovaCellDefaults{
 		ConductorContainerImageURL: util.GetEnvVar("RELATED_IMAGE_NOVA_CONDUCTOR_IMAGE_URL_DEFAULT", NovaConductorContainerImage),
-		MetadataContainerImageURL:  util.GetEnvVar("RELATED_IMAGE_NOVA_METADATA_IMAGE_URL_DEFAULT", NovaMetadataContainerImage),
+		MetadataContainerImageURL:  util.GetEnvVar("RELATED_IMAGE_NOVA_API_IMAGE_URL_DEFAULT", NovaMetadataContainerImage),
 		NoVNCContainerImageURL:     util.GetEnvVar("RELATED_IMAGE_NOVA_NOVNC_IMAGE_URL_DEFAULT", NovaNoVNCContainerImage),
 	}
 

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -15,8 +15,6 @@ spec:
           value: quay.io/podified-antelope-centos9/openstack-nova-api:current-podified
         - name: RELATED_IMAGE_NOVA_CONDUCTOR_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-nova-conductor:current-podified
-        - name: RELATED_IMAGE_NOVA_METADATA_IMAGE_URL_DEFAULT
-          value: quay.io/podified-antelope-centos9/openstack-nova-api:current-podified
         - name: RELATED_IMAGE_NOVA_NOVNC_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-nova-novncproxy:current-podified
         - name: RELATED_IMAGE_NOVA_SCHEDULER_IMAGE_URL_DEFAULT

--- a/test/functional/nova_controller_test.go
+++ b/test/functional/nova_controller_test.go
@@ -910,12 +910,12 @@ var _ = Describe("Nova controller", func() {
 			novaDefault := GetNova(novaNames.NovaName)
 
 			Expect(novaDefault.Spec.APIServiceTemplate.ContainerImage).To(Equal(util.GetEnvVar("RELATED_IMAGE_NOVA_API_IMAGE_URL_DEFAULT", novav1.NovaAPIContainerImage)))
-			Expect(novaDefault.Spec.MetadataServiceTemplate.ContainerImage).To(Equal(util.GetEnvVar("RELATED_IMAGE_NOVA_METADATA_IMAGE_URL_DEFAULT", novav1.NovaMetadataContainerImage)))
+			Expect(novaDefault.Spec.MetadataServiceTemplate.ContainerImage).To(Equal(util.GetEnvVar("RELATED_IMAGE_NOVA_API_IMAGE_URL_DEFAULT", novav1.NovaMetadataContainerImage)))
 			Expect(novaDefault.Spec.SchedulerServiceTemplate.ContainerImage).To(Equal(util.GetEnvVar("RELATED_IMAGE_NOVA_SCHEDULER_IMAGE_URL_DEFAULT", novav1.NovaSchedulerContainerImage)))
 
 			for _, cell := range novaDefault.Spec.CellTemplates {
 				Expect(cell.ConductorServiceTemplate.ContainerImage).To(Equal(util.GetEnvVar("RELATED_IMAGE_NOVA_CONDUCTOR_IMAGE_URL_DEFAULT", novav1.NovaConductorContainerImage)))
-				Expect(cell.MetadataServiceTemplate.ContainerImage).To(Equal(util.GetEnvVar("RELATED_IMAGE_NOVA_METADATA_IMAGE_URL_DEFAULT", novav1.NovaMetadataContainerImage)))
+				Expect(cell.MetadataServiceTemplate.ContainerImage).To(Equal(util.GetEnvVar("RELATED_IMAGE_NOVA_API_IMAGE_URL_DEFAULT", novav1.NovaMetadataContainerImage)))
 				Expect(cell.NoVNCProxyServiceTemplate.ContainerImage).To(Equal(util.GetEnvVar("RELATED_IMAGE_NOVA_NOVNC_IMAGE_URL_DEFAULT", novav1.NovaNoVNCContainerImage)))
 			}
 		})

--- a/test/functional/nova_metadata_controller_test.go
+++ b/test/functional/nova_metadata_controller_test.go
@@ -661,7 +661,7 @@ var _ = Describe("NovaMetadata controller", func() {
 		})
 		It("has the expected container image default", func() {
 			novaMetadataDefault := GetNovaMetadata(novaNames.MetadataName)
-			Expect(novaMetadataDefault.Spec.ContainerImage).To(Equal(util.GetEnvVar("RELATED_IMAGE_NOVA_METADATA_IMAGE_URL_DEFAULT", novav1.NovaMetadataContainerImage)))
+			Expect(novaMetadataDefault.Spec.ContainerImage).To(Equal(util.GetEnvVar("RELATED_IMAGE_NOVA_API_IMAGE_URL_DEFAULT", novav1.NovaMetadataContainerImage)))
 		})
 	})
 })


### PR DESCRIPTION
This fixes a warning when building bundles with USE_IMAGE_DIGESTS=true by removing the related image constant for METADATA which is exactly the same as API. This does not change internal operator code which could support a separate METADATA image at some point in the future