### PR TITLE
Update nodeset to use newer crc

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -74,12 +74,7 @@
       - ci/nova-operator-kuttl/playbooks/deploy-deps.yaml
     run:
       - ci/nova-operator-kuttl/playbooks/run-kuttl.yaml
-    nodeset:
-      nodes:
-        - name: controller
-          label: cloud-centos-9-stream-tripleo-vexxhost
-        - name: crc
-          label: coreos-crc-extracted-xxl
+    nodeset: centos-9-medium-crc-extracted-2-30-0-3xl
     vars:
       collection_namespace_override: "nova-kuttl-default"
       zuul_log_collection: true


### PR DESCRIPTION
The base job already has crc 2.30 while we were using 2.19. This is causing nmstate errors in the kuttl job.