### PR TITLE
Enable CPU power management by default for libvirt compute

### DIFF
--- a/templates/nova.conf
+++ b/templates/nova.conf
@@ -184,8 +184,8 @@ rx_queue_size=512
 tx_queue_size=512
 swtpm_enabled=True
 volume_use_multipath=true
-
 live_migration_uri = qemu+ssh://nova@%s/system?keyfile=/var/lib/nova/.ssh/ssh-privatekey
+cpu_power_management=true
 {{end}}
 
 {{if (index . "cell_db_address")}}

--- a/test/functional/novacell_controller_test.go
+++ b/test/functional/novacell_controller_test.go
@@ -276,6 +276,7 @@ var _ = Describe("NovaCell controller", func() {
 			Expect(configData).To(
 				ContainSubstring(
 					"live_migration_uri = qemu+ssh://nova@%s/system?keyfile=/var/lib/nova/.ssh/ssh-privatekey"))
+			Expect(configData).To(ContainSubstring("cpu_power_management=true"))
 
 			th.ExpectCondition(
 				cell1.CellCRName,


### PR DESCRIPTION
Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/591 (to pick up a new tcib) (merged)
Implementes: https://issues.redhat.com/browse/OSPRH-83