### PR TITLE
[envtest]Cover ServiceAccount usage

### DIFF
--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -49,7 +49,7 @@ func GetDefaultNovaAPISpec(novaNames NovaNames) map[string]interface{} {
 		"cell0DatabaseHostname": "nova-cell0-db-hostname",
 		"keystoneAuthURL":       "keystone-auth-url",
 		"containerImage":        ContainerImage,
-		"serviceAccount":        "nova",
+		"serviceAccount":        "nova-sa",
 		"registeredCells":       map[string]string{},
 	}
 }
@@ -164,7 +164,7 @@ func GetDefaultNovaConductorSpec(cell CellNames) map[string]interface{} {
 		"secret":              cell.InternalCellSecretName.Name,
 		"containerImage":      ContainerImage,
 		"keystoneAuthURL":     "keystone-auth-url",
-		"serviceAccount":      "nova",
+		"serviceAccount":      "nova-sa",
 		"customServiceConfig": "foo=bar",
 	}
 }
@@ -284,7 +284,7 @@ func GetDefaultNovaSchedulerSpec(novaNames NovaNames) map[string]interface{} {
 		"cell0DatabaseHostname": "nova-cell0-db-hostname",
 		"keystoneAuthURL":       "keystone-auth-url",
 		"containerImage":        ContainerImage,
-		"serviceAccount":        "nova",
+		"serviceAccount":        "nova-sa",
 		"registeredCells":       map[string]string{},
 	}
 }
@@ -610,7 +610,7 @@ func GetDefaultNovaMetadataSpec(secretName types.NamespacedName) map[string]inte
 		"cellDatabaseHostname": "nova-cell-db-hostname",
 		"containerImage":       ContainerImage,
 		"keystoneAuthURL":      "keystone-auth-url",
-		"serviceAccount":       "nova",
+		"serviceAccount":       "nova-sa",
 	}
 }
 
@@ -654,7 +654,7 @@ func GetDefaultNovaNoVNCProxySpec(cell CellNames) map[string]interface{} {
 		"cellDatabaseHostname": "nova-cell-db-hostname",
 		"containerImage":       ContainerImage,
 		"keystoneAuthURL":      "keystone-auth-url",
-		"serviceAccount":       "nova",
+		"serviceAccount":       "nova-sa",
 		"cellName":             cell.CellName,
 	}
 }

--- a/test/functional/nova_controller_test.go
+++ b/test/functional/nova_controller_test.go
@@ -263,6 +263,10 @@ var _ = Describe("Nova controller", func() {
 				corev1.ConditionTrue,
 			)
 
+			mappingJob := th.GetJob(cell0.CellMappingJobName)
+			Expect(mappingJob.Spec.Template.Spec.ServiceAccountName).To(
+				Equal(novaNames.ServiceAccountName.Name))
+
 			th.SimulateJobSuccess(cell0.CellMappingJobName)
 
 			// TODO(bogdando): move to CellNames.MappingJob*

--- a/test/functional/nova_metadata_controller_test.go
+++ b/test/functional/nova_metadata_controller_test.go
@@ -211,6 +211,7 @@ var _ = Describe("NovaMetadata controller", func() {
 				)
 
 				ss := th.GetStatefulSet(novaNames.MetadataStatefulSetName)
+				Expect(ss.Spec.Template.Spec.ServiceAccountName).To(Equal("nova-sa"))
 				Expect(int(*ss.Spec.Replicas)).To(Equal(1))
 				Expect(ss.Spec.Template.Spec.Volumes).To(HaveLen(2))
 				Expect(ss.Spec.Template.Spec.Containers).To(HaveLen(2))

--- a/test/functional/nova_novncproxy_test.go
+++ b/test/functional/nova_novncproxy_test.go
@@ -204,6 +204,7 @@ var _ = Describe("NovaNoVNCProxy controller", func() {
 				)
 
 				ss := th.GetStatefulSet(cell1.NoVNCProxyStatefulSetName)
+				Expect(ss.Spec.Template.Spec.ServiceAccountName).To(Equal("nova-sa"))
 				Expect(int(*ss.Spec.Replicas)).To(Equal(1))
 				Expect(ss.Spec.Template.Spec.Volumes).To(HaveLen(2))
 				Expect(ss.Spec.Template.Spec.Containers).To(HaveLen(2))

--- a/test/functional/nova_scheduler_test.go
+++ b/test/functional/nova_scheduler_test.go
@@ -206,6 +206,7 @@ var _ = Describe("NovaScheduler controller", func() {
 			)
 
 			ss := th.GetStatefulSet(novaNames.SchedulerStatefulSetName)
+			Expect(ss.Spec.Template.Spec.ServiceAccountName).To(Equal("nova-sa"))
 			Expect(int(*ss.Spec.Replicas)).To(Equal(1))
 			Expect(ss.Spec.Template.Spec.Volumes).To(HaveLen(1))
 			Expect(ss.Spec.Template.Spec.Containers).To(HaveLen(1))

--- a/test/functional/novaapi_controller_test.go
+++ b/test/functional/novaapi_controller_test.go
@@ -230,6 +230,7 @@ var _ = Describe("NovaAPI controller", func() {
 			)
 
 			ss := th.GetStatefulSet(novaNames.APIStatefulSetName)
+			Expect(ss.Spec.Template.Spec.ServiceAccountName).To(Equal("nova-sa"))
 			Expect(int(*ss.Spec.Replicas)).To(Equal(1))
 			Expect(ss.Spec.Template.Spec.Volumes).To(HaveLen(2))
 			Expect(ss.Spec.Template.Spec.Containers).To(HaveLen(2))

--- a/test/functional/novaconductor_controller_test.go
+++ b/test/functional/novaconductor_controller_test.go
@@ -218,6 +218,7 @@ var _ = Describe("NovaConductor controller", func() {
 				condition.DBSyncReadyRunningMessage,
 			)
 			job := th.GetJob(cell0.DBSyncJobName)
+			Expect(job.Spec.Template.Spec.ServiceAccountName).To(Equal("nova-sa"))
 			Expect(job.Spec.Template.Spec.Volumes).To(HaveLen(2))
 			Expect(job.Spec.Template.Spec.InitContainers).To(HaveLen(0))
 			Expect(job.Spec.Template.Spec.Containers).To(HaveLen(1))
@@ -284,6 +285,7 @@ var _ = Describe("NovaConductor controller", func() {
 					corev1.ConditionFalse,
 				)
 				ss := th.GetStatefulSet(cell0.ConductorStatefulSetName)
+				Expect(ss.Spec.Template.Spec.ServiceAccountName).To(Equal("nova-sa"))
 				Expect(ss.Spec.Template.Spec.Containers).To(HaveLen(1))
 				container := ss.Spec.Template.Spec.Containers[0]
 				Expect(container.LivenessProbe.Exec.Command).To(


### PR DESCRIPTION
When the separate nova ServiceAccount is added in
e920cedd51414875c94505d631a5c64711f6e547 test coverage was not added to ensure the ServiceAccount is passed to the StatefulSets and Jobs created by the controller. This is now added.