### PR TITLE
Rename test_fw to cifmw_run_test_role

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -113,7 +113,7 @@
     parent: podified-multinode-edpm-deployment-crc-3comp
     dependencies: ["nova-operator-content-provider"]
     vars:
-      test_fw: test_operator
+      cifmw_run_test_role: test_operator
       cifmw_test_operator_concurrency: 4
       cifmw_test_operator_timeout: 7200
       # NOTE(gibi): identity.v3_endpoint_type override is a WA to force the


### PR DESCRIPTION
Once [1] has been approved, the parameter test_fw has been renamed to cifmw_run_test_role.
This patch fixes it for the jobs that use that parameter.

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/1171