### PR TITLE
Introduce Debug stopJob to replace stopDBSync                

### DIFF
--- a/api/bases/nova.openstack.org_nova.yaml
+++ b/api/bases/nova.openstack.org_nova.yaml
@@ -1203,21 +1203,18 @@ spec:
                     description: PreserveJobs - do not delete jobs after they finished
                       e.g. to check logs
                     type: boolean
-                  stopDBSync:
+                  stopJob:
                     default: false
-                    description: 'StopDBSync allows stopping the init container before
-                      running db sync to apply the DB schema QUESTION(gibi): Not all
-                      CR will run dbsync, should we have per CR Debug struct or keep
-                      this generic one and ignore fields in the controller that are
-                      not applicable'
+                    description: StopJob allows stopping the jobs containers, like
+                      mapping cells, or dbsync, before executing the script of the
+                      job. If the CR does not start any Jobs, then the value of the
+                      field is ignored.
                     type: boolean
                   stopService:
                     default: false
-                    description: 'StopService allows stopping the service container
-                      before staring the openstack service binary QUESTION(gibi):
-                      Not all CR will run a service, should we have per CR Debug struct
-                      or keep this generic one and ignore fields in the controller
-                      that are not applicable'
+                    description: StopService allows stopping the service container
+                      before staring the openstack service binary. If the CR does
+                      not start any service, then the value of the field is ignored.
                     type: boolean
                 type: object
               keystoneInstance:

--- a/api/bases/nova.openstack.org_novaapis.yaml
+++ b/api/bases/nova.openstack.org_novaapis.yaml
@@ -87,21 +87,18 @@ spec:
                     description: PreserveJobs - do not delete jobs after they finished
                       e.g. to check logs
                     type: boolean
-                  stopDBSync:
+                  stopJob:
                     default: false
-                    description: 'StopDBSync allows stopping the init container before
-                      running db sync to apply the DB schema QUESTION(gibi): Not all
-                      CR will run dbsync, should we have per CR Debug struct or keep
-                      this generic one and ignore fields in the controller that are
-                      not applicable'
+                    description: StopJob allows stopping the jobs containers, like
+                      mapping cells, or dbsync, before executing the script of the
+                      job. If the CR does not start any Jobs, then the value of the
+                      field is ignored.
                     type: boolean
                   stopService:
                     default: false
-                    description: 'StopService allows stopping the service container
-                      before staring the openstack service binary QUESTION(gibi):
-                      Not all CR will run a service, should we have per CR Debug struct
-                      or keep this generic one and ignore fields in the controller
-                      that are not applicable'
+                    description: StopService allows stopping the service container
+                      before staring the openstack service binary. If the CR does
+                      not start any service, then the value of the field is ignored.
                     type: boolean
                 type: object
               defaultConfigOverwrite:

--- a/api/bases/nova.openstack.org_novacells.yaml
+++ b/api/bases/nova.openstack.org_novacells.yaml
@@ -164,21 +164,18 @@ spec:
                     description: PreserveJobs - do not delete jobs after they finished
                       e.g. to check logs
                     type: boolean
-                  stopDBSync:
+                  stopJob:
                     default: false
-                    description: 'StopDBSync allows stopping the init container before
-                      running db sync to apply the DB schema QUESTION(gibi): Not all
-                      CR will run dbsync, should we have per CR Debug struct or keep
-                      this generic one and ignore fields in the controller that are
-                      not applicable'
+                    description: StopJob allows stopping the jobs containers, like
+                      mapping cells, or dbsync, before executing the script of the
+                      job. If the CR does not start any Jobs, then the value of the
+                      field is ignored.
                     type: boolean
                   stopService:
                     default: false
-                    description: 'StopService allows stopping the service container
-                      before staring the openstack service binary QUESTION(gibi):
-                      Not all CR will run a service, should we have per CR Debug struct
-                      or keep this generic one and ignore fields in the controller
-                      that are not applicable'
+                    description: StopService allows stopping the service container
+                      before staring the openstack service binary. If the CR does
+                      not start any service, then the value of the field is ignored.
                     type: boolean
                 type: object
               keystoneAuthURL:

