### PR TITLE
nova-metadata-neutron-config secret to only have 05-nova-metadata.conf

### DIFF
--- a/controllers/novametadata_controller.go
+++ b/controllers/novametadata_controller.go
@@ -612,7 +612,7 @@ func (r *NovaMetadataReconciler) generateNeutronConfigs(
 		{
 			Name:               configName,
 			Namespace:          instance.GetNamespace(),
-			Type:               util.TemplateTypeConfig,
+			Type:               util.TemplateTypeNone,
 			InstanceType:       instance.GetObjectKind().GroupVersionKind().Kind,
 			ConfigOptions:      templateParameters,
 			Labels:             labels,


### PR DESCRIPTION
Right now the generated nova-metadata-neutron-config has not only the 05-nova-metadata.conf file. Instead it has rendered httpd.conf and nova-metadata-config.json:

```
apiVersion: v1
data:
  05-nova-metadata.conf: W0RFRkFVTFR...
  httpd.conf: U2VydmVyVG9rZW5zIFByb2...
  nova-metadata-config.json: ewogICJ...
```

This change sets the Template Type to util.TemplateTypeNone that it won't render the templates from the config subdir and only renders the one provided via the AdditionalTemplate.