### PR TITLE
adapt to zuul_inventory.yml to zuul-params.yml rename

### DIFF
--- a/ci/nova-operator-base/playbooks/pre-wrapper.yaml
+++ b/ci/nova-operator-base/playbooks/pre-wrapper.yaml
@@ -12,7 +12,7 @@
       -e "{{   extra_vars }}"
       {%-   endfor %}
       {%- endif %}
-      -e @scenarios/centos-9/zuul_inventory.yml
+      -e "@{{ ansible_user_dir }}/ci-framework-data/artifacts/parameters/zuul-params.yml"
     ci_framework_playbooks_path: "{{[ ansible_user_dir,
               zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir,
               'ci_framework','playbooks'] | ansible.builtin.path_join }}"


### PR DESCRIPTION
ci framework pr 642 changed the name of the generated paramaters file to denote its not really an inventory.

this change just adaps the nova job to take account of that rename

(cherry picked from commit ed5ce2fa73aac44779d3de2f84b3470ad7ae9259)