### PR TITLE
update kuttl job to split out crc

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -26,8 +26,9 @@
       deploy openstack and then test it. This job will fetch the job
       output directory so child jobs can just add additional logs to that
       in there post-playbooks.
-    parent: cifmw-base-crc-openstack
+    parent: cifmw-podified-multinode-edpm-base-crc
     abstract: true
+    attempts: 1
     dependencies: ["nova-operator-content-provider"]
     required-projects:
       - github.com/openstack-k8s-operators/ci-framework
@@ -37,7 +38,7 @@
     roles:
       - zuul: github.com/openstack-k8s-operators/ci-framework
     pre-run:
-      - ci/nova-operator-base/playbooks/pre.yaml
+      - ci/nova-operator-base/playbooks/pre-wrapper.yaml
     post-run:
       - ci/nova-operator-base/playbooks/collect-logs.yaml
 
@@ -73,8 +74,46 @@
       - ci/nova-operator-kuttl/playbooks/deploy-deps.yaml
     run:
       - ci/nova-operator-kuttl/playbooks/run-kuttl.yaml
+    nodeset:
+      nodes:
+        - name: controller
+          label: cloud-centos-9-stream-tripleo-vexxhost
+        - name: crc
+          label: coreos-crc-extracted-xxl
     vars:
       collection_namespace_override: "nova-kuttl-default"
+      zuul_log_collection: true
+    extra-vars:
+      crc_ci_bootstrap_networking:
+        networks:
+          default:
+            range: 192.168.122.0/24
+            mtu: 1500
+          internal-api:
+            vlan: 20
+            range: 172.17.0.0/24
+          storage:
+            vlan: 21
+            range: 172.18.0.0/24
+          tenant:
+            vlan: 22
+            range: 172.19.0.0/24
+        instances:
+          controller:
+            networks:
+              default:
+                ip: 192.168.122.11
+          crc:
+            networks:
+              default:
+                ip: 192.168.122.10
+              internal-api:
+                ip: 172.17.0.5
+              storage:
+                ip: 172.18.0.5
+              tenant:
+                ip: 172.19.0.5
+
 
 - project:
     name: openstack-k8s-operators/nova-operator

--- a/ci/nova-operator-base/ci_fw_vars.yaml
+++ b/ci/nova-operator-base/ci_fw_vars.yaml
@@ -1,0 +1,19 @@
+---
+ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+cifmw_installyamls_repos: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
+cifmw_install_yamls_vars:
+  DATAPLANE_REPO: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/dataplane-operator"
+  STORAGE_CLASS: crc-csi-hostpath-provisioner
+  BMO_SETUP: false
+
+cifmw_openshift_user: "kubeadmin"
+cifmw_openshift_password: "123456789"
+cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
+
+cifmw_openshift_setup_skip_internal_registry: true
+
+# edpm_prepare role vars
+cifmw_operator_build_meta_name: "openstack-operator"
+cifmw_edpm_prepare_skip_crc_storage_creation: true
+
+cifmw_rhol_crc_use_installyamls: true

--- a/ci/nova-operator-base/playbooks/collect-logs.yaml
+++ b/ci/nova-operator-base/playbooks/collect-logs.yaml
@@ -1,14 +1,4 @@
 ---
-- hosts: all
-  name: Create zuul-output log dir
-  gather_facts: false
-  tasks:
-    - name: Create log dir
-      ansible.builtin.file:
-        path: "{{ ansible_user_dir }}/zuul-output/logs"
-        state: directory
-        mode: "0755"
-
 - hosts: controller
   name: Collect logs on the controller
   gather_facts: false
@@ -20,8 +10,10 @@
         path: "{{ ansible_user_dir }}/zuul-output/logs/controller"
         state: directory
         mode: "0755"
-
     - name: Collect general openshift cr info
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+        PATH: "{{ cifmw_path | default(ansible_env.PATH) }}"
       ansible.builtin.shell: |
         source ~/.bashrc
         collection_namespace_dir="{{ ansible_user_dir }}/zuul-output/logs/controller/{{collection_namespace}}"

