### PR TITLE
Revert "Enable CPU power management by default for libvirt compute"

### DIFF
--- a/templates/nova.conf
+++ b/templates/nova.conf
@@ -185,8 +185,8 @@ rx_queue_size=512
 tx_queue_size=512
 swtpm_enabled=True
 volume_use_multipath=true
+
 live_migration_uri = qemu+ssh://nova@%s/system?keyfile=/var/lib/nova/.ssh/ssh-privatekey
-cpu_power_management=true
 {{end}}
 
 {{if (index . "cell_db_address")}}

--- a/test/functional/novacell_controller_test.go
+++ b/test/functional/novacell_controller_test.go
@@ -277,7 +277,6 @@ var _ = Describe("NovaCell controller", func() {
 			Expect(configData).To(
 				ContainSubstring(
 					"live_migration_uri = qemu+ssh://nova@%s/system?keyfile=/var/lib/nova/.ssh/ssh-privatekey"))
-			Expect(configData).To(ContainSubstring("cpu_power_management=true"))
 
 			th.ExpectCondition(
 				cell1.CellCRName,


### PR DESCRIPTION
This reverts commit 3d19fcc042878f923f745f9a9addec07a9dabd6f. As there are multiple errors when cpu_dedicate_set is defined.

Related: [OSPRH-83](https://issues.redhat.com/browse/OSPRH-83)
Related: [OSPRH-3505](https://issues.redhat.com/browse/OSPRH-3505)

(cherry picked from commit 8f204945b887a562229143f40901c4540925e9cd)