### PR TITLE
Default [upgrade_levels]compute=auto for all services

### DIFF
--- a/pkg/nova/cellmapping.go
+++ b/pkg/nova/cellmapping.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	cellMappingCommand      = "/usr/local/bin/kolla_set_configs && /var/lib/openstack/bin/ensure_cell_mapping.sh"
+	cellMappingCommand = "/usr/local/bin/kolla_set_configs && /var/lib/openstack/bin/ensure_cell_mapping.sh"
 )
 
 func CellMappingJob(

--- a/templates/nova.conf
+++ b/templates/nova.conf
@@ -286,3 +286,6 @@ project_domain_name = {{ .default_project_domain }}
 user_domain_name = {{ .default_user_domain}}
 {{ end }}
 {{ end }}
+
+[upgrade_levels]
+compute = auto

--- a/test/functional/nova_compute_ironic_controller_test.go
+++ b/test/functional/nova_compute_ironic_controller_test.go
@@ -152,6 +152,8 @@ var _ = Describe("NovaCompute controller", func() {
 				configData := string(configDataMap.Data["01-nova.conf"])
 				Expect(configData).Should(
 					ContainSubstring("transport_url=rabbit://cell1/fake"))
+				Expect(configData).Should(
+					ContainSubstring("[upgrade_levels]\ncompute = auto"))
 				Expect(configData).Should(ContainSubstring("password = service-password"))
 				Expect(configData).Should(ContainSubstring("compute_driver = ironic.IronicDriver"))
 				Expect(configDataMap.Data).Should(HaveKey("02-nova-override.conf"))

--- a/test/functional/nova_metadata_controller_test.go
+++ b/test/functional/nova_metadata_controller_test.go
@@ -171,6 +171,8 @@ var _ = Describe("NovaMetadata controller", func() {
 				Expect(configData).Should(
 					ContainSubstring(
 						"connection = mysql+pymysql://nova_api:api-database-password@nova-api-db-hostname/nova_api"))
+				Expect(configData).Should(
+					ContainSubstring("[upgrade_levels]\ncompute = auto"))
 				Expect(configDataMap.Data).Should(HaveKey("02-nova-override.conf"))
 				extraData := string(configDataMap.Data["02-nova-override.conf"])
 				Expect(extraData).To(Equal("foo=bar"))

--- a/test/functional/nova_novncproxy_test.go
+++ b/test/functional/nova_novncproxy_test.go
@@ -164,6 +164,8 @@ var _ = Describe("NovaNoVNCProxy controller", func() {
 				Expect(configData).Should(ContainSubstring("novncproxy_port = 6080"))
 				Expect(configData).Should(ContainSubstring("password = service-password"))
 				Expect(configData).Should(ContainSubstring("transport_url=rabbit://cell1/fake"))
+				Expect(configData).Should(
+					ContainSubstring("[upgrade_levels]\ncompute = auto"))
 				Expect(configDataMap.Data).Should(HaveKey("02-nova-override.conf"))
 				extraData := string(configDataMap.Data["02-nova-override.conf"])
 				Expect(extraData).To(Equal("foo=bar"))

--- a/test/functional/nova_scheduler_test.go
+++ b/test/functional/nova_scheduler_test.go
@@ -165,6 +165,8 @@ var _ = Describe("NovaScheduler controller", func() {
 			configData := string(configDataMap.Data["01-nova.conf"])
 			Expect(configData).To(ContainSubstring("transport_url=rabbit://api/fake"))
 			Expect(configData).To(ContainSubstring("password = service-password"))
+			Expect(configData).Should(
+				ContainSubstring("[upgrade_levels]\ncompute = auto"))
 			Expect(configDataMap.Data).Should(HaveKey("02-nova-override.conf"))
 			extraConfigData := string(configDataMap.Data["02-nova-override.conf"])
 			Expect(extraConfigData).To(Equal("foo=bar"))

--- a/test/functional/novaapi_controller_test.go
+++ b/test/functional/novaapi_controller_test.go
@@ -181,6 +181,8 @@ var _ = Describe("NovaAPI controller", func() {
 				Expect(configData).Should(ContainSubstring("osapi_compute_workers=1"))
 				Expect(configData).Should(ContainSubstring("auth_url = keystone-internal-auth-url"))
 				Expect(configData).Should(ContainSubstring("www_authenticate_uri = keystone-public-auth-url"))
+				Expect(configData).Should(
+					ContainSubstring("[upgrade_levels]\ncompute = auto"))
 				Expect(configDataMap.Data).Should(HaveKey("02-nova-override.conf"))
 				extraData := string(configDataMap.Data["02-nova-override.conf"])
 				Expect(extraData).To(Equal("foo=bar"))

--- a/test/functional/novacell_controller_test.go
+++ b/test/functional/novacell_controller_test.go
@@ -271,6 +271,8 @@ var _ = Describe("NovaCell controller", func() {
 				fmt.Sprintf("nova-novncproxy-%s-public.%s.svc:6080", cell1.CellName, cell1.CellCRName.Namespace))
 			Expect(configData).To(ContainSubstring(vncUrlConfig))
 			Expect(configData).To(ContainSubstring("[vnc]\nenabled = True"))
+			Expect(configData).Should(
+				ContainSubstring("[upgrade_levels]\ncompute = auto"))
 
 			th.ExpectCondition(
 				cell1.CellCRName,

--- a/test/functional/novaconductor_controller_test.go
+++ b/test/functional/novaconductor_controller_test.go
@@ -165,6 +165,8 @@ var _ = Describe("NovaConductor controller", func() {
 				configData := string(configDataMap.Data["01-nova.conf"])
 				Expect(configData).Should(ContainSubstring("password = service-password"))
 				Expect(configData).Should(ContainSubstring("transport_url=rabbit://cell0/fake"))
+				Expect(configData).Should(
+					ContainSubstring("[upgrade_levels]\ncompute = auto"))
 				Expect(configDataMap.Data).Should(HaveKey("02-nova-override.conf"))
 				extraData := string(configDataMap.Data["02-nova-override.conf"])
 				Expect(extraData).To(Equal("foo=bar"))


### PR DESCRIPTION
This is important for upgrade and adoption support and safe to use in greenfield as well.