### PR TITLE
Run two nova-api and -metadata processes per pods

### DIFF
--- a/templates/novaapi/config/httpd.conf
+++ b/templates/novaapi/config/httpd.conf
@@ -38,7 +38,9 @@ LogLevel info
   WSGIProcessGroup nova-api
   WSGIApplicationGroup %{GLOBAL}
   WSGIPassAuthorization On
-  WSGIDaemonProcess nova-api processes=1 threads=1 user=nova group=nova display-name=nova-api
+  ## In general we want nova-api to scale via k8s replicas but we need
+  ## two processes per replica to always has a room for a healthecheck query
+  WSGIDaemonProcess nova-api processes=2 threads=1 user=nova group=nova display-name=nova-api
   WSGIScriptAlias / /usr/bin/nova-api-wsgi
 </VirtualHost>
 

--- a/templates/novametadata/config/httpd.conf
+++ b/templates/novametadata/config/httpd.conf
@@ -38,7 +38,9 @@ LogLevel info
   WSGIProcessGroup nova-metadata
   WSGIApplicationGroup %{GLOBAL}
   WSGIPassAuthorization On
-  WSGIDaemonProcess nova-metadata processes=1 threads=1 user=nova group=nova display-name=nova-metadata-api
+  ## In general we want nova-metadata to scale via k8s replicas but we need
+  ## two processes per replica to always has a room for a healthecheck query
+  WSGIDaemonProcess nova-metadata processes=2 threads=1 user=nova group=nova display-name=nova-metadata-api
   WSGIScriptAlias / /usr/bin/nova-metadata-wsgi
 </VirtualHost>
 


### PR DESCRIPTION
We want our services to be scaled by pod replicas but we still need two
processes per API pods to always have a room for a healthcheck API
query.
