### PR TITLE
Revert "Reapply "Enable CPU power management by default for libvirt compute""

### DIFF
--- a/templates/nova.conf
+++ b/templates/nova.conf
@@ -194,8 +194,8 @@ rx_queue_size=512
 tx_queue_size=512
 swtpm_enabled=True
 volume_use_multipath=true
+
 live_migration_uri = qemu+ssh://nova@%s/system?keyfile=/var/lib/nova/.ssh/ssh-privatekey
-cpu_power_management=true
 {{end}}
 
 {{if (index . "cell_db_address")}}

--- a/test/functional/novacell_controller_test.go
+++ b/test/functional/novacell_controller_test.go
@@ -277,7 +277,6 @@ var _ = Describe("NovaCell controller", func() {
 			Expect(configData).To(
 				ContainSubstring(
 					"live_migration_uri = qemu+ssh://nova@%s/system?keyfile=/var/lib/nova/.ssh/ssh-privatekey"))
-			Expect(configData).To(ContainSubstring("cpu_power_management=true"))
 			// The nova compute agent is expected to log to stdout. On edpm nodes this allows podman to
 			// capture the logs and make them available via `podman logs` while also redirecting the logs
 			// to the systemd journal. For openshift compute services, the logs are captured by the openshift


### PR DESCRIPTION


This reverts commit 41497aaed81e537bce2e9f62d7175bc593177b9a.