### PR TITLE
update container images for fips

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,9 +160,13 @@ run: manifests generate fmt vet ## Run a controller from your host.
 	/bin/bash hack/clean_local_webhook.sh
 	go run ./main.go -metrics-bind-address ":$(METRICS_PORT)" -health-probe-bind-address ":$(HEALTH_PORT)"
 
+
+# Extra vars which will be passed to the Docker-build
+DOCKER_BUILD_ARGS ?=
+
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
-	podman build -t ${IMG} .
+	podman build -t ${IMG} . ${DOCKER_BUILD_ARGS}
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can use [openshift-local](https://developers.redhat.com/products/openshift-l
 
 ### golang
 
-this repo currently uses go 1.18
+This repo currently uses go 1.19+
 
 ### pre-commit
 


### PR DESCRIPTION
This change modifes the builder image use the fully qualified name
but maintains the current version of go 1.19

A new GO_BUILD_EXTRA_ENV_ARGS build argument is added to allow
the env parmaters set during the go build step to be
modifed when building the image.

it defaults to "CGO_ENABLED=0 GO111MODULE=on"

we use CGO_ENABLED=0 by default so that the manager binary
is staticly linked. this allows us to use the
gcr.io/distroless/static:nonroot image as our base image.

prow jobs will be added to test building with
CGO_ENABLED=1 and a fips enabled toolchain

The makefile is extened to support passing DOCKER_BUILD_ARGS
to the build command executed by docker-build

Closes: [OSPRH-3106](https://issues.redhat.com//browse/OSPRH-3106)