--- a/api/bases/nova.openstack.org_novacomputes.yaml
+++ b/api/bases/nova.openstack.org_novacomputes.yaml
@@ -83,21 +83,18 @@ spec:
                     description: PreserveJobs - do not delete jobs after they finished
                       e.g. to check logs
                     type: boolean
-                  stopDBSync:
+                  stopJob:
                     default: false
-                    description: 'StopDBSync allows stopping the init container before
-                      running db sync to apply the DB schema QUESTION(gibi): Not all
-                      CR will run dbsync, should we have per CR Debug struct or keep
-                      this generic one and ignore fields in the controller that are
-                      not applicable'
+                    description: StopJob allows stopping the jobs containers, like
+                      mapping cells, or dbsync, before executing the script of the
+                      job. If the CR does not start any Jobs, then the value of the
+                      field is ignored.
                     type: boolean
                   stopService:
                     default: false
-                    description: 'StopService allows stopping the service container
-                      before staring the openstack service binary QUESTION(gibi):
-                      Not all CR will run a service, should we have per CR Debug struct
-                      or keep this generic one and ignore fields in the controller
-                      that are not applicable'
+                    description: StopService allows stopping the service container
+                      before staring the openstack service binary. If the CR does
+                      not start any service, then the value of the field is ignored.
                     type: boolean
                 type: object
               defaultConfigOverwrite:

--- a/api/bases/nova.openstack.org_novaconductors.yaml
+++ b/api/bases/nova.openstack.org_novaconductors.yaml
@@ -93,21 +93,18 @@ spec:
                     description: PreserveJobs - do not delete jobs after they finished
                       e.g. to check logs
                     type: boolean
-                  stopDBSync:
+                  stopJob:
                     default: false
-                    description: 'StopDBSync allows stopping the init container before
-                      running db sync to apply the DB schema QUESTION(gibi): Not all
-                      CR will run dbsync, should we have per CR Debug struct or keep
-                      this generic one and ignore fields in the controller that are
-                      not applicable'
+                    description: StopJob allows stopping the jobs containers, like
+                      mapping cells, or dbsync, before executing the script of the
+                      job. If the CR does not start any Jobs, then the value of the
+                      field is ignored.
                     type: boolean
                   stopService:
                     default: false
-                    description: 'StopService allows stopping the service container
-                      before staring the openstack service binary QUESTION(gibi):
-                      Not all CR will run a service, should we have per CR Debug struct
-                      or keep this generic one and ignore fields in the controller
-                      that are not applicable'
+                    description: StopService allows stopping the service container
+                      before staring the openstack service binary. If the CR does
+                      not start any service, then the value of the field is ignored.
                     type: boolean
                 type: object
               defaultConfigOverwrite:

--- a/api/bases/nova.openstack.org_novametadata.yaml
+++ b/api/bases/nova.openstack.org_novametadata.yaml
@@ -95,21 +95,18 @@ spec:
                     description: PreserveJobs - do not delete jobs after they finished
                       e.g. to check logs
                     type: boolean
-                  stopDBSync:
+                  stopJob:
                     default: false
-                    description: 'StopDBSync allows stopping the init container before
-                      running db sync to apply the DB schema QUESTION(gibi): Not all
-                      CR will run dbsync, should we have per CR Debug struct or keep
-                      this generic one and ignore fields in the controller that are
-                      not applicable'
+                    description: StopJob allows stopping the jobs containers, like
+                      mapping cells, or dbsync, before executing the script of the
+                      job. If the CR does not start any Jobs, then the value of the
+                      field is ignored.
                     type: boolean
                   stopService:
                     default: false
-                    description: 'StopService allows stopping the service container
-                      before staring the openstack service binary QUESTION(gibi):
-                      Not all CR will run a service, should we have per CR Debug struct
-                      or keep this generic one and ignore fields in the controller
-                      that are not applicable'
+                    description: StopService allows stopping the service container
+                      before staring the openstack service binary. If the CR does
+                      not start any service, then the value of the field is ignored.
                     type: boolean
                 type: object
               defaultConfigOverwrite:

--- a/api/bases/nova.openstack.org_novanovncproxies.yaml
+++ b/api/bases/nova.openstack.org_novanovncproxies.yaml
@@ -82,21 +82,18 @@ spec:
                     description: PreserveJobs - do not delete jobs after they finished
                       e.g. to check logs
                     type: boolean
