### PR TITLE
update mariadb to include finalizer secret logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240306153230-dc65ab49ebc0
 	github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.20240306153230-dc65ab49ebc0
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240306153230-dc65ab49ebc0
-	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240303091826-438dde8600d3
+	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240313124955-f152bee56715
 	github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20221209164002-f9e6b9363961
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20240213143201-ec583247a57a

--- a/go.sum
+++ b/go.sum
@@ -88,8 +88,8 @@ github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.2024030
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.20240306153230-dc65ab49ebc0/go.mod h1:vD2gy8bM6HkEY2unmpOXtwza515tUUucRP2IR0nffmU=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240306153230-dc65ab49ebc0 h1:JH0VLFw5w9CnJnw7snDxkqRrTPHIPCyqk03ePlOpEa8=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240306153230-dc65ab49ebc0/go.mod h1:/ZkLOznBDxjChwIFFK3xg3EZ13WmZPP4ehu5wWy1T8E=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240303091826-438dde8600d3 h1:fwb+GvvnN9Mhkgg5pBksZ8W5+hLCcNOorHsUTQYA1Lg=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240303091826-438dde8600d3/go.mod h1:f9IIyWeoskWoeWaDFF3qmAJ2Kqyovfi0Ar/QUfk3qag=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240313124955-f152bee56715 h1:p/27BiJbPCel9U12Q3ym4N7brVK5CMqx1plLO6j/fcU=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240313124955-f152bee56715/go.mod h1:f9IIyWeoskWoeWaDFF3qmAJ2Kqyovfi0Ar/QUfk3qag=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
this PR updates mariadb-operator to include [1], which will add / remove finalizers on the Secret objects that are associated with MariaDBAccount objects.  This ensures that GetDatabaseByNameAndAccount will successfully locate a MariaDBDatabase/MariaDBAccount/Secret trio, rather than returning not found, allowing ``Database.DeleteFinalizer()`` to be called when a resource is in reconcile delete.

[1] https://github.com/openstack-k8s-operators/mariadb-operator/pull/210