### PR TITLE
[CI]Enable multi compute tempest testing in Zuul

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -113,11 +113,101 @@
                 ip: 172.18.0.5
               tenant:
                 ip: 172.19.0.5
-
-
+- job:
+    name: nova-operator-tempest-multinode
+    parent: podified-multinode-edpm-deployment-crc-3comp
+    dependencies: ["nova-operator-content-provider"]
+    vars:
+      cifmw_tempest_tempestconf_profile:
+          overrides:
+            compute.min_compute_nodes: 3
+            compute-feature-enabled.vnc_console: true
+            compute-feature-enabled.stable_rescue: true
+            compute_feature_enabled.hostname_fqdn_sanitization: true
+            validation.run_validation: true
+            # NOTE(gibi): This is a WA to force the publicURL as otherwise
+            # tempest gets configured with adminURL and that causes test
+            # instability.
+            identity.v3_endpoint_type: public
+      cifmw_tempest_tests_allowed:
+        - tempest.
+      cifmw_tempest_tests_skipped:
+      # We don't have a running cinder-volume
+        - cinder_tempest_plugin.
+        - ServersTestBootFromVolume
+        - tempest.api.compute.volumes.test_volumes_list
+        - tempest.api.volume.admin
+        - tempest.api.volume.test_image_metadata
+        - tempest.api.volume.test_snapshot_metadata
+        - tempest.api.volume.test_volume_absolute_limits
+        - tempest.api.volume.test_volume_metadata
+        - tempest.api.volume.test_volumes_actions
+        - tempest.api.volume.test_volumes_list
+        - tempest.api.volume.test_volumes_negative
+        - tempest.api.volume.test_volumes_snapshots
+        - tempest.api.volume.test_volumes_snapshots_list
+        - tempest.api.compute.admin.test_volume.AttachSCSIVolumeTestJSON
+        - tempest.api.compute.admin.test_volumes_negative.VolumesAdminNegativeTest
+        - test_delete_server_while_in_attached_volume
+        - tempest.api.compute.servers.test_device_tagging
+        - test_rebuild_server_with_volume_attached
+        - test_rescued_vm_attach_volume
+        - test_rescued_vm_detach_volume
+        - test_create_server_from_non_bootable_volume
+        - test_create_server_invalid_bdm_in_2nd_dict
+        - test_attach_volume_shelved_or_offload_server
+        - test_detach_volume_shelved_or_offload_server
+        - test_attach_detach_volume
+        - test_list_get_volume_attachments
+        - test_attach_attached_volume
+        - test_delete_attached_volume
+        - tempest.api.compute.volumes.test_volumes_get
+        - tempest.api.volume.admin.test_backends_capabilities
+        - tempest.api.volume.admin.test_group_snapshots
+        - tempest.api.volume.admin.test_groups
+        - tempest.api.volume.admin.test_volume_hosts
+        - tempest.api.volume.admin.test_volume_pools
+        - tempest.api.volume.admin.test_volume_quotas
+        - tempest.api.volume.admin.test_volume_retype
+        - tempest.api.volume.admin.test_volume_services.VolumesServicesTestJSON.test_get_service_by_volume_host_name
+        - tempest.api.volume.admin.test_volume_type_access
+        - tempest.api.volume.admin.test_volume_types.VolumeTypesTest.test_volume_crud_with_volume_type_and_extra_specs
+        - tempest.api.volume.admin.test_volumes_actions
+        - tempest.api.volume.test_availability_zone
+        - tempest.api.volume.test_volume_delete_cascade
+        - tempest.api.volume.test_volume_transfers
+        - tempest.api.volume.test_volumes_clone
+        - tempest.api.volume.test_volumes_extend
+        - tempest.api.volume.test_volumes_get
+        - tempest.api.volume.test_volumes_snapshots_negative.VolumesSnapshotNegativeTestJSON.test_volume_from_snapshot_decreasing_size
+        - test_minimum_basic_instance_hard_reboot_after_vol_snap_deletion
+        - tempest.scenario.test_minimum_basic.TestMinimumBasicScenario.test_minimum_basic_scenario
+        - test_shelve_volume_backed_instance
+        - tempest.scenario.test_stamp_pattern
+        - tempest.scenario.test_volume_boot_pattern
+        - test_volume_snapshot_create_get_list_delete
+        - tempest.api.compute.servers.test_server_rescue.ServerBootFromVolumeStableRescueTest
+        - test_stable_device_rescue_disk_virtio_with_volume_attached
+      # Need to check
+        - tempest.api.compute.admin.test_auto_allocate_network.AutoAllocateNetworkTest.test_server_multi_create_auto_allocate
+        - tempest.api.object_storage.test_container_sync_middleware
+        - tempest.api.object_storage.test_object_version
+        - tempest.api.compute.servers.test_server_rescue.ServerStableDeviceRescueTestIDE
+      # Migration does not work yet
+        - tempest.api.compute.admin.test_live_migration
+        - tempest.api.compute.admin.test_migrations
+        - test_delete_server_while_in_verify_resize_state
+        - test_resize_server_from_auto_to_manual
+        - test_resize_server_from_manual_to_auto
+        - test_resize_server
+        - test_resize_volume_backed_server_confirm
+        - test_server_connectivity_cold_migration
+        - test_server_connectivity_live_migration
+        - test_server_connectivity_resize
 - project:
     name: openstack-k8s-operators/nova-operator
     github-check:
       jobs:
         - nova-operator-content-provider
         - nova-operator-kuttl
+        - nova-operator-tempest-multinode


### PR DESCRIPTION
This reused the podified-multinode-edpm-deployment-crc-3comp job to run full tempest.

There are limitations:
* cinder-volume has 0 replicas so no volume related tests are run
* nova-operator does not support migration operations so those tests are
  skipped