--- a/ci/nova-operator-base/playbooks/pre-wrapper.yaml
+++ b/ci/nova-operator-base/playbooks/pre-wrapper.yaml
@@ -1,0 +1,33 @@
+- name: "Run ci/nova-operator-base/playbooks/pre.yml"
+  hosts: controller
+  gather_facts: true
+  vars:
+    nova_operator_basedir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/nova-operator"
+    ansible_playbook_command: "ansible-playbook -vv"
+    ansible_playbook_command_suffix: >-
+      -e @scenarios/centos-9/base.yml
+      -e @{{nova_operator_basedir}}/ci/nova-operator-base/ci_fw_vars.yaml
+      {%- if cifmw_extras is defined %}
+      {%-   for extra_vars in cifmw_extras %}
+      -e "{{   extra_vars }}"
+      {%-   endfor %}
+      {%- endif %}
+      -e @scenarios/centos-9/zuul_inventory.yml
+    ci_framework_playbooks_path: "{{[ ansible_user_dir,
+              zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir,
+              'ci_framework','playbooks'] | ansible.builtin.path_join }}"
+    pre_playbook: "{{nova_operator_basedir}}/ci/nova-operator-base/playbooks/pre.yaml"
+    controller_logs_dir: "{{ ansible_user_dir }}/zuul-output/logs/controller"
+  tasks:
+    - name: Create log dir
+      ansible.builtin.file:
+        path: "{{ controller_logs_dir }}"
+        state: directory
+        mode: "0755"
+    - name: Run pre playbook
+      ansible.builtin.shell:
+        executable: /bin/bash
+        chdir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework"
+        cmd: >-
+          {{ansible_playbook_command}} {{ansible_playbook_command_suffix}} {{pre_playbook}}
+          2>&1 | tee {{ controller_logs_dir }}/nova-operator-base_pre.log

--- a/ci/nova-operator-base/playbooks/pre.yaml
+++ b/ci/nova-operator-base/playbooks/pre.yaml
@@ -1,41 +1,112 @@
 ---
-- hosts: controller
-  name: Deploy Openstack Operators
-  vars:
-    install_yamls_basedir: "{{ local_install_yamls_basedir | default(ansible_user_dir + '/src/github.com/openstack-k8s-operators/install_yamls')}}"
+- name: Run ci_framework bootstrap playbook
+  ansible.builtin.import_playbook: >-
+      {{[ ansible_user_dir,
+      zuul.projects["github.com/openstack-k8s-operators/ci-framework"].src_dir,
+      "ci_framework/playbooks/01-bootstrap.yml"] | ansible.builtin.path_join}}
+
+- hosts: "{{ cifmw_target_host | default('localhost') }}"
+  name: install dev tools
   tasks:
-    - name: Add crc creds
+    - name: Download install_yamls deps
       ansible.builtin.include_role:
