### PR TITLE
switch to structured logging

### DIFF
--- a/controllers/nova_controller.go
+++ b/controllers/nova_controller.go
@@ -1036,7 +1036,7 @@ func (r *NovaReconciler) ensureAPI(
 	}
 
 	if op != controllerutil.OperationResultNone {
-		Log.Info(fmt.Sprintf("NovaAPI %s , NovaAPI.Name %s.", string(op)), api.Name)
+		Log.Info(fmt.Sprintf("NovaAPI %s , NovaAPI.Name %s.", string(op), api.Name))
 	}
 
 	c := api.Status.Conditions.Mirror(novav1.NovaAPIReadyCondition)
@@ -1315,7 +1315,7 @@ func (r *NovaReconciler) ensureMQ(
 	}
 
 	if op != controllerutil.OperationResultNone {
-		Log.Info(fmt.Sprintf("TransportURL object %s created or patched %s", transportName, transportURL))
+		Log.Info(fmt.Sprintf("TransportURL object %s created or patched %+v", transportName, transportURL))
 		return "", nova.MQCreating, nil
 	}
 

--- a/controllers/nova_controller.go
+++ b/controllers/nova_controller.go
@@ -879,7 +879,7 @@ func (r *NovaReconciler) ensureCell(
 	}
 
 	if op != controllerutil.OperationResultNone {
-		Log.Info(fmt.Sprintf("NovaCell %s.", string(op)), "NovaCell.Name", cell.Name)
+		Log.Info(fmt.Sprintf("NovaCell %s , NovaCell.Name %s", string(op), cell.Name))
 	}
 
 	if !cell.IsReady() {
@@ -1036,7 +1036,7 @@ func (r *NovaReconciler) ensureAPI(
 	}
 
 	if op != controllerutil.OperationResultNone {
-		Log.Info(fmt.Sprintf("NovaAPI %s.", string(op)), "NovaAPI.Name", api.Name)
+		Log.Info(fmt.Sprintf("NovaAPI %s , NovaAPI.Name %s.", string(op)), api.Name)
 	}
 
 	c := api.Status.Conditions.Mirror(novav1.NovaAPIReadyCondition)
@@ -1110,9 +1110,8 @@ func (r *NovaReconciler) ensureScheduler(
 	}
 
 	if op != controllerutil.OperationResultNone {
-		Log.Info(fmt.Sprintf("NovaScheduler %s.", string(op)),
-			"NovaScheduler.Name", scheduler.Name,
-		)
+		Log.Info(fmt.Sprintf("NovaScheduler %s. NovaScheduler.Name %s", string(op),
+			scheduler.Name))
 	}
 
 	c := scheduler.Status.Conditions.Mirror(novav1.NovaSchedulerReadyCondition)
@@ -1316,7 +1315,7 @@ func (r *NovaReconciler) ensureMQ(
 	}
 
 	if op != controllerutil.OperationResultNone {
-		Log.Info(fmt.Sprintf("TransportURL object %s created or patched", transportName), transportURL)
+		Log.Info(fmt.Sprintf("TransportURL object %s created or patched %s", transportName, transportURL))
 		return "", nova.MQCreating, nil
 	}
 
@@ -1460,7 +1459,7 @@ func (r *NovaReconciler) ensureMetadata(
 	}
 
 	if op != controllerutil.OperationResultNone {
-		Log.Info(fmt.Sprintf("NovaMetadata %s.", string(op)), "NovaMetadata.Name", metadata.Name)
+		Log.Info(fmt.Sprintf("NovaMetadata %s, NovaMetadata.Name %s", string(op), metadata.Name))
 	}
 
 	c := metadata.Status.Conditions.Mirror(novav1.NovaMetadataReadyCondition)

--- a/controllers/novacell_controller.go
+++ b/controllers/novacell_controller.go
@@ -751,7 +751,7 @@ func (r *NovaCellReconciler) ensureNovaCompute(
 	}
 
 	if op != controllerutil.OperationResultNone {
-		Log.Info(fmt.Sprintf("NovaCompute %s.", string(op)), "NovaCompute.Name", novacompute.Name)
+		Log.Info(fmt.Sprintf("NovaCompute %s, NovaCompute.Name %s .", string(op), novacompute.Name))
 	}
 
 	if novacompute.IsReady() {

--- a/controllers/novacell_controller.go
+++ b/controllers/novacell_controller.go
@@ -39,6 +39,7 @@ import (
 	helper "github.com/openstack-k8s-operators/lib-common/modules/common/helper"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/labels"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/service"
+	util "github.com/openstack-k8s-operators/lib-common/modules/common/util"
 
 	novav1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
 )

--- a/controllers/novametadata_controller.go
+++ b/controllers/novametadata_controller.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"github.com/go-logr/logr"
 	common "github.com/openstack-k8s-operators/lib-common/modules/common"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
@@ -51,6 +52,11 @@ type NovaMetadataReconciler struct {
 	ReconcilerBase
 }
 
+// getlogger returns a logger object with a prefix of "conroller.name" and aditional controller context fields
+func (r *NovaMetadataReconciler) GetLogger(ctx context.Context) logr.Logger {
+	return log.FromContext(ctx).WithName("Controllers").WithName("NovaMetadata")
+}
+
 //+kubebuilder:rbac:groups=nova.openstack.org,resources=novametadata,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=nova.openstack.org,resources=novametadata/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=nova.openstack.org,resources=novametadata/finalizers,verbs=update
@@ -70,7 +76,7 @@ type NovaMetadataReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.12.2/pkg/reconcile
 func (r *NovaMetadataReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {
-	l := log.FromContext(ctx)
+	Log := r.GetLogger(ctx)
 
 	// Fetch the NovaMetadata instance that needs to be reconciled
 	instance := &novav1.NovaMetadata{}
@@ -81,11 +87,11 @@ func (r *NovaMetadataReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			// Request object not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected.
 			// For additional cleanup logic use finalizers. Return and don't requeue.
-			l.Info("NovaMetadata instance not found, probably deleted before reconciled. Nothing to do.")
+			Log.Info("NovaMetadata instance not found, probably deleted before reconciled. Nothing to do.")
 			return ctrl.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
-		l.Error(err, "Failed to read the NovaMetadata instance.")
+		Log.Error(err, "Failed to read the NovaMetadata instance.")
 		return ctrl.Result{}, err
 	}
 
@@ -94,13 +100,13 @@ func (r *NovaMetadataReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		r.Client,
 		r.Kclient,
 		r.Scheme,
-		r.Log,
+		Log,
 	)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	util.LogForObject(h, "Reconciling", instance)
+	Log.Info("Reconciling")
 
 	// initialize status fields
 	if err = r.initStatus(ctx, h, instance); err != nil {
@@ -205,8 +211,7 @@ func (r *NovaMetadataReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// We have to wait until our service is fully exposed so that we can
 	// generate the compute config containing the metadata host
 	if !instance.Status.Conditions.IsTrue(condition.ExposeServiceReadyCondition) {
-		util.LogForObject(
-			h, "Waiting for the service to be exposed before generating compute configuration", instance)
+		Log.Info("Waiting for the service to be exposed before generating compute configuration")
 		return ctrl.Result{}, nil
 	}
 
@@ -217,7 +222,7 @@ func (r *NovaMetadataReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return result, err
 	}
 
-	util.LogForObject(h, "Successfully reconciled", instance)
+	Log.Info("Successfully reconciled")
 	return ctrl.Result{}, nil
 }
 
@@ -365,11 +370,13 @@ func (r *NovaMetadataReconciler) ensureDeployment(
 	inputHash string,
 	annotations map[string]string,
 ) (ctrl.Result, error) {
+	Log := r.GetLogger(ctx)
+
 	serviceLabels := getMetadataServiceLabels(instance.Spec.CellName)
 	ss := statefulset.NewStatefulSet(novametadata.StatefulSet(instance, inputHash, serviceLabels, annotations), r.RequeueTimeout)
 	ctrlResult, err := ss.CreateOrPatch(ctx, h)
 	if err != nil && !k8s_errors.IsNotFound(err) {
-		util.LogErrorForObject(h, err, "Deployment failed", instance)
+		Log.Error(err, "Deployment failed")
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.DeploymentReadyCondition,
 			condition.ErrorReason,
@@ -378,7 +385,7 @@ func (r *NovaMetadataReconciler) ensureDeployment(
 			err.Error()))
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{} || k8s_errors.IsNotFound(err)) {
-		util.LogForObject(h, "Deployment in progress", instance)
+		Log.Info("Deployment in progress")
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.DeploymentReadyCondition,
 			condition.RequestedReason,
@@ -417,10 +424,10 @@ func (r *NovaMetadataReconciler) ensureDeployment(
 	}
 
 	if instance.Status.ReadyCount > 0 || *instance.Spec.Replicas == 0 {
-		util.LogForObject(h, "Deployment is ready", instance)
+		Log.Info("Deployment is ready")
 		instance.Status.Conditions.MarkTrue(condition.DeploymentReadyCondition, condition.DeploymentReadyMessage)
 	} else {
-		util.LogForObject(h, "Deployment is not ready", instance, "Status", ss.GetStatefulSet().Status)
+		Log.Info("Deployment is not ready", "Status", ss.GetStatefulSet().Status)
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.DeploymentReadyCondition,
 			condition.RequestedReason,
@@ -527,10 +534,11 @@ func (r *NovaMetadataReconciler) reconcileDelete(
 	h *helper.Helper,
 	instance *novav1.NovaMetadata,
 ) error {
-	util.LogForObject(h, "Reconciling delete", instance)
+	Log := r.GetLogger(ctx)
+	Log.Info("Reconciling delete")
 	// TODO(ksambor): add cleanup for the service rows in the nova DB
 	// when the service is scaled in or deleted
-	util.LogForObject(h, "Reconciled delete successfully", instance)
+	Log.Info("Reconciled delete successfully")
 	return nil
 }
 
@@ -632,6 +640,6 @@ func (r *NovaMetadataReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.Service{}).
 		Owns(&corev1.Secret{}).
 		Watches(&source.Kind{Type: &corev1.Secret{}},
-			handler.EnqueueRequestsFromMapFunc(r.GetSecretMapperFor(&novav1.NovaMetadataList{}))).
+			handler.EnqueueRequestsFromMapFunc(r.GetSecretMapperFor(&novav1.NovaMetadataList{}, context.TODO()))).
 		Complete(r)
 }

--- a/controllers/novascheduler_controller.go
+++ b/controllers/novascheduler_controller.go
@@ -198,9 +198,9 @@ func (r *NovaSchedulerReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	// clean up nova services from nova db should be always a last step in reconcile
 	// to make sure that
-	err = r.cleanServiceFromNovaDb(ctx, h, instance, secret, l)
+	err = r.cleanServiceFromNovaDb(ctx, h, instance, secret, Log)
 	if err != nil {
-		l.Error(err, "Failed cleaning services from nova db")
+		Log.Error(err, "Failed cleaning services from nova db")
 	}
 
 	return ctrl.Result{}, nil


### PR DESCRIPTION
This automatically adds additional fields like reconcile_id etc.. from the controller context.

before :

2023-05-18T01:53:14+03:00 INFO  controllers.KeystoneAPI Reconciled Service init successfully

after:

2023-10-18T02:27:44.637+0300    INFO    Controllers.NovaNoVNCProxy      Successfully reconciled {"control
ler": "novanovncproxy", "controllerGroup": "nova.openstack.org", "controllerKind": "NovaNoVNCProxy", "Nov
aNoVNCProxy": {"name":"nova-cell1-novncproxy","namespace":"openstack"}, "namespace": "openstack", "name":
 "nova-cell1-novncproxy", "reconcileID": "93d8ab7c-76f0-45ed-9981-f925fef21ae7", "instance": {"apiVersion
": "nova.openstack.org/v1beta1", "kind": "NovaNoVNCProxy", "namespace": "openstack", "name": "nova-cell1-
novncproxy"}}

*by using per reconcile function respective logger objects, the intention is to lay the ground for parallel reconciliation in future and avoid race conditions as ctx objects are reconcile run specific.
