### PR TITLE
[webhook]Fix compute template rejection messages

### DIFF
--- a/api/v1beta1/nova_webhook.go
+++ b/api/v1beta1/nova_webhook.go
@@ -204,12 +204,12 @@ func (r *NovaSpec) ValidateCellTemplates(basePath *field.Path) field.ErrorList {
 			if computeTemplate.ComputeDriver == IronicDriver {
 				errors = append(
 					errors, computeTemplate.ValidateIronicDriverReplicas(
-						basePath.Child("novaComputeTemplates"))...,
+						cellPath.Child("novaComputeTemplates").Key(computeName))...,
 				)
 			}
 			errors = append(
 				errors, ValidateNovaComputeName(
-					basePath.Child("novaComputeTemplates"), computeName)...,
+					cellPath.Child("novaComputeTemplates").Key(computeName), computeName)...,
 			)
 		}
 	}

--- a/api/v1beta1/novacell_webhook.go
+++ b/api/v1beta1/novacell_webhook.go
@@ -137,12 +137,12 @@ func (r *NovaCellSpec) validate(basePath *field.Path) field.ErrorList {
 		if computeTemplate.ComputeDriver == IronicDriver {
 			errors = append(
 				errors, computeTemplate.ValidateIronicDriverReplicas(
-					basePath.Child("novaComputeTemplates"))...,
+					basePath.Child("novaComputeTemplates").Key(computeName))...,
 			)
 		}
 		errors = append(
 			errors, ValidateNovaComputeName(
-				basePath.Child("novaComputeTemplates"), computeName)...,
+				basePath.Child("novaComputeTemplates").Key(computeName), computeName)...,
 		)
 	}
 

--- a/api/v1beta1/novacompute_webhook.go
+++ b/api/v1beta1/novacompute_webhook.go
@@ -184,9 +184,9 @@ func ValidateNovaComputeName(path *field.Path, computeName string) field.ErrorLi
 
 // ValidateNovaComputeCell0 validates cell0 NoVNCProxy template. This is expected to be
 // called by higher level validation webhooks
-func ValidateNovaComputeCell0(basePath *field.Path, mapLenght int) field.ErrorList {
+func ValidateNovaComputeCell0(basePath *field.Path, mapLength int) field.ErrorList {
 	var errors field.ErrorList
-	if mapLenght > 0 {
+	if mapLength > 0 {
 		errors = append(
 			errors,
 			field.Invalid(


### PR DESCRIPTION
Some of the validation code used wrong yaml path when referring to the invalid value in the rejection message. This is fixed now and a missing test case is added to cover ironic replicas.