-                  stopDBSync:
+                  stopJob:
                     default: false
-                    description: 'StopDBSync allows stopping the init container before
-                      running db sync to apply the DB schema QUESTION(gibi): Not all
-                      CR will run dbsync, should we have per CR Debug struct or keep
-                      this generic one and ignore fields in the controller that are
-                      not applicable'
+                    description: StopJob allows stopping the jobs containers, like
+                      mapping cells, or dbsync, before executing the script of the
+                      job. If the CR does not start any Jobs, then the value of the
+                      field is ignored.
                     type: boolean
                   stopService:
                     default: false
-                    description: 'StopService allows stopping the service container
-                      before staring the openstack service binary QUESTION(gibi):
-                      Not all CR will run a service, should we have per CR Debug struct
-                      or keep this generic one and ignore fields in the controller
-                      that are not applicable'
+                    description: StopService allows stopping the service container
+                      before staring the openstack service binary. If the CR does
+                      not start any service, then the value of the field is ignored.
                     type: boolean
                 type: object
               defaultConfigOverwrite:

--- a/api/bases/nova.openstack.org_novaschedulers.yaml
+++ b/api/bases/nova.openstack.org_novaschedulers.yaml
@@ -87,21 +87,18 @@ spec:
                     description: PreserveJobs - do not delete jobs after they finished
                       e.g. to check logs
                     type: boolean
-                  stopDBSync:
+                  stopJob:
                     default: false
-                    description: 'StopDBSync allows stopping the init container before
-                      running db sync to apply the DB schema QUESTION(gibi): Not all
-                      CR will run dbsync, should we have per CR Debug struct or keep
-                      this generic one and ignore fields in the controller that are
-                      not applicable'
+                    description: StopJob allows stopping the jobs containers, like
+                      mapping cells, or dbsync, before executing the script of the
+                      job. If the CR does not start any Jobs, then the value of the
+                      field is ignored.
                     type: boolean
                   stopService:
                     default: false
-                    description: 'StopService allows stopping the service container
-                      before staring the openstack service binary QUESTION(gibi):
-                      Not all CR will run a service, should we have per CR Debug struct
-                      or keep this generic one and ignore fields in the controller
-                      that are not applicable'
+                    description: StopService allows stopping the service container
+                      before staring the openstack service binary. If the CR does
+                      not start any service, then the value of the field is ignored.
                     type: boolean
                 type: object
               defaultConfigOverwrite:

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -76,23 +76,22 @@ type NovaServiceBase struct {
 }
 
 // Debug allows enabling different debug option for the operator
+// QUESTION(gibi): Not all CR will run a service, dbsync, or cells mappings
+// jobs.  Should we have per CR Debug struct, or keep this generic one and
+// ignore fields in the controller that are not applicable?
 type Debug struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
-	// StopDBSync allows stopping the init container before running db sync
-	// to apply the DB schema
-	// QUESTION(gibi): Not all CR will run dbsync, should we have per CR
-	// Debug struct or keep this generic one and ignore fields in the
-	// controller that are not applicable
-	StopDBSync bool `json:"stopDBSync"`
+	// StopService allows stopping the service container before staring the
+	// openstack service binary. If the CR does not start any service, then the
+	// value of the field is ignored.
+	StopService bool `json:"stopService"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
-	// StopService allows stopping the service container before staring
-	// the openstack service binary
-	// QUESTION(gibi): Not all CR will run a service, should we have per CR
-	// Debug struct or keep this generic one and ignore fields in the
-	// controller that are not applicable
-	StopService bool `json:"stopService"`
+	// StopJob allows stopping the jobs containers, like mapping cells, or
+	// dbsync, before executing the script of the job. If the CR does not start
+	// any Jobs, then the value of the field is ignored.
+	StopJob bool `json:"stopJob"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
 	// PreserveJobs - do not delete jobs after they finished e.g. to check logs

--- a/config/crd/bases/nova.openstack.org_nova.yaml
+++ b/config/crd/bases/nova.openstack.org_nova.yaml
@@ -1203,21 +1203,18 @@ spec:
                     description: PreserveJobs - do not delete jobs after they finished
                       e.g. to check logs
                     type: boolean
