### PR TITLE
Fix unstable validation test

### DIFF
--- a/test/functional/validation_webhook_test.go
+++ b/test/functional/validation_webhook_test.go
@@ -593,9 +593,8 @@ var _ = Describe("Nova validation", func() {
 		Expect(errors.As(err, &statusError)).To(BeTrue())
 		Expect(statusError.ErrStatus.Message).To(
 			ContainSubstring(
-				"invalid: spec.cellTemplates[cell2].cellMessageBusInstance: " +
-					"Invalid value: \"rabbitmq-of-caerbannog\": RabbitMqCluster " +
-					"CR need to be uniq per cell. It's duplicated with cell: cell1",
+				"Invalid value: \"rabbitmq-of-caerbannog\": RabbitMqCluster " +
+					"CR need to be uniq per cell. It's duplicated with cell:",
 			),
 		)
 	})


### PR DESCRIPTION
Because of undefined iteration order in go we can't depend on in it in tests. This test still will check if error occured simply will ignor cell naming in log msg