### PR TITLE
enable srbac by default

### DIFF
--- a/templates/nova.conf
+++ b/templates/nova.conf
@@ -62,7 +62,8 @@ heartbeat_in_pthread=false
 
 {{ if eq .service_name "nova-api"}}
 [oslo_policy]
-enforce_new_defaults=false
+enforce_new_defaults=true
+enforce_scope=true
 {{end}}
 
 {{ if eq .service_name "nova-conductor"}}

--- a/test/functional/novaapi_controller_test.go
+++ b/test/functional/novaapi_controller_test.go
@@ -183,6 +183,9 @@ var _ = Describe("NovaAPI controller", func() {
 				Expect(configData).Should(ContainSubstring("www_authenticate_uri = keystone-public-auth-url"))
 				Expect(configData).Should(
 					ContainSubstring("[upgrade_levels]\ncompute = auto"))
+				Expect(configData).Should(ContainSubstring("enforce_new_defaults=true"))
+				Expect(configData).Should(ContainSubstring("enforce_scope=true"))
+				// test config override
 				Expect(configDataMap.Data).Should(HaveKey("02-nova-override.conf"))
 				extraData := string(configDataMap.Data["02-nova-override.conf"])
 				Expect(extraData).To(Equal("foo=bar"))


### PR DESCRIPTION
This change enables nova's srbac feature
including scope enforcement

Closes: [OSPRH-1505](https://issues.redhat.com//browse/OSPRH-1505)