### PR TITLE
Fix VNC config generation

### DIFF
--- a/templates/nova.conf
+++ b/templates/nova.conf
@@ -129,9 +129,7 @@ notify_on_state_change = vm_and_task_state
 enabled = True
 novncproxy_host = "::0"
 novncproxy_port = 6080
-{{end}}
-
-{{ if and (eq .service_name "nova-compute") .vnc_enabled }}
+{{ else if and (eq .service_name "nova-compute") .vnc_enabled }}
 [vnc]
 enabled = True
 novncproxy_base_url = {{ .novncproxy_base_url }}
@@ -141,7 +139,7 @@ server_listen = "::0"
 # dns currently so we need to use my_ip for now.
 # https://docs.openstack.org/nova/latest/configuration/config.html#DEFAULT.console_host
 server_proxyclient_address = "$my_ip"
-{{else}}
+{{else if and (eq .service_name "nova-compute") (not .vnc_enabled) }}
 [vnc]
 enabled = False
 {{end}}


### PR DESCRIPTION
863615c0c5b899f73f0f98049a14c9c2203d9e0e reworked the VNC config template but made a mistake that causes that the vncproxy service gets two [vnc] section generated and non vnc related services gets a [vnc]enabled=false generated.

This is fixed now.