### PR TITLE
[compute]Configure live migration

### DIFF
--- a/templates/nova.conf
+++ b/templates/nova.conf
@@ -162,6 +162,11 @@ disable_fallback_pcpu_query=true
 {{ if eq .service_name "nova-compute"}}
 enable_qemu_monitor_announce_self=true
 reserve_disk_resource_for_image_cache=true
+
+# NOTE(gibi): We need this as live migration does not work with
+# cpu_mode=host-model . See https://bugs.launchpad.net/nova/+bug/2039803
+skip_cpu_compare_on_dest = true
+
 {{end}}
 
 {{ if eq .service_name "nova-compute"}}

--- a/templates/nova.conf
+++ b/templates/nova.conf
@@ -179,6 +179,8 @@ rx_queue_size=512
 tx_queue_size=512
 swtpm_enabled=True
 volume_use_multipath=true
+
+live_migration_uri = qemu+ssh://nova@%s/system?keyfile=/var/lib/nova/.ssh/ssh-privatekey
 {{end}}
 
 {{if (index . "cell_db_address")}}

--- a/test/functional/novacell_controller_test.go
+++ b/test/functional/novacell_controller_test.go
@@ -273,6 +273,9 @@ var _ = Describe("NovaCell controller", func() {
 			Expect(configData).To(ContainSubstring("[vnc]\nenabled = True"))
 			Expect(configData).Should(
 				ContainSubstring("[upgrade_levels]\ncompute = auto"))
+			Expect(configData).To(
+				ContainSubstring(
+					"live_migration_uri = qemu+ssh://nova@%s/system?keyfile=/var/lib/nova/.ssh/ssh-privatekey"))
 
 			th.ExpectCondition(
 				cell1.CellCRName,


### PR DESCRIPTION
The default nova-compute config is changed 
* to contain a live_migration_uri config that is suitable for the current EDPM deployment model.
* to set skip_cpu_compare_on_dest = True workaround flag to avoid an upstream nova bug https://bugs.launchpad.net/nova/+bug/2039803 