### PR TITLE
[envtest]Cover the size of nova-metadata-neutron-config

### DIFF
--- a/test/functional/nova_metadata_controller_test.go
+++ b/test/functional/nova_metadata_controller_test.go
@@ -284,6 +284,7 @@ var _ = Describe("NovaMetadata controller", func() {
 
 				computeConfigData := th.GetSecret(novaNames.MetadataNeutronConfigDataName)
 				Expect(computeConfigData).ShouldNot(BeNil())
+				Expect(computeConfigData.Data).To(HaveLen(1))
 				Expect(computeConfigData.Data).Should(HaveKey("05-nova-metadata.conf"))
 				configData := string(computeConfigData.Data["05-nova-metadata.conf"])
 				Expect(configData).To(


### PR DESCRIPTION
We had a regression recently due to not checking in the test that the nova-metadata-neutron-config should have a single key.

This is adding the missing test coverage. The fix was done in #628