### PR TITLE
Fix neutron config format

### DIFF
--- a/templates/neutron-metadata.conf
+++ b/templates/neutron-metadata.conf
@@ -1,3 +1,5 @@
 [DEFAULT]
 nova_metadata_host = {{.nova_metadata_host}}
+nova_metadata_port = {{.nova_metadata_port}}
+nova_metadata_protocol = {{.nova_metadata_protocol}}
 metadata_proxy_shared_secret = {{.metadata_proxy_shared_secret}}

--- a/test/functional/nova_metadata_controller_test.go
+++ b/test/functional/nova_metadata_controller_test.go
@@ -286,11 +286,13 @@ var _ = Describe("NovaMetadata controller", func() {
 				Expect(configData).To(
 					ContainSubstring(
 						fmt.Sprintf(
-							"nova_metadata_host = http://nova-metadata-internal.%s.svc:8775",
+							"nova_metadata_host = nova-metadata-internal.%s.svc",
 							novaNames.MetadataName.Namespace,
 						),
 					),
 				)
+				Expect(configData).To(ContainSubstring("nova_metadata_port = 8775"))
+				Expect(configData).To(ContainSubstring("nova_metadata_protocol = http"))
 				Expect(configData).To(ContainSubstring("metadata_proxy_shared_secret = metadata-secret"))
 
 				metadata := GetNovaMetadata(novaNames.MetadataName)
@@ -376,11 +378,13 @@ var _ = Describe("NovaMetadata controller", func() {
 			Expect(configData).To(
 				ContainSubstring(
 					fmt.Sprintf(
-						"nova_metadata_host = http://nova-metadata-cell1-internal.%s.svc:8775",
+						"nova_metadata_host = nova-metadata-cell1-internal.%s.svc",
 						cell1.MetadataName.Namespace,
 					),
 				),
 			)
+			Expect(configData).To(ContainSubstring("nova_metadata_port = 8775"))
+			Expect(configData).To(ContainSubstring("nova_metadata_protocol = http"))
 			Expect(configData).To(ContainSubstring("metadata_proxy_shared_secret = metadata-secret"))
 
 			metadata := GetNovaMetadata(cell1.MetadataName)


### PR DESCRIPTION
The nova_metadata_host was set to a full URL but that only support hostname. So the config generation changed to split the URL and fill nova_metadata_host, nova_metadata_port, and nova_metadata_protocol accordingly.

Closes: #532