-        name: rhol_crc
-        tasks_from: add_crc_creds
-    - name: install tools
-      ansible.builtin.command:
-        cmd: "make download_tools"
-        chdir: "{{install_yamls_basedir}}/devsetup"
+        name: 'install_yamls_makes'
+        tasks_from: 'make_download_tools'
+
+- name: Run ci_framework infra playbook
+  ansible.builtin.import_playbook: >-
+      {{[ ansible_user_dir,
+      zuul.projects["github.com/openstack-k8s-operators/ci-framework"].src_dir,
+      "ci_framework/playbooks/02-infra.yml"] | ansible.builtin.path_join}}
+
+- name: Build dataset hook
+  hosts: localhost
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: Load parameters
+      ansible.builtin.include_vars:
+        dir: "{{ item }}"
+      loop:
+        - "{{ cifmw_basedir }}/artifacts/parameters"
+        - "/etc/ci/env"
+      loop_control:
+        label: "{{ item }}"
+
+    - name: Check we have some compute in inventory
+      ansible.builtin.set_fact:
+        has_compute: >-
+          {% set ns = namespace(found=false) -%}
+          {% for host in hostvars.keys() -%}
+          {%   if host is match('^compute.*') -%}
+          {%     set ns.found = true -%}
+          {%   endif -%}
+          {% endfor -%}
+          {{ ns.found }}
+
+    - name: Ensure that the isolated net was configured for crc
+      ansible.builtin.assert:
+        that:
+          - crc_ci_bootstrap_networks_out is defined
+          - "'crc' in crc_ci_bootstrap_networks_out"
+          - "'default' in crc_ci_bootstrap_networks_out['crc']"
+
+    - name: Ensure we have needed bits for compute when needed
+      when:
+        - has_compute | bool
+      ansible.builtin.assert:
+        that:
+          - "'compute' in crc_ci_bootstrap_networks_out"
+          - "'default' in crc_ci_bootstrap_networks_out['compute']"
+
+    - name: Set facts for further usage within the framework
+      ansible.builtin.set_fact:
+        cifmw_edpm_prepare_extra_vars:
+          NNCP_INTERFACE: "{{ crc_ci_bootstrap_networks_out.crc.default.iface }}"
+          NETWORK_MTU: "{{ crc_ci_bootstrap_networks_out.crc.default.mtu }}"
+
+- hosts: "{{ cifmw_target_host | default('localhost') }}"
+  name: Deploy Openstack Operators
+  tasks:
+    - name: Set install_yamls Makefile environment variables
+      vars:
+        operators_build_output: "{{ (cifmw_operator_build_output | default({'operators':{}})).operators }}"
+      ansible.builtin.set_fact:
+        cifmw_edpm_prepare_common_env: >-
+          {{
+            cifmw_install_yamls_environment |
+            combine({'PATH': cifmw_path}) |
+            combine(cifmw_edpm_prepare_extra_vars | default({}))
+          }}
+        cifmw_edpm_prepare_make_openstack_env: |
+          OPENSTACK_IMG: "{{ cifmw_operator_build_output.operators['openstack-operator']['image_catalog'] | default(omit) }}"
+          OPENSTACK_BUNDLE_IMG: "{{ cifmw_operator_build_output.operators['openstack-operator']['image_bundle'] | default(omit) }}"
+          NOVA_IMG: "{{ cifmw_operator_build_output.operators['nova-operator']['image_catalog'] | default(omit) }}"
+        cifmw_edpm_prepare_operators_build_output: "{{ operators_build_output }}"
     - name: Deploy openstack Operators
       block:
         - name: detect if openstack operator is installed
+          environment:
+            KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+            PATH: "{{ cifmw_path | default(ansible_env.PATH) }}"
           ansible.builtin.command:
             cmd: "oc get sub --ignore-not-found=true -n openstack-operators -o name openstack-operator"
           ignore_errors: true
           register: openstack_operator_subscription
-        - name: add crc default interface
-          when: openstack_operator_subscription.stdout == ""
-          ansible.builtin.command:
-            cmd: "make crc_attach_default_interface"
-            chdir: "{{install_yamls_basedir}}/devsetup"
         - name: Install openstack operator
           when: openstack_operator_subscription.stdout == ""
-          ansible.builtin.command:
-            cmd: "make openstack"
-            chdir: "{{install_yamls_basedir}}"
-            creates: "{{install_yamls_basedir}}/out/openstack-operator/openstack/op/*"
-          environment:
-            OPENSTACK_IMG: "{{ cifmw_operator_build_output.operators['openstack-operator']['image_catalog'] | default(omit) }}"
-            OPENSTACK_BUNDLE_IMG: "{{ cifmw_operator_build_output.operators['openstack-operator']['image_bundle'] | default(omit) }}"
-            NOVA_IMG: "{{ cifmw_operator_build_output.operators['nova-operator']['image_catalog'] | default(omit) }}"
+          vars:
+            make_openstack_env: "{{ cifmw_edpm_prepare_common_env |
+              combine(cifmw_edpm_prepare_make_openstack_env | from_yaml)}}"
+            make_openstack_dryrun: "{{ cifmw_edpm_prepare_dry_run }}"
+          ansible.builtin.include_role:
+            name: 'install_yamls_makes'
+            tasks_from: 'make_openstack'
         - name: Wait for OpenStack subscription creation
           when: openstack_operator_subscription.stdout == ""
+          environment:
+            KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+            PATH: "{{ cifmw_path | default(ansible_env.PATH) }}"
           ansible.builtin.command:
             cmd: >-
               oc get sub openstack-operator
@@ -47,8 +118,17 @@
           delay: 10
         - name: Wait for OpenStack operator to get installed
           when: openstack_operator_subscription.stdout == ""
