### PR TITLE
[must-gather]Add GMR file trigger support

### DIFF
--- a/templates/nova.conf
+++ b/templates/nova.conf
@@ -309,3 +309,7 @@ user_domain_name = {{ .default_user_domain}}
 
 [upgrade_levels]
 compute = auto
+
+[oslo_reports]
+# api services need file based GMR trigger as apache disables signal handling
+file_event_handler=/var/lib/nova


### PR DESCRIPTION
The API services can only use the file trigger for GMR as apache
disables signal handling. This PR adds the file trigger config for
every server.
GMR can be triggered by
```
  oc exec  <service pod> -- touch /var/lib/nova
```
Optionally non apache based services produce GMR also via
```
  oc exec <service pod> -- kill -USR2 1
```

Related-to: https://issues.redhat.com/browse/OSPRH-730