-                  stopDBSync:
+                  stopJob:
                     default: false
-                    description: 'StopDBSync allows stopping the init container before
-                      running db sync to apply the DB schema QUESTION(gibi): Not all
-                      CR will run dbsync, should we have per CR Debug struct or keep
-                      this generic one and ignore fields in the controller that are
-                      not applicable'
+                    description: StopJob allows stopping the jobs containers, like
+                      mapping cells, or dbsync, before executing the script of the
+                      job. If the CR does not start any Jobs, then the value of the
+                      field is ignored.
                     type: boolean
                   stopService:
                     default: false
-                    description: 'StopService allows stopping the service container
-                      before staring the openstack service binary QUESTION(gibi):
-                      Not all CR will run a service, should we have per CR Debug struct
-                      or keep this generic one and ignore fields in the controller
-                      that are not applicable'
+                    description: StopService allows stopping the service container
+                      before staring the openstack service binary. If the CR does
+                      not start any service, then the value of the field is ignored.
                     type: boolean
                 type: object
               keystoneInstance:

--- a/config/crd/bases/nova.openstack.org_novaapis.yaml
+++ b/config/crd/bases/nova.openstack.org_novaapis.yaml
@@ -87,21 +87,18 @@ spec:
                     description: PreserveJobs - do not delete jobs after they finished
                       e.g. to check logs
                     type: boolean
-                  stopDBSync:
+                  stopJob:
                     default: false
-                    description: 'StopDBSync allows stopping the init container before
-                      running db sync to apply the DB schema QUESTION(gibi): Not all
-                      CR will run dbsync, should we have per CR Debug struct or keep
-                      this generic one and ignore fields in the controller that are
-                      not applicable'
+                    description: StopJob allows stopping the jobs containers, like
+                      mapping cells, or dbsync, before executing the script of the
+                      job. If the CR does not start any Jobs, then the value of the
+                      field is ignored.
                     type: boolean
                   stopService:
                     default: false
-                    description: 'StopService allows stopping the service container
-                      before staring the openstack service binary QUESTION(gibi):
-                      Not all CR will run a service, should we have per CR Debug struct
-                      or keep this generic one and ignore fields in the controller
-                      that are not applicable'
+                    description: StopService allows stopping the service container
+                      before staring the openstack service binary. If the CR does
+                      not start any service, then the value of the field is ignored.
                     type: boolean
                 type: object
               defaultConfigOverwrite:

--- a/config/crd/bases/nova.openstack.org_novacells.yaml
+++ b/config/crd/bases/nova.openstack.org_novacells.yaml
@@ -164,21 +164,18 @@ spec:
                     description: PreserveJobs - do not delete jobs after they finished
                       e.g. to check logs
                     type: boolean
-                  stopDBSync:
+                  stopJob:
                     default: false
-                    description: 'StopDBSync allows stopping the init container before
-                      running db sync to apply the DB schema QUESTION(gibi): Not all
-                      CR will run dbsync, should we have per CR Debug struct or keep
-                      this generic one and ignore fields in the controller that are
-                      not applicable'
+                    description: StopJob allows stopping the jobs containers, like
+                      mapping cells, or dbsync, before executing the script of the
+                      job. If the CR does not start any Jobs, then the value of the
+                      field is ignored.
                     type: boolean
                   stopService:
                     default: false
-                    description: 'StopService allows stopping the service container
-                      before staring the openstack service binary QUESTION(gibi):
-                      Not all CR will run a service, should we have per CR Debug struct
-                      or keep this generic one and ignore fields in the controller
-                      that are not applicable'
+                    description: StopService allows stopping the service container
+                      before staring the openstack service binary. If the CR does
+                      not start any service, then the value of the field is ignored.
                     type: boolean
                 type: object
               keystoneAuthURL:

--- a/config/crd/bases/nova.openstack.org_novacomputes.yaml
+++ b/config/crd/bases/nova.openstack.org_novacomputes.yaml
@@ -83,21 +83,18 @@ spec:
                     description: PreserveJobs - do not delete jobs after they finished
                       e.g. to check logs
                     type: boolean
-                  stopDBSync:
+                  stopJob:
                     default: false
