### PR TITLE
[tempest]Disable swift tests

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -205,6 +205,9 @@
         - test_server_connectivity_cold_migration
         - test_server_connectivity_live_migration
         - test_server_connectivity_resize
+      # Swift test failing with unauthorized errors
+        - tempest.api.object_storage
+        - tempest.scenario.test_object_storage
 - project:
     name: openstack-k8s-operators/nova-operator
     github-check:


### PR DESCRIPTION
The object storage tests started to fail with Unauthorized errors. So this PR disables them. We might keep them disabled for the long run as nova-operator and nova does not depends on swift.