### PR TITLE
Enable multipath for volume attachments

### DIFF
--- a/templates/nova.conf
+++ b/templates/nova.conf
@@ -172,6 +172,7 @@ images_type=qcow2
 rx_queue_size=512
 tx_queue_size=512
 swtpm_enabled=True
+volume_use_multipath=true
 {{end}}
 
 {{if (index . "cell_db_address")}}


### PR DESCRIPTION
Configure nova-compute so that it always requests (via os-brick) volume attachments provide multiple paths whenever possible. Multiple paths are requested, but not required. An attachment request can succeed, even when only a single path can be supplied.