### PR TITLE
Remove CI-framework ci_framework dir references

### DIFF
--- a/ci/nova-operator-base/ansible.cfg
+++ b/ci/nova-operator-base/ansible.cfg
@@ -1,2 +1,2 @@
 [defaults]
-roles_path = /usr/share/ansible/roles:/etc/ansible/roles:../../../ci-framework/ci_framework/roles
+roles_path = /usr/share/ansible/roles:/etc/ansible/roles:../../../ci-framework/roles

--- a/ci/nova-operator-base/playbooks/pre-wrapper.yaml
+++ b/ci/nova-operator-base/playbooks/pre-wrapper.yaml
@@ -15,7 +15,7 @@
       -e "@{{ ansible_user_dir }}/ci-framework-data/artifacts/parameters/zuul-params.yml"
     ci_framework_playbooks_path: "{{[ ansible_user_dir,
               zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir,
-              'ci_framework','playbooks'] | ansible.builtin.path_join }}"
+              'playbooks'] | ansible.builtin.path_join }}"
     pre_playbook: "{{nova_operator_basedir}}/ci/nova-operator-base/playbooks/pre.yaml"
     controller_logs_dir: "{{ ansible_user_dir }}/zuul-output/logs/controller"
   tasks:

--- a/ci/nova-operator-base/playbooks/pre.yaml
+++ b/ci/nova-operator-base/playbooks/pre.yaml
@@ -3,7 +3,7 @@
   ansible.builtin.import_playbook: >-
       {{[ ansible_user_dir,
       zuul.projects["github.com/openstack-k8s-operators/ci-framework"].src_dir,
-      "ci_framework/playbooks/01-bootstrap.yml"] | ansible.builtin.path_join}}
+      "playbooks/01-bootstrap.yml"] | ansible.builtin.path_join}}
 
 - hosts: "{{ cifmw_target_host | default('localhost') }}"
   name: install dev tools
@@ -17,7 +17,7 @@
   ansible.builtin.import_playbook: >-
       {{[ ansible_user_dir,
       zuul.projects["github.com/openstack-k8s-operators/ci-framework"].src_dir,
-      "ci_framework/playbooks/02-infra.yml"] | ansible.builtin.path_join}}
+      "playbooks/02-infra.yml"] | ansible.builtin.path_join}}
 
 - name: Build dataset hook
   hosts: localhost

--- a/ci/nova-operator-kuttl/ansible.cfg
+++ b/ci/nova-operator-kuttl/ansible.cfg
@@ -1,2 +1,2 @@
 [defaults]
-roles_path = /usr/share/ansible/roles:/etc/ansible/roles:../../../ci-framework/ci_framework/roles
+roles_path = /usr/share/ansible/roles:/etc/ansible/roles:../../../ci-framework/roles


### PR DESCRIPTION
Since the framework is removing that unnecessary level, that is now a symlink of the root level dirs, we can safely get rid off that directory usages before they are gone in the framework repo.