### PR TITLE
[envtest]Use database helpers from mariadb-operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.1.1-0.20230927082538-4f614f333d17
 	github.com/openstack-k8s-operators/lib-common/modules/database v0.1.1-0.20230927082538-4f614f333d17
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.1.2-0.20230927082538-4f614f333d17
-	github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230918111825-8999b3b2dc3c
+	github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230928103342-106bb85983f4
 	github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20221209164002-f9e6b9363961
 	go.uber.org/zap v1.26.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -248,8 +248,8 @@ github.com/openstack-k8s-operators/lib-common/modules/openstack v0.1.1-0.2023092
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.1.1-0.20230927082538-4f614f333d17/go.mod h1:+iJZo5alCeOGD/524hWWdlINA6zqY+MjfWT7cDcbvBE=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.1.2-0.20230927082538-4f614f333d17 h1:zJguNin+9IwRnGKy1A7ranxASKO1vTvWxoXwkCz8MWw=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.1.2-0.20230927082538-4f614f333d17/go.mod h1:YOFHrNK/QqCvZUPlDJYmDyaCkbKIB98V04uyofiC9a8=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230918111825-8999b3b2dc3c h1:9R8T1WRwuPS5KMfsQWxAMSGPuJrGMJ7bODKK9dirhHA=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230918111825-8999b3b2dc3c/go.mod h1:xXHF/R/L0XamRHR/UkzlgzSTocBQ6GSQ2U16Q9Mf/bA=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230928103342-106bb85983f4 h1:37bbJ9XzpCvB+zZckdweJEEH3pqM6Q88OHH8eHFvlpI=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230928103342-106bb85983f4/go.mod h1:xhiz5wFdKWwVM7BF/VYon4TT3NuUPXp/Pyn2hWcp0CE=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/test/functional/nova_controller_test.go
+++ b/test/functional/nova_controller_test.go
@@ -41,8 +41,8 @@ var _ = Describe("Nova controller", func() {
 					},
 				))
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(
 					novaNames.NovaName.Namespace,
 					"openstack",
 					corev1.ServiceSpec{
@@ -81,8 +81,8 @@ var _ = Describe("Nova controller", func() {
 			DeferCleanup(
 				k8sClient.Delete, ctx, CreateNovaMessageBusSecret(cell0))
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(
 					novaNames.NovaName.Namespace,
 					"openstack",
 					corev1.ServiceSpec{
@@ -161,9 +161,9 @@ var _ = Describe("Nova controller", func() {
 				novav1.NovaAPIDBReadyCondition,
 				corev1.ConditionFalse,
 			)
-			th.GetMariaDBDatabase(novaNames.APIMariaDBDatabaseName)
+			mariadb.GetMariaDBDatabase(novaNames.APIMariaDBDatabaseName)
 
-			th.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
 			th.ExpectCondition(
 				novaNames.NovaName,
 				ConditionGetterFunc(NovaConditionGetter),
@@ -199,9 +199,9 @@ var _ = Describe("Nova controller", func() {
 				novav1.NovaAllCellsDBReadyCondition,
 				corev1.ConditionFalse,
 			)
-			th.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
-			th.GetMariaDBDatabase(cell0.MariaDBDatabaseName)
-			th.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
+			mariadb.GetMariaDBDatabase(cell0.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
 			th.ExpectCondition(
 				novaNames.NovaName,
 				ConditionGetterFunc(NovaConditionGetter),
@@ -212,8 +212,8 @@ var _ = Describe("Nova controller", func() {
 
 		It("creates cell0 NovaCell", func() {
 			keystone.SimulateKeystoneServiceReady(novaNames.KeystoneServiceName)
-			th.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
-			th.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
 			th.SimulateTransportURLReady(cell0.TransportURLName)
 			// assert that cell related CRs are created
 			cell := GetNovaCell(cell0.CellCRName)
@@ -317,8 +317,8 @@ var _ = Describe("Nova controller", func() {
 
 		It("creates an internal Secret for the top level services", func() {
 			keystone.SimulateKeystoneServiceReady(novaNames.KeystoneServiceName)
-			th.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
-			th.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
 			th.SimulateTransportURLReady(cell0.TransportURLName)
 			th.SimulateJobSuccess(cell0.DBSyncJobName)
 			th.SimulateStatefulSetReplicaReady(cell0.ConductorStatefulSetName)
@@ -344,8 +344,8 @@ var _ = Describe("Nova controller", func() {
 
 		It("creates NovaAPI", func() {
 			keystone.SimulateKeystoneServiceReady(novaNames.KeystoneServiceName)
-			th.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
-			th.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
 			th.SimulateTransportURLReady(cell0.TransportURLName)
 			th.SimulateJobSuccess(cell0.DBSyncJobName)
 			th.SimulateStatefulSetReplicaReady(cell0.ConductorStatefulSetName)
@@ -383,8 +383,8 @@ var _ = Describe("Nova controller", func() {
 
 		It("creates NovaScheduler", func() {
 			keystone.SimulateKeystoneServiceReady(novaNames.KeystoneServiceName)
-			th.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
-			th.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
 			th.SimulateTransportURLReady(cell0.TransportURLName)
 			th.SimulateJobSuccess(cell0.DBSyncJobName)
 			th.SimulateStatefulSetReplicaReady(cell0.ConductorStatefulSetName)
@@ -422,8 +422,8 @@ var _ = Describe("Nova controller", func() {
 
 		It("creates NovaMetadata", func() {
 			keystone.SimulateKeystoneServiceReady(novaNames.KeystoneServiceName)
-			th.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
-			th.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
 			th.SimulateTransportURLReady(cell0.TransportURLName)
 			th.SimulateJobSuccess(cell0.DBSyncJobName)
 			th.SimulateStatefulSetReplicaReady(cell0.ConductorStatefulSetName)
@@ -467,8 +467,8 @@ var _ = Describe("Nova controller", func() {
 			DeferCleanup(
 				k8sClient.Delete, ctx, CreateNovaMessageBusSecret(cell0))
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(
 					novaNames.NovaName.Namespace,
 					"openstack",
 					corev1.ServiceSpec{
@@ -481,8 +481,8 @@ var _ = Describe("Nova controller", func() {
 			DeferCleanup(th.DeleteInstance, CreateNovaWithCell0(novaNames.NovaName))
 
 			keystone.SimulateKeystoneServiceReady(novaNames.KeystoneServiceName)
-			th.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
-			th.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
 			th.SimulateTransportURLReady(cell0.TransportURLName)
 			GetNovaCell(cell0.CellCRName)
 			GetNovaConductor(cell0.ConductorName)
@@ -533,8 +533,8 @@ var _ = Describe("Nova controller", func() {
 			DeferCleanup(
 				k8sClient.Delete, ctx, CreateNovaMessageBusSecret(cell0))
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(
 					novaNames.NovaName.Namespace,
 					"openstack",
 					corev1.ServiceSpec{
@@ -547,8 +547,8 @@ var _ = Describe("Nova controller", func() {
 			DeferCleanup(th.DeleteInstance, CreateNovaWithCell0(novaNames.NovaName))
 
 			keystone.SimulateKeystoneServiceReady(novaNames.KeystoneServiceName)
-			th.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
-			th.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
 			th.SimulateTransportURLReady(cell0.TransportURLName)
 			th.SimulateJobSuccess(cell0.DBSyncJobName)
 			th.SimulateStatefulSetReplicaReady(cell0.ConductorStatefulSetName)
@@ -581,8 +581,8 @@ var _ = Describe("Nova controller", func() {
 				k8sClient.Delete, ctx, CreateNovaMessageBusSecret(cell0))
 
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(
 					cell0.MariaDBDatabaseName.Namespace,
 					cell0.MariaDBDatabaseName.Name,
 					corev1.ServiceSpec{
@@ -591,8 +591,8 @@ var _ = Describe("Nova controller", func() {
 				),
 			)
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(
 					novaNames.APIMariaDBDatabaseName.Namespace,
 					novaNames.APIMariaDBDatabaseName.Name,
 					corev1.ServiceSpec{
@@ -613,8 +613,8 @@ var _ = Describe("Nova controller", func() {
 
 		It("uses the correct hostnames to access the different DB services", func() {
 			keystone.SimulateKeystoneServiceReady(novaNames.KeystoneServiceName)
-			th.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
-			th.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
 			th.SimulateTransportURLReady(cell0.TransportURLName)
 
 			cell0DBSync := th.GetJob(cell0.DBSyncJobName)
@@ -725,8 +725,8 @@ var _ = Describe("Nova controller", func() {
 			DeferCleanup(
 				k8sClient.Delete, ctx, CreateNovaMessageBusSecret(cell0))
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(
 					novaNames.NovaName.Namespace,
 					"openstack",
 					corev1.ServiceSpec{
@@ -759,16 +759,16 @@ var _ = Describe("Nova controller", func() {
 		It("removes the finalizers from the nova dbs", func() {
 			keystone.SimulateKeystoneServiceReady(novaNames.KeystoneServiceName)
 
-			apiDB := th.GetMariaDBDatabase(novaNames.APIMariaDBDatabaseName)
+			apiDB := mariadb.GetMariaDBDatabase(novaNames.APIMariaDBDatabaseName)
 			Expect(apiDB.Finalizers).To(ContainElement("Nova"))
-			cell0DB := th.GetMariaDBDatabase(cell0.MariaDBDatabaseName)
+			cell0DB := mariadb.GetMariaDBDatabase(cell0.MariaDBDatabaseName)
 			Expect(cell0DB.Finalizers).To(ContainElement("Nova"))
 
 			th.DeleteInstance(GetNova(novaNames.NovaName))
 
-			apiDB = th.GetMariaDBDatabase(novaNames.APIMariaDBDatabaseName)
+			apiDB = mariadb.GetMariaDBDatabase(novaNames.APIMariaDBDatabaseName)
 			Expect(apiDB.Finalizers).NotTo(ContainElement("Nova"))
-			cell0DB = th.GetMariaDBDatabase(cell0.MariaDBDatabaseName)
+			cell0DB = mariadb.GetMariaDBDatabase(cell0.MariaDBDatabaseName)
 			Expect(cell0DB.Finalizers).NotTo(ContainElement("Nova"))
 		})
 	})
@@ -780,8 +780,8 @@ var _ = Describe("Nova controller", func() {
 			DeferCleanup(
 				k8sClient.Delete, ctx, CreateNovaMessageBusSecret(cell0))
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(
 					novaNames.NovaName.Namespace,
 					"openstack",
 					corev1.ServiceSpec{
@@ -828,8 +828,8 @@ var _ = Describe("Nova controller", func() {
 			DeferCleanup(th.DeleteInstance, CreateNova(novaNames.NovaName, rawSpec))
 
 			keystone.SimulateKeystoneServiceReady(novaNames.KeystoneServiceName)
-			th.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
-			th.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
 			th.SimulateTransportURLReady(cell0.TransportURLName)
 			th.SimulateJobSuccess(cell0.DBSyncJobName)
 		})

--- a/test/functional/nova_multicell_test.go
+++ b/test/functional/nova_multicell_test.go
@@ -39,10 +39,10 @@ var _ = Describe("Nova multicell", func() {
 			DeferCleanup(k8sClient.Delete, ctx, CreateNovaMessageBusSecret(cell2))
 
 			serviceSpec := corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 3306}}}
-			DeferCleanup(th.DeleteDBService, th.CreateDBService(novaNames.APIMariaDBDatabaseName.Namespace, novaNames.APIMariaDBDatabaseName.Name, serviceSpec))
-			DeferCleanup(th.DeleteDBService, th.CreateDBService(cell0.MariaDBDatabaseName.Namespace, cell0.MariaDBDatabaseName.Name, serviceSpec))
-			DeferCleanup(th.DeleteDBService, th.CreateDBService(cell1.MariaDBDatabaseName.Namespace, cell1.MariaDBDatabaseName.Name, serviceSpec))
-			DeferCleanup(th.DeleteDBService, th.CreateDBService(cell2.MariaDBDatabaseName.Namespace, cell2.MariaDBDatabaseName.Name, serviceSpec))
+			DeferCleanup(mariadb.DeleteDBService, mariadb.CreateDBService(novaNames.APIMariaDBDatabaseName.Namespace, novaNames.APIMariaDBDatabaseName.Name, serviceSpec))
+			DeferCleanup(mariadb.DeleteDBService, mariadb.CreateDBService(cell0.MariaDBDatabaseName.Namespace, cell0.MariaDBDatabaseName.Name, serviceSpec))
+			DeferCleanup(mariadb.DeleteDBService, mariadb.CreateDBService(cell1.MariaDBDatabaseName.Namespace, cell1.MariaDBDatabaseName.Name, serviceSpec))
+			DeferCleanup(mariadb.DeleteDBService, mariadb.CreateDBService(cell2.MariaDBDatabaseName.Namespace, cell2.MariaDBDatabaseName.Name, serviceSpec))
 
 			spec := GetDefaultNovaSpec()
 			cell0Template := GetDefaultNovaCellTemplate()
@@ -80,8 +80,8 @@ var _ = Describe("Nova multicell", func() {
 		})
 
 		It("creates cell0 NovaCell", func() {
-			th.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
-			th.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
 			th.SimulateTransportURLReady(cell0.TransportURLName)
 
 			th.ExpectCondition(
@@ -142,8 +142,8 @@ var _ = Describe("Nova multicell", func() {
 		})
 
 		It("creates NovaAPI", func() {
-			th.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
-			th.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
 			th.SimulateTransportURLReady(cell0.TransportURLName)
 			th.SimulateJobSuccess(cell0.DBSyncJobName)
 			th.SimulateStatefulSetReplicaReady(cell0.ConductorStatefulSetName)
@@ -191,23 +191,23 @@ var _ = Describe("Nova multicell", func() {
 		})
 
 		It("creates all cell DBs", func() {
-			th.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
 			th.SimulateTransportURLReady(cell0.TransportURLName)
-			th.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
 			th.SimulateJobSuccess(cell0.DBSyncJobName)
 			th.SimulateStatefulSetReplicaReady(cell0.ConductorStatefulSetName)
 			th.SimulateJobSuccess(cell0.CellMappingJobName)
 			th.SimulateStatefulSetReplicaReady(novaNames.APIDeploymentName)
 			keystone.SimulateKeystoneEndpointReady(novaNames.APIKeystoneEndpointName)
 
-			th.SimulateMariaDBDatabaseCompleted(cell1.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(cell1.MariaDBDatabaseName)
 			th.ExpectCondition(
 				novaNames.NovaName,
 				ConditionGetterFunc(NovaConditionGetter),
 				novav1.NovaAllCellsDBReadyCondition,
 				corev1.ConditionFalse,
 			)
-			th.SimulateMariaDBDatabaseCompleted(cell2.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(cell2.MariaDBDatabaseName)
 			th.ExpectCondition(
 				novaNames.NovaName,
 				ConditionGetterFunc(NovaConditionGetter),
@@ -237,15 +237,15 @@ var _ = Describe("Nova multicell", func() {
 		})
 
 		It("creates cell1 NovaCell", func() {
-			th.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
-			th.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
 			th.SimulateTransportURLReady(cell0.TransportURLName)
 			th.SimulateJobSuccess(cell0.DBSyncJobName)
 			th.SimulateStatefulSetReplicaReady(cell0.ConductorStatefulSetName)
 			th.SimulateJobSuccess(cell0.CellMappingJobName)
 			th.SimulateStatefulSetReplicaReady(novaNames.APIDeploymentName)
 			keystone.SimulateKeystoneEndpointReady(novaNames.APIKeystoneEndpointName)
-			th.SimulateMariaDBDatabaseCompleted(cell1.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(cell1.MariaDBDatabaseName)
 			th.SimulateTransportURLReady(cell1.TransportURLName)
 
 			th.ExpectCondition(
@@ -314,8 +314,8 @@ var _ = Describe("Nova multicell", func() {
 			Expect(metadata.Spec.RegisteredCells).To(Equal(nova.Status.RegisteredCells))
 		})
 		It("creates cell2 NovaCell", func() {
-			th.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
-			th.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
 			th.SimulateTransportURLReady(cell0.TransportURLName)
 			th.SimulateJobSuccess(cell0.DBSyncJobName)
 			th.SimulateStatefulSetReplicaReady(cell0.ConductorStatefulSetName)
@@ -324,14 +324,14 @@ var _ = Describe("Nova multicell", func() {
 			keystone.SimulateKeystoneEndpointReady(novaNames.APIKeystoneEndpointName)
 			th.SimulateStatefulSetReplicaReady(novaNames.SchedulerStatefulSetName)
 			th.SimulateStatefulSetReplicaReady(novaNames.MetadataStatefulSetName)
-			th.SimulateMariaDBDatabaseCompleted(cell1.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(cell1.MariaDBDatabaseName)
 			th.SimulateTransportURLReady(cell1.TransportURLName)
 			th.SimulateStatefulSetReplicaReady(cell1.NoVNCProxyStatefulSetName)
 			th.SimulateJobSuccess(cell1.DBSyncJobName)
 			th.SimulateStatefulSetReplicaReady(cell1.ConductorStatefulSetName)
 			th.SimulateJobSuccess(cell1.CellMappingJobName)
 
-			th.SimulateMariaDBDatabaseCompleted(cell2.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(cell2.MariaDBDatabaseName)
 			th.SimulateTransportURLReady(cell2.TransportURLName)
 
 			th.ExpectCondition(
@@ -434,7 +434,7 @@ var _ = Describe("Nova multicell", func() {
 		It("creates cell2 NovaCell even if everything else fails", func() {
 			// Don't simulate any success for any other DBs MQs or Cells
 			// just for cell2
-			th.SimulateMariaDBDatabaseCompleted(cell2.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(cell2.MariaDBDatabaseName)
 			th.SimulateTransportURLReady(cell2.TransportURLName)
 
 			// assert that cell related CRs are created
@@ -471,15 +471,15 @@ var _ = Describe("Nova multicell", func() {
 			)
 		})
 		It("creates Nova API even if cell1 and cell2 fails", func() {
-			th.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
-			th.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
 			th.SimulateTransportURLReady(cell0.TransportURLName)
 			th.SimulateJobSuccess(cell0.DBSyncJobName)
 			th.SimulateStatefulSetReplicaReady(cell0.ConductorStatefulSetName)
 
 			// Simulate that cell1 DB sync failed and do not simulate
 			// cell2 DB creation success so that will be in Creating state.
-			th.SimulateMariaDBDatabaseCompleted(cell1.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(cell1.MariaDBDatabaseName)
 			th.SimulateTransportURLReady(cell1.TransportURLName)
 			th.SimulateJobFailure(cell1.DBSyncJobName)
 
@@ -501,9 +501,9 @@ var _ = Describe("Nova multicell", func() {
 			)
 		})
 		It("does not create cell1 if cell0 fails as cell1 needs API access", func() {
-			th.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
-			th.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
-			th.SimulateMariaDBDatabaseCompleted(cell1.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(cell1.MariaDBDatabaseName)
 			th.SimulateTransportURLReady(cell0.TransportURLName)
 			th.SimulateTransportURLReady(cell1.TransportURLName)
 
@@ -524,8 +524,8 @@ var _ = Describe("Nova multicell", func() {
 
 			serviceSpec := corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 3306}}}
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(novaNames.APIMariaDBDatabaseName.Namespace, novaNames.APIMariaDBDatabaseName.Name, serviceSpec))
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(novaNames.APIMariaDBDatabaseName.Namespace, novaNames.APIMariaDBDatabaseName.Name, serviceSpec))
 
 			spec := GetDefaultNovaSpec()
 			cell0Template := GetDefaultNovaCellTemplate()
@@ -558,9 +558,9 @@ var _ = Describe("Nova multicell", func() {
 			keystone.SimulateKeystoneServiceReady(novaNames.KeystoneServiceName)
 		})
 		It("cell0 becomes ready with 0 conductor replicas and the rest of nova is deployed", func() {
-			th.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
-			th.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
-			th.SimulateMariaDBDatabaseCompleted(cell1.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(cell1.MariaDBDatabaseName)
 			th.SimulateTransportURLReady(cell0.TransportURLName)
 			th.SimulateTransportURLReady(cell1.TransportURLName)
 
@@ -635,14 +635,14 @@ var _ = Describe("Nova multicell", func() {
 			DeferCleanup(k8sClient.Delete, ctx, CreateNovaMessageBusSecret(cell0))
 			serviceSpec := corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 3306}}}
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(
 					novaNames.APIMariaDBDatabaseName.Namespace,
 					novaNames.APIMariaDBDatabaseName.Name,
 					serviceSpec))
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(
 					cell1.MariaDBDatabaseName.Namespace,
 					cell1.MariaDBDatabaseName.Name,
 					serviceSpec))
@@ -670,7 +670,7 @@ var _ = Describe("Nova multicell", func() {
 		})
 
 		It("waits for cell0 DB to be created", func(ctx SpecContext) {
-			th.SimulateMariaDBDatabaseCompleted(cell1.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(cell1.MariaDBDatabaseName)
 			th.SimulateTransportURLReady(cell1.TransportURLName)
 			// NOTE(gibi): before the fix https://github.com/openstack-k8s-operators/nova-operator/pull/356
 			// nova-controller panic at this point and test would hang
@@ -689,9 +689,9 @@ var _ = Describe("Nova multicell", func() {
 			DeferCleanup(k8sClient.Delete, ctx, CreateNovaMessageBusSecret(cell1))
 
 			serviceSpec := corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 3306}}}
-			DeferCleanup(th.DeleteDBService, th.CreateDBService(novaNames.APIMariaDBDatabaseName.Namespace, novaNames.APIMariaDBDatabaseName.Name, serviceSpec))
-			DeferCleanup(th.DeleteDBService, th.CreateDBService(cell0.MariaDBDatabaseName.Namespace, cell0.MariaDBDatabaseName.Name, serviceSpec))
-			DeferCleanup(th.DeleteDBService, th.CreateDBService(cell1.MariaDBDatabaseName.Namespace, cell1.MariaDBDatabaseName.Name, serviceSpec))
+			DeferCleanup(mariadb.DeleteDBService, mariadb.CreateDBService(novaNames.APIMariaDBDatabaseName.Namespace, novaNames.APIMariaDBDatabaseName.Name, serviceSpec))
+			DeferCleanup(mariadb.DeleteDBService, mariadb.CreateDBService(cell0.MariaDBDatabaseName.Namespace, cell0.MariaDBDatabaseName.Name, serviceSpec))
+			DeferCleanup(mariadb.DeleteDBService, mariadb.CreateDBService(cell1.MariaDBDatabaseName.Namespace, cell1.MariaDBDatabaseName.Name, serviceSpec))
 
 			spec := GetDefaultNovaSpec()
 			cell0Template := GetDefaultNovaCellTemplate()
@@ -726,9 +726,9 @@ var _ = Describe("Nova multicell", func() {
 			keystone.SimulateKeystoneServiceReady(novaNames.KeystoneServiceName)
 		})
 		It("cell0 becomes ready without metadata and the rest of nova is deployed", func() {
-			th.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
-			th.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
-			th.SimulateMariaDBDatabaseCompleted(cell1.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(cell1.MariaDBDatabaseName)
 			th.SimulateTransportURLReady(cell0.TransportURLName)
 			th.SimulateTransportURLReady(cell1.TransportURLName)
 			th.SimulateJobSuccess(cell0.DBSyncJobName)
@@ -754,9 +754,9 @@ var _ = Describe("Nova multicell", func() {
 			AssertMetadataDoesNotExist(cell0.MetadataName)
 		})
 		It("puts the metadata secret to cell1 secret but not to cell0 secret", func() {
-			th.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
-			th.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
-			th.SimulateMariaDBDatabaseCompleted(cell1.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(cell1.MariaDBDatabaseName)
 			th.SimulateTransportURLReady(cell0.TransportURLName)
 			th.SimulateTransportURLReady(cell1.TransportURLName)
 			th.SimulateJobSuccess(cell0.DBSyncJobName)

--- a/test/functional/nova_reconfiguration_test.go
+++ b/test/functional/nova_reconfiguration_test.go
@@ -42,11 +42,11 @@ func CreateNovaWith3CellsAndEnsureReady(novaNames NovaNames) {
 
 	serviceSpec := corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 3306}}}
 	DeferCleanup(
-		th.DeleteDBService,
-		th.CreateDBService(novaNames.APIMariaDBDatabaseName.Namespace, novaNames.APIMariaDBDatabaseName.Name, serviceSpec))
-	DeferCleanup(th.DeleteDBService, th.CreateDBService(cell0.MariaDBDatabaseName.Namespace, cell0.MariaDBDatabaseName.Name, serviceSpec))
-	DeferCleanup(th.DeleteDBService, th.CreateDBService(cell1.MariaDBDatabaseName.Namespace, cell1.MariaDBDatabaseName.Name, serviceSpec))
-	DeferCleanup(th.DeleteDBService, th.CreateDBService(cell2.MariaDBDatabaseName.Namespace, cell2.MariaDBDatabaseName.Name, serviceSpec))
+		mariadb.DeleteDBService,
+		mariadb.CreateDBService(novaNames.APIMariaDBDatabaseName.Namespace, novaNames.APIMariaDBDatabaseName.Name, serviceSpec))
+	DeferCleanup(mariadb.DeleteDBService, mariadb.CreateDBService(cell0.MariaDBDatabaseName.Namespace, cell0.MariaDBDatabaseName.Name, serviceSpec))
+	DeferCleanup(mariadb.DeleteDBService, mariadb.CreateDBService(cell1.MariaDBDatabaseName.Namespace, cell1.MariaDBDatabaseName.Name, serviceSpec))
+	DeferCleanup(mariadb.DeleteDBService, mariadb.CreateDBService(cell2.MariaDBDatabaseName.Namespace, cell2.MariaDBDatabaseName.Name, serviceSpec))
 
 	spec := GetDefaultNovaSpec()
 	cell0Template := GetDefaultNovaCellTemplate()
@@ -77,10 +77,10 @@ func CreateNovaWith3CellsAndEnsureReady(novaNames NovaNames) {
 	keystone.SimulateKeystoneServiceReady(novaNames.KeystoneServiceName)
 	// END of common logic with Nova multicell test
 
-	th.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
-	th.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
-	th.SimulateMariaDBDatabaseCompleted(cell1.MariaDBDatabaseName)
-	th.SimulateMariaDBDatabaseCompleted(cell2.MariaDBDatabaseName)
+	mariadb.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
+	mariadb.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
+	mariadb.SimulateMariaDBDatabaseCompleted(cell1.MariaDBDatabaseName)
+	mariadb.SimulateMariaDBDatabaseCompleted(cell2.MariaDBDatabaseName)
 
 	th.SimulateTransportURLReady(cell0.TransportURLName)
 	th.SimulateTransportURLReady(cell1.TransportURLName)

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -56,6 +56,7 @@ import (
 
 	keystone_test "github.com/openstack-k8s-operators/keystone-operator/api/test/helpers"
 	common_test "github.com/openstack-k8s-operators/lib-common/modules/test/helpers"
+	mariadb_test "github.com/openstack-k8s-operators/mariadb-operator/api/test/helpers"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -71,6 +72,7 @@ var (
 	logger    logr.Logger
 	th        *common_test.TestHelper
 	keystone  *keystone_test.TestHelper
+	mariadb   *mariadb_test.TestHelper
 	novaNames NovaNames
 	cell0     CellNames
 	cell1     CellNames
@@ -170,7 +172,9 @@ var _ = BeforeSuite(func() {
 	th = common_test.NewTestHelper(ctx, k8sClient, timeout, interval, logger)
 	Expect(th).NotTo(BeNil())
 	keystone = keystone_test.NewTestHelper(ctx, k8sClient, timeout, interval, logger)
-	Expect(th).NotTo(BeNil())
+	Expect(keystone).NotTo(BeNil())
+	mariadb = mariadb_test.NewTestHelper(ctx, k8sClient, timeout, interval, logger)
+	Expect(mariadb).NotTo(BeNil())
 
 	// Start the controller-manager in a goroutine
 	webhookInstallOptions := &testEnv.WebhookInstallOptions


### PR DESCRIPTION
This is necessary to remove a dependency cycle from lib-common