### PR TITLE
Set ServiceAccount for cell novametadata

### DIFF
--- a/api/v1beta1/novametadata_types.go
+++ b/api/v1beta1/novametadata_types.go
@@ -247,6 +247,7 @@ func NewNovaMetadataSpec(
 		},
 		KeystoneAuthURL: novaCell.KeystoneAuthURL,
 		ServiceUser:     novaCell.ServiceUser,
+		ServiceAccount:  novaCell.ServiceAccount,
 		Override:        novaCell.MetadataServiceTemplate.Override,
 	}
 	return metadataSpec

--- a/test/functional/novacell_controller_test.go
+++ b/test/functional/novacell_controller_test.go
@@ -219,7 +219,7 @@ var _ = Describe("NovaCell controller", func() {
 		})
 
 		It("creates the NovaMetadata and tracks its readiness", func() {
-			GetNovaMetadata(cell1.MetadataName)
+			metadata := GetNovaMetadata(cell1.MetadataName)
 			th.ExpectCondition(
 				cell1.CellCRName,
 				ConditionGetterFunc(NovaCellConditionGetter),
@@ -228,6 +228,7 @@ var _ = Describe("NovaCell controller", func() {
 			)
 			novaCell := GetNovaCell(cell1.CellCRName)
 			Expect(novaCell.Status.MetadataServiceReadyCount).To(Equal(int32(0)))
+			Expect(metadata.Spec.ServiceAccount).To(Equal(novaCell.Spec.ServiceAccount))
 
 			// make metadata ready
 			th.SimulateStatefulSetReplicaReady(cell1.MetadataStatefulSetName)


### PR DESCRIPTION
When deploy novametadata per cell, pod create fails right now with

pods "nova-cell1-metadata-0" is forbidden: unable to validate against any security context constraint: ...

The reason is that in metadata per cell use case no ServiceAccount is being set in NewNovaMetadataSpec() as it is done when deploying single NovaMetadata [1].
This adds setting ServiceAccount in NewNovaMetadataSpec().

[1] https://github.com/openstack-k8s-operators/nova-operator/blob/main/controllers/nova_controller.go#L1428