-                    description: 'StopDBSync allows stopping the init container before
-                      running db sync to apply the DB schema QUESTION(gibi): Not all
-                      CR will run dbsync, should we have per CR Debug struct or keep
-                      this generic one and ignore fields in the controller that are
-                      not applicable'
+                    description: StopJob allows stopping the jobs containers, like
+                      mapping cells, or dbsync, before executing the script of the
+                      job. If the CR does not start any Jobs, then the value of the
+                      field is ignored.
                     type: boolean
                   stopService:
                     default: false
-                    description: 'StopService allows stopping the service container
-                      before staring the openstack service binary QUESTION(gibi):
-                      Not all CR will run a service, should we have per CR Debug struct
-                      or keep this generic one and ignore fields in the controller
-                      that are not applicable'
+                    description: StopService allows stopping the service container
+                      before staring the openstack service binary. If the CR does
+                      not start any service, then the value of the field is ignored.
                     type: boolean
                 type: object
               defaultConfigOverwrite:

--- a/config/crd/bases/nova.openstack.org_novaconductors.yaml
+++ b/config/crd/bases/nova.openstack.org_novaconductors.yaml
@@ -93,21 +93,18 @@ spec:
                     description: PreserveJobs - do not delete jobs after they finished
                       e.g. to check logs
                     type: boolean
-                  stopDBSync:
+                  stopJob:
                     default: false
-                    description: 'StopDBSync allows stopping the init container before
-                      running db sync to apply the DB schema QUESTION(gibi): Not all
-                      CR will run dbsync, should we have per CR Debug struct or keep
-                      this generic one and ignore fields in the controller that are
-                      not applicable'
+                    description: StopJob allows stopping the jobs containers, like
+                      mapping cells, or dbsync, before executing the script of the
+                      job. If the CR does not start any Jobs, then the value of the
+                      field is ignored.
                     type: boolean
                   stopService:
                     default: false
-                    description: 'StopService allows stopping the service container
-                      before staring the openstack service binary QUESTION(gibi):
-                      Not all CR will run a service, should we have per CR Debug struct
-                      or keep this generic one and ignore fields in the controller
-                      that are not applicable'
+                    description: StopService allows stopping the service container
+                      before staring the openstack service binary. If the CR does
+                      not start any service, then the value of the field is ignored.
                     type: boolean
                 type: object
               defaultConfigOverwrite:

--- a/config/crd/bases/nova.openstack.org_novametadata.yaml
+++ b/config/crd/bases/nova.openstack.org_novametadata.yaml
@@ -95,21 +95,18 @@ spec:
                     description: PreserveJobs - do not delete jobs after they finished
                       e.g. to check logs
                     type: boolean
-                  stopDBSync:
+                  stopJob:
                     default: false
-                    description: 'StopDBSync allows stopping the init container before
-                      running db sync to apply the DB schema QUESTION(gibi): Not all
-                      CR will run dbsync, should we have per CR Debug struct or keep
-                      this generic one and ignore fields in the controller that are
-                      not applicable'
+                    description: StopJob allows stopping the jobs containers, like
+                      mapping cells, or dbsync, before executing the script of the
+                      job. If the CR does not start any Jobs, then the value of the
+                      field is ignored.
                     type: boolean
                   stopService:
                     default: false
-                    description: 'StopService allows stopping the service container
-                      before staring the openstack service binary QUESTION(gibi):
-                      Not all CR will run a service, should we have per CR Debug struct
-                      or keep this generic one and ignore fields in the controller
-                      that are not applicable'
+                    description: StopService allows stopping the service container
+                      before staring the openstack service binary. If the CR does
+                      not start any service, then the value of the field is ignored.
                     type: boolean
                 type: object
               defaultConfigOverwrite:

--- a/config/crd/bases/nova.openstack.org_novanovncproxies.yaml
+++ b/config/crd/bases/nova.openstack.org_novanovncproxies.yaml
@@ -82,21 +82,18 @@ spec:
                     description: PreserveJobs - do not delete jobs after they finished
                       e.g. to check logs
                     type: boolean
-                  stopDBSync:
+                  stopJob:
                     default: false
