### PR TITLE
add a nova tempest ceph job

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -128,6 +128,61 @@
         [libvirt]
         cpu_mode = custom
         cpu_models = Nehalem
+- job:
+    name: nova-operator-tempest-multinode-ceph
+    parent: podified-multinode-hci-deployment-crc-3comp
+    dependencies: ["openstack-k8s-operators-content-provider"]
+    # Note:  When inheriting from a job (or creating a variant of a job) vars are merged with previous definitions
+    vars:
+      cifmw_extras:
+        - "@scenarios/centos-9/multinode-ci.yml"
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/nova-operator'].src_dir }}/ci/nova-operator-tempest-multinode-ceph/ci_fw_vars.yaml"
+      # dedupe this later
+      cifmw_run_test_role: test_operator
+      cifmw_test_operator_concurrency: 4
+      cifmw_test_operator_timeout: 7200
+      cifmw_tempest_tempestconf_config:
+          overrides: |
+            compute.min_compute_nodes 3
+            identity.v3_endpoint_type public
+            compute-feature-enabled.vnc_console true
+            compute-feature-enabled.stable_rescue true
+            compute-feature-enabled.hostname_fqdn_sanitization true
+            compute-feature-enabled.live_migration true
+            compute-feature-enabled.block_migration_for_live_migration false
+            volume.storage_protocol ceph
+            validation.run_validation true
+            service_available.swift false
+            service_available.cinder true
+      cifmw_test_operator_tempest_include_list: |
+          tempest.api.compute
+          tempest.scenario
+      # for now lets disable all encyption tests just to ensure we have basic integration working
+      # skip test_rebuild_volume_backed_server because of incorrect user "Please login as 'cirros' user, not as root"
+      cifmw_test_operator_tempest_exclude_list: |
+          tempest.api.compute.servers.test_device_tagging
+          test_create_server_invalid_bdm_in_2nd_dict
+          tempest.scenario.test_minimum_basic.TestMinimumBasicScenario.test_minimum_basic_scenario
+          tempest.scenario.test_stamp_pattern
+          tempest.api.compute.admin.test_live_migration.LiveMigrationTest.test_live_migration_with_trunk
+          tempest.scenario.test_network_advanced_server_ops.TestNetworkAdvancedServerOps.test_server_connectivity_live_migration
+          tempest.api.compute.admin.test_auto_allocate_network.AutoAllocateNetworkTest.test_server_multi_create_auto_allocate
+          tempest.api.compute.servers.test_server_rescue.ServerStableDeviceRescueTestIDE
+          tempest.scenario.test_network_basic_ops.TestNetworkBasicOps.test_mtu_sized_frames
+          tempest.scenario.test_encrypted_cinder_volumes.TestEncryptedCinderVolumes
+          crypt
+          tempest.api.compute.servers.test_server_actions.ServerActionsV293TestJSON.test_rebuild_volume_backed_server
+          tempest.scenario.test_server_volume_attachment.TestServerVolumeAttachScenarioOldVersion.test_old_versions_reject
+          tempest.scenario.test_server_volume_attachment.TestServerVolumeAttachmentScenario.test_server_detach_rules
+
+      # We need to use a custom cpu model to allow live migrating between
+      # slightly different computes coming from the node pool
+      # for ceph i might need to add https://github.com/openstack-k8s-operators/docs/blob/main/ceph.md#configure-nova
+      # but if i do i can just add that here as i dont know what the fsid will be
+      cifmw_edpm_deploy_nova_compute_extra_config: |
+        [libvirt]
+        cpu_mode = custom
+        cpu_models = Nehalem
 
 - project:
     name: openstack-k8s-operators/nova-operator
@@ -136,3 +191,4 @@
         - openstack-k8s-operators-content-provider
         - nova-operator-kuttl
         - nova-operator-tempest-multinode
+        - nova-operator-tempest-multinode-ceph

--- a/ci/nova-operator-tempest-multinode-ceph/ci_fw_vars.yaml
+++ b/ci/nova-operator-tempest-multinode-ceph/ci_fw_vars.yaml
@@ -1,0 +1,40 @@
+---
+cifmw_install_yamls_vars:
+  BMO_SETUP: false
+  INSTALL_CERT_MANAGER: false
+
+cifmw_edpm_prepare_skip_crc_storage_creation: true
+
+
+cifmw_services_swift_enabled: false
+pre_deploy:
+  - name: 61 HCI pre deploy kustomizations
+    type: playbook
+    source: control_plane_hci_pre_deploy.yml
+
+# note by defualt the source for the playbook specified
+# in the hooks is relative to
+# https://github.com/openstack-k8s-operators/ci-framework/tree/main/hooks/playbooks
+# if you want to use a different source you can use the full path on the ansible controller
+post_deploy:
+  - name: 81 Kustomize OpenStack CR with Ceph
+    type: playbook
+    source: control_plane_ceph_backends.yml
+  - name: 82 Kustomize and update Control Plane
+    type: playbook
+    source: control_plane_kustomize_deploy.yml
+
+# we can use this hook to create flavors, images, etc
+# before we execute tempest simiilar to how we would use
+# local.sh in devstack based jobs
+# pre_tempest:
+#   - name: Create manila resources
+#     type: playbook
+#     source: manila_create_default_resources.yml
+
+cifmw_run_tests: true
+cifmw_tempest_container: openstack-tempest-extras
+# we do not want the ci framwork trying to enbable any
+# tempest groups by default we will manage all tempest execution
+# via the job definition.
+cifmw_tempest_default_groups: []


### PR DESCRIPTION
This second job variant is trying to enable ceph for nova
and cinder storage.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/1515
Closes: [OSPRH-94](https://issues.redhat.com//browse/OSPRH-94)
