### PR TITLE
Fix operator crash at compute removal

### DIFF
--- a/controllers/novacell_controller.go
+++ b/controllers/novacell_controller.go
@@ -675,8 +675,7 @@ func (r *NovaCellReconciler) ensureNovaComputeDeleted(
 	if err != nil && k8s_errors.IsNotFound(err) {
 		return err
 	}
-	Log.Info("NovaCompute isn't defined in the cell, so deleted NovaCompute",
-		instance, "NovaCompute", compute)
+	Log.Info("NovaCompute isn't defined in the cell, so deleted NovaCompute", "NovaCompute", compute)
 
 	return nil
 }

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -943,3 +943,11 @@ func GetDefaultNovaComputeSpec(cell CellNames) map[string]interface{} {
 		"computeDriver":        novav1.IronicDriver,
 	}
 }
+
+func AssertComputeDoesNotExist(name types.NamespacedName) {
+	instance := &novav1.NovaCompute{}
+	Eventually(func(g Gomega) {
+		err := k8sClient.Get(ctx, name, instance)
+		g.Expect(k8s_errors.IsNotFound(err)).To(BeTrue())
+	}, timeout, interval).Should(Succeed())
+}


### PR DESCRIPTION
When a compute definition is removed from the novaComputeTemplates the nova-operator crashed due to a wrong logging statement. This is fixed now and the missing test coverage is added.