### PR TITLE
Fix kolla config for host discovery job

### DIFF
--- a/templates/nova-manage/config/host-discover-config.json
+++ b/templates/nova-manage/config/host-discover-config.json
@@ -1,5 +1,5 @@
 {
-    "command": "/var/lib/openstack/bin/host_discover.sh",
+    "command": "/bin/host_discover.sh",
     "config_files": [
         {
             "source": "/var/lib/openstack/config/nova-blank.conf",


### PR DESCRIPTION
Kolla copies the script to bin and sets the proper permissions to it but then it tries to execute it from the mount point where only root has permission.

```
❯ oc logs --follow nova-cell1-host-discover-8vtfm
+ sudo -E kolla_set_configs
sudo: unable to send audit message: Operation not permitted
INFO:__main__:Loading config file at /var/lib/kolla/config_files/config.json
INFO:__main__:Validating config file
INFO:__main__:Kolla config strategy set to: COPY_ALWAYS
INFO:__main__:Copying service configuration files
INFO:__main__:Deleting /etc/nova/nova.conf
INFO:__main__:Copying /var/lib/openstack/config/nova-blank.conf to /etc/nova/nova.conf
INFO:__main__:Setting permission for /etc/nova/nova.conf
INFO:__main__:Copying /var/lib/openstack/config/01-nova.conf to /etc/nova/nova.conf.d/01-nova.conf
INFO:__main__:Setting permission for /etc/nova/nova.conf.d/01-nova.conf
INFO:__main__:Copying /var/lib/openstack/bin/host_discover.sh to /bin/host_discover.sh
INFO:__main__:Setting permission for /bin/host_discover.sh
INFO:__main__:Writing out command to execute
++ cat /run_command
+ CMD=/var/lib/openstack/bin/host_discover.sh
+ ARGS=
+ sudo kolla_copy_cacerts
sudo: unable to send audit message: Operation not permitted
+ [[ ! -n '' ]]
+ . kolla_extend_start
+ echo 'Running command: '\''/var/lib/openstack/bin/host_discover.sh'\'''
Running command: '/var/lib/openstack/bin/host_discover.sh'
+ umask 0022
+ exec /var/lib/openstack/bin/host_discover.sh
/usr/local/bin/kolla_start: line 22: /var/lib/openstack/bin/host_discover.sh: Permission denied
```

So this patch fixed the kolla config to execute the script from /bin