### PR TITLE
Configure nova-compute to log to stdout

### DIFF
--- a/controllers/novacell_controller.go
+++ b/controllers/novacell_controller.go
@@ -776,7 +776,6 @@ func (r *NovaCellReconciler) generateComputeConfigs(
 		"default_user_domain":    "Default",   // fixme
 		"compute_driver":         "libvirt.LibvirtDriver",
 		"transport_url":          string(secret.Data[TransportURLSelector]),
-		"log_file":               "/var/log/containers/nova/nova-compute.log",
 	}
 	// vnc is optional so we only need to configure it for the compute
 	// if the proxy service is deployed in the cell

--- a/test/functional/novacell_controller_test.go
+++ b/test/functional/novacell_controller_test.go
@@ -278,6 +278,11 @@ var _ = Describe("NovaCell controller", func() {
 				ContainSubstring(
 					"live_migration_uri = qemu+ssh://nova@%s/system?keyfile=/var/lib/nova/.ssh/ssh-privatekey"))
 			Expect(configData).To(ContainSubstring("cpu_power_management=true"))
+			// The nova compute agent is expected to log to stdout. On edpm nodes this allows podman to
+			// capture the logs and make them available via `podman logs` while also redirecting the logs
+			// to the systemd journal. For openshift compute services, the logs are captured by the openshift
+			// logging infrastructure.
+			Expect(configData).To(Not(ContainSubstring("log_file = /var/log/nova/nova-compute.log")))
 
 			th.ExpectCondition(
 				cell1.CellCRName,


### PR DESCRIPTION
This change configures nova-compute to log to stdout
so that the logs can be redirected to the systemd journal
or openshift logging infrastructure.

Related: [OSPRH-140](https://issues.redhat.com//browse/OSPRH-140)
