### PR TITLE
[api]ensure sidecar terminates on SIGTERM

### DIFF
--- a/pkg/novaapi/deployment.go
+++ b/pkg/novaapi/deployment.go
@@ -129,9 +129,16 @@ func StatefulSet(
 						{
 							Name: instance.Name + "-log",
 							Command: []string{
-								"/bin/bash",
+								"/usr/bin/dumb-init",
 							},
-							Args:  []string{"-c", "tail -n+1 -F /var/log/nova/nova-api.log"},
+							Args: []string{
+								"--single-child",
+								"--",
+								"/usr/bin/tail",
+								"-n+1",
+								"-F",
+								"/var/log/nova/nova-api.log",
+							},
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: ptr.To(nova.NovaUserID),

--- a/pkg/novametadata/deployment.go
+++ b/pkg/novametadata/deployment.go
@@ -129,9 +129,16 @@ func StatefulSet(
 						{
 							Name: instance.Name + "-log",
 							Command: []string{
-								"/bin/bash",
+								"/usr/bin/dumb-init",
 							},
-							Args:  []string{"-c", "tail -n+1 -F /var/log/nova/nova-metadata.log"},
+							Args: []string{
+								"--single-child",
+								"--",
+								"/usr/bin/tail",
+								"-n+1",
+								"-F",
+								"/var/log/nova/nova-metadata.log",
+							},
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: ptr.To(nova.NovaUserID),


### PR DESCRIPTION
We noticed that nova-api and nova-metadata pods do not immediately terminate on delete as the logging sidecar ignores SIGTERM. This PR adds the usage of dump-init to the sidecar command to ensure it handles SIGTERM properly

Fixes: [OSPRH-770](https://issues.redhat.com//browse/OSPRH-770)