### PR TITLE
enforce service user token role

### DIFF
--- a/templates/nova.conf
+++ b/templates/nova.conf
@@ -193,6 +193,10 @@ username = {{ .nova_keystone_user }}
 password = {{ .nova_keystone_password }}
 cafile = {{ .openstack_cacert }}
 region_name = {{ .openstack_region_name }}
+# This is part of hardening related to CVE-2023-2088
+# https://docs.openstack.org/nova/latest/configuration/config.html#keystone_authtoken.service_token_roles_required
+# when enabled the service token user must have the service role to be considered valid.
+service_token_roles_required = true
 
 [placement]
 auth_url =  {{ .keystone_internal_url }}

--- a/test/functional/novaapi_controller_test.go
+++ b/test/functional/novaapi_controller_test.go
@@ -171,6 +171,12 @@ var _ = Describe("NovaAPI controller", func() {
 				// service_user configuration to work to address Bug: #2004555
 				Expect(configData).Should(ContainSubstring("[service_user]"))
 				Expect(configData).Should(ContainSubstring("password = service-password"))
+				// as part of additional hardening we now require service_token_roles_required
+				// to be set to true to ensure that the service token is not just a user token
+				// nova does not currently rely on the service token for enforcement of elevated
+				// privileges but this is a good practice to follow and might be required in the
+				// future
+				Expect(configData).Should(ContainSubstring("service_token_roles_required = true"))
 				Expect(configData).Should(ContainSubstring("enabled_apis=osapi_compute"))
 				Expect(configData).Should(ContainSubstring("osapi_compute_workers=1"))
 				Expect(configDataMap.Data).Should(HaveKey("02-nova-override.conf"))


### PR DESCRIPTION
This change make the service role required
for service token recieved by nova be defining
[keystone_authtoken]/service_token_roles_required=true

Closes: [OSPRH-228](https://issues.redhat.com//browse/OSPRH-228)