+          environment:
+            KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+            PATH: "{{ cifmw_path | default(ansible_env.PATH) }}"
           ansible.builtin.command:
             cmd: >-
               oc wait InstallPlan {{ cifmw_edpm_prepare_wait_installplan_out.stdout }}
               --namespace=openstack-operators
               --for=jsonpath='{.status.phase}'=Complete --timeout=20m
+        - name: Update OpenStack Services containers Env
+          when: cifmw_edpm_prepare_update_os_containers | bool
+          vars:
+            cifmw_set_openstack_containers_extra_vars: "{{ cifmw_edpm_prepare_extra_vars }}"
+          ansible.builtin.include_role:
+            name: set_openstack_containers

--- a/ci/nova-operator-compute-kit/playbooks/deploy-openstack.yaml
+++ b/ci/nova-operator-compute-kit/playbooks/deploy-openstack.yaml
@@ -9,10 +9,16 @@
     nova_operator_basedir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/nova-operator"
   tasks:
     - name: Deploy OpenStack
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+        PATH: "{{ cifmw_path | default(ansible_env.PATH) }}"
       ansible.builtin.command: "oc apply -k {{ nova_operator_basedir }}/ci/nova-operator-compute-kit/topology/ci"
       changed_when: true
 
     - name: Make sure Openstack CR is ready
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+        PATH: "{{ cifmw_path | default(ansible_env.PATH) }}"
       ansible.builtin.command: oc wait OpenstackControlPlane openstack --for condition=Ready --timeout=180s
       changed_when: false
       retries: 3

--- a/ci/nova-operator-compute-kit/playbooks/tempest.yaml
+++ b/ci/nova-operator-compute-kit/playbooks/tempest.yaml
@@ -5,14 +5,23 @@
     nova_operator_basedir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/nova-operator"
   tasks:
     - name: Use OpenStack Namespace
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+        PATH: "{{ cifmw_path | default(ansible_env.PATH) }}"
       ansible.builtin.command: oc project openstack
       changed_when: false
 
     - name: Deploy OpenStack
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+        PATH: "{{ cifmw_path | default(ansible_env.PATH) }}"
       ansible.builtin.command: "oc apply -k {{ nova_operator_basedir }}/ci/nova-operator-compute-kit/topology/tempest"
       changed_when: true
 
     - name: Wait for tempest-worker pod to start
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+        PATH: "{{ cifmw_path | default(ansible_env.PATH) }}"
       ansible.builtin.command: oc wait pod tempest-worker --for condition=Ready --timeout=120s
       changed_when: false
 
@@ -23,6 +32,9 @@
         mode: "0755"
 
     - name: Run tempest tests
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+        PATH: "{{ cifmw_path | default(ansible_env.PATH) }}"
       ansible.builtin.command: "oc rsh pod/tempest-worker /var/lib/tempest/run_tempest.sh"
       register: tempest_output
       changed_when: true

--- a/ci/nova-operator-kuttl/playbooks/deploy-deps.yaml
+++ b/ci/nova-operator-kuttl/playbooks/deploy-deps.yaml
@@ -4,6 +4,9 @@
     nova_operator_basedir: "{{local_nova_operator_basedir | default(ansible_user_dir + '/src/github.com/openstack-k8s-operators/nova-operator')}}"
   tasks:
     - name: install kuttl test_suite dependencies
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+        PATH: "{{ cifmw_path | default(ansible_env.PATH) }}"
       ansible.builtin.command:
         cmd: make kuttl-test-prep
         chdir: "{{nova_operator_basedir}}"

--- a/ci/nova-operator-kuttl/playbooks/run-kuttl.yaml
+++ b/ci/nova-operator-kuttl/playbooks/run-kuttl.yaml
@@ -4,6 +4,9 @@
     kuttl_log_dir: "{{local_log_dir | default(ansible_user_dir + '/zuul-output/logs/controller')}}"
   tasks:
     - name: install kuttl test_suite dependencies
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+        PATH: "{{ cifmw_path | default(ansible_env.PATH) }}"
       ansible.builtin.command:
         cmd: make kuttl-test-run
         chdir: "{{nova_operator_basedir}}"


### PR DESCRIPTION
this change updates nova-operator-base to use
cifmw-podified-multinode-edpm-base-crc as the parent job
and modifes the nova-operator-kuttl job to modify the nodeset
to disable the extra compute vm.