-                    description: 'StopDBSync allows stopping the init container before
-                      running db sync to apply the DB schema QUESTION(gibi): Not all
-                      CR will run dbsync, should we have per CR Debug struct or keep
-                      this generic one and ignore fields in the controller that are
-                      not applicable'
+                    description: StopJob allows stopping the jobs containers, like
+                      mapping cells, or dbsync, before executing the script of the
+                      job. If the CR does not start any Jobs, then the value of the
+                      field is ignored.
                     type: boolean
                   stopService:
                     default: false
-                    description: 'StopService allows stopping the service container
-                      before staring the openstack service binary QUESTION(gibi):
-                      Not all CR will run a service, should we have per CR Debug struct
-                      or keep this generic one and ignore fields in the controller
-                      that are not applicable'
+                    description: StopService allows stopping the service container
+                      before staring the openstack service binary. If the CR does
+                      not start any service, then the value of the field is ignored.
                     type: boolean
                 type: object
               defaultConfigOverwrite:

--- a/config/crd/bases/nova.openstack.org_novaschedulers.yaml
+++ b/config/crd/bases/nova.openstack.org_novaschedulers.yaml
@@ -87,21 +87,18 @@ spec:
                     description: PreserveJobs - do not delete jobs after they finished
                       e.g. to check logs
                     type: boolean
-                  stopDBSync:
+                  stopJob:
                     default: false
-                    description: 'StopDBSync allows stopping the init container before
-                      running db sync to apply the DB schema QUESTION(gibi): Not all
-                      CR will run dbsync, should we have per CR Debug struct or keep
-                      this generic one and ignore fields in the controller that are
-                      not applicable'
+                    description: StopJob allows stopping the jobs containers, like
+                      mapping cells, or dbsync, before executing the script of the
+                      job. If the CR does not start any Jobs, then the value of the
+                      field is ignored.
                     type: boolean
                   stopService:
                     default: false
-                    description: 'StopService allows stopping the service container
-                      before staring the openstack service binary QUESTION(gibi):
-                      Not all CR will run a service, should we have per CR Debug struct
-                      or keep this generic one and ignore fields in the controller
-                      that are not applicable'
+                    description: StopService allows stopping the service container
+                      before staring the openstack service binary. If the CR does
+                      not start any service, then the value of the field is ignored.
                     type: boolean
                 type: object
               defaultConfigOverwrite:

--- a/pkg/nova/cellmapping.go
+++ b/pkg/nova/cellmapping.go
@@ -5,8 +5,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	common "github.com/openstack-k8s-operators/lib-common/modules/common"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
 	novav1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
+)
+
+const (
+	cellMappingCommand      = "/usr/local/bin/kolla_set_configs && /var/lib/openstack/bin/ensure_cell_mapping.sh"
 )
 
 func CellMappingJob(
@@ -19,9 +24,11 @@ func CellMappingJob(
 ) *batchv1.Job {
 	runAsUser := int64(0)
 
-	args := []string{
-		"-c",
-		"/usr/local/bin/kolla_set_configs && /var/lib/openstack/bin/ensure_cell_mapping.sh",
+	args := []string{"-c"}
+	if cell.Spec.Debug.StopJob {
+		args = append(args, common.DebugCommand)
+	} else {
+		args = append(args, cellMappingCommand)
 	}
 
 	envVars := map[string]env.Setter{}

--- a/pkg/novaconductor/dbsync.go
+++ b/pkg/novaconductor/dbsync.go
@@ -42,7 +42,7 @@ func CellDBSyncJob(
 	runAsUser := int64(0)
 
 	args := []string{"-c"}
-	if instance.Spec.Debug.StopDBSync {
+	if instance.Spec.Debug.StopJob {
 		args = append(args, common.DebugCommand)
 	} else {
 		args = append(args, cellDBSyncCommand)


### PR DESCRIPTION
Add Debug.StopJob into CR specs to control execution of
a job.

Added that, StopDBSync now becomes redundant as it controls db sync,
which is also a job. Having a generic StopJob looks better.
Remove StopDBSync and change the db sync job to use StopJob as well.

The 2nd user of the stopJob debug interface is the nova cellmapper job.

We can add more jobs in the future, which might be useful to debug as
well.

Also, remove implementation specific questions from the spec fileds
descriptions. 
