### PR TITLE
[envtest]Stabilize racy testcase

### DIFF
--- a/test/functional/novacell_controller_test.go
+++ b/test/functional/novacell_controller_test.go
@@ -457,8 +457,10 @@ var _ = Describe("NovaCell controller", func() {
 				condition.ReadyCondition,
 				corev1.ConditionTrue,
 			)
-			novaCell = GetNovaCell(cell1.CellCRName)
-			Expect(novaCell.Status.NovaComputesStatus).To(BeEmpty())
+			Eventually(func(g Gomega) {
+				novaCell = GetNovaCell(cell1.CellCRName)
+				g.Expect(novaCell.Status.NovaComputesStatus).To(BeEmpty())
+			}, timeout, interval).Should(Succeed())
 
 		})
 	})


### PR DESCRIPTION
The 8ff92076b115d5bd5805011d5e3eb3c08c611d58 introduced a racy test case as it expected that the NovaCell status is up to date after the Cell's Ready condition is True during NovaCompute delete. It turns out that it is not true. So this patch wraps the test asserts to an Eventually block to stabilize them.

The original issue could be reproduced locally with:
```
diff --git a/controllers/novacell_controller.go b/controllers/novacell_controller.go
index 4080438d..5f0e06bb 100644
--- a/controllers/novacell_controller.go
+++ b/controllers/novacell_controller.go
@@ -191,6 +191,7 @@ func (r *NovaCellReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
                        if err != nil {
                                return ctrl.Result{}, err
                        }
+                       time.Sleep(1 * time.Second)
                        delete(instance.Status.NovaComputesStatus, computeName)
                }
```