### PR TITLE
Use database helpers from mariadb-operator/api

### DIFF
--- a/controllers/nova_controller.go
+++ b/controllers/nova_controller.go
@@ -44,7 +44,6 @@ import (
 	common_rbac "github.com/openstack-k8s-operators/lib-common/modules/common/rbac"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/secret"
 	util "github.com/openstack-k8s-operators/lib-common/modules/common/util"
-	database "github.com/openstack-k8s-operators/lib-common/modules/database"
 
 	novav1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/nova-operator/pkg/nova"
@@ -639,7 +638,7 @@ func (r *NovaReconciler) ensureDB(
 	ctx context.Context,
 	h *helper.Helper,
 	instance *novav1.Nova,
-	db *database.Database,
+	db *mariadbv1.Database,
 	databaseServiceName string,
 	targetCondition condition.Type,
 ) (nova.DatabaseStatus, error) {
@@ -671,8 +670,8 @@ func (r *NovaReconciler) ensureAPIDB(
 	ctx context.Context,
 	h *helper.Helper,
 	instance *novav1.Nova,
-) (*database.Database, nova.DatabaseStatus, error) {
-	apiDB := database.NewDatabaseWithNamespace(
+) (*mariadbv1.Database, nova.DatabaseStatus, error) {
+	apiDB := mariadbv1.NewDatabaseWithNamespace(
 		nova.NovaAPIDatabaseName,
 		instance.Spec.APIDatabaseUser,
 		instance.Spec.Secret,
@@ -699,8 +698,8 @@ func (r *NovaReconciler) ensureCellDB(
 	instance *novav1.Nova,
 	cellName string,
 	cellTemplate novav1.NovaCellTemplate,
-) (*database.Database, nova.DatabaseStatus, error) {
-	cellDB := database.NewDatabaseWithNamespace(
+) (*mariadbv1.Database, nova.DatabaseStatus, error) {
+	cellDB := mariadbv1.NewDatabaseWithNamespace(
 		"nova_"+cellName,
 		cellTemplate.CellDatabaseUser,
 		instance.Spec.Secret,
@@ -727,8 +726,8 @@ func (r *NovaReconciler) ensureCell(
 	instance *novav1.Nova,
 	cellName string,
 	cellTemplate novav1.NovaCellTemplate,
-	cellDB *database.Database,
-	apiDB *database.Database,
+	cellDB *mariadbv1.Database,
+	apiDB *mariadbv1.Database,
 	cellTransportURL string,
 	keystoneAuthURL string,
 	secret corev1.Secret,
@@ -816,8 +815,8 @@ func (r *NovaReconciler) ensureAPI(
 	h *helper.Helper,
 	instance *novav1.Nova,
 	cell0Template novav1.NovaCellTemplate,
-	cell0DB *database.Database,
-	apiDB *database.Database,
+	cell0DB *mariadbv1.Database,
+	apiDB *mariadbv1.Database,
 	keystoneInternalAuthURL string,
 	keystonePublicAuthURL string,
 	secretName string,
@@ -897,8 +896,8 @@ func (r *NovaReconciler) ensureScheduler(
 	h *helper.Helper,
 	instance *novav1.Nova,
 	cell0Template novav1.NovaCellTemplate,
-	cell0DB *database.Database,
-	apiDB *database.Database,
+	cell0DB *mariadbv1.Database,
+	apiDB *mariadbv1.Database,
 	keystoneAuthURL string,
 	secretName string,
 ) (ctrl.Result, error) {
@@ -1021,7 +1020,7 @@ func (r *NovaReconciler) ensureDBDeletion(
 	}
 	// iterate over novaDbs and remove finalizers
 	for _, dbName := range novaDbs {
-		db, err := database.GetDatabaseByName(ctx, h, dbName)
+		db, err := mariadbv1.GetDatabaseByName(ctx, h, dbName)
 		if err != nil && !k8s_errors.IsNotFound(err) {
 			return err
 		}
@@ -1200,8 +1199,8 @@ func (r *NovaReconciler) ensureMetadata(
 	h *helper.Helper,
 	instance *novav1.Nova,
 	cell0Template novav1.NovaCellTemplate,
-	cell0DB *database.Database,
-	apiDB *database.Database,
+	cell0DB *mariadbv1.Database,
+	apiDB *mariadbv1.Database,
 	keystoneAuthURL string,
 	secretName string,
 ) (ctrl.Result, error) {

--- a/go.mod
+++ b/go.mod
@@ -11,9 +11,8 @@ require (
 	github.com/openstack-k8s-operators/infra-operator/apis v0.1.1-0.20231001103054-f74a88ed4971
 	github.com/openstack-k8s-operators/keystone-operator/api v0.1.1-0.20231002064359-5fc1bb3e3299
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.1.1-0.20231002090319-8c85a5806ffb
-	github.com/openstack-k8s-operators/lib-common/modules/database v0.1.1-0.20231002090319-8c85a5806ffb
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.1.2-0.20231002090319-8c85a5806ffb
-	github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230928152002-65395552e015
+	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.0
 	github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20221209164002-f9e6b9363961
 	go.uber.org/zap v1.26.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -242,14 +242,12 @@ github.com/openstack-k8s-operators/keystone-operator/api v0.1.1-0.20231002064359
 github.com/openstack-k8s-operators/keystone-operator/api v0.1.1-0.20231002064359-5fc1bb3e3299/go.mod h1:5v0ngxNmFp8QsINo2bufx1/COJc0q6jm3FMhP3xIAWE=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.1.1-0.20231002090319-8c85a5806ffb h1:jgbzzrCprRSJJO9K0GbfX1DuFQysVygLKFDkk0liqcM=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.1.1-0.20231002090319-8c85a5806ffb/go.mod h1:Ozg6SxfwOtMkiH553c0XQBWuygZQq4jDQCpR4hZqlxM=
-github.com/openstack-k8s-operators/lib-common/modules/database v0.1.1-0.20231002090319-8c85a5806ffb h1:GZIEP4q+7lLzrxIAloglg61EMGzh+TQ7h99E0/D0Uu0=
-github.com/openstack-k8s-operators/lib-common/modules/database v0.1.1-0.20231002090319-8c85a5806ffb/go.mod h1:RroLfB6Wstc+z7JVJY9o+6YPu+wBIzTAAfMpwhv7pDI=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.1.1-0.20231002090319-8c85a5806ffb h1:AfMP5iucttYsiY1Jwo6PlrgmJ14dDyZ/qAukkZ7NBSk=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.1.1-0.20231002090319-8c85a5806ffb/go.mod h1:LOXXvTQCwhOBNd+0FTlgllpa3wqlkI6Vf3Q5QVRVPlw=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.1.2-0.20231002090319-8c85a5806ffb h1:O24il+OZEi9dIVMZT8m+Y/ttkk9BZ+UPYuA4gYre/tw=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.1.2-0.20231002090319-8c85a5806ffb/go.mod h1:j2CcjMoznTNJWx0hZtHqXbemfm5657oT/7ItEWgUOw0=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230928152002-65395552e015 h1:1G37nuB9C8QPp7tScEpwbR7eQj+2e6l089MNzj5cChk=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230928152002-65395552e015/go.mod h1:xhiz5wFdKWwVM7BF/VYon4TT3NuUPXp/Pyn2hWcp0CE=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.3.0 h1:FB0xB6whYM6W4XIncYo2mPiOJWkFsIOWtCT+UOtvOaQ=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.3.0/go.mod h1:xhiz5wFdKWwVM7BF/VYon4TT3NuUPXp/Pyn2hWcp0CE=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/pkg/nova/common.go
+++ b/pkg/nova/common.go
@@ -19,7 +19,7 @@ package nova
 import (
 	"fmt"
 
-	"github.com/openstack-k8s-operators/lib-common/modules/database"
+	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 )
 
 const (
@@ -94,7 +94,7 @@ const (
 
 // Database -
 type Database struct {
-	Database *database.Database
+	Database *mariadbv1.Database
 	Status   DatabaseStatus
 }
 


### PR DESCRIPTION
The lib-common/modules/database is moved to mariadb-operator/api to remove a circular dependency.