### PR TITLE
Print object diff in ValidateUpdate webhook call

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -3,6 +3,7 @@ module github.com/openstack-k8s-operators/nova-operator/api
 go 1.20
 
 require (
+	github.com/google/go-cmp v0.6.0
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240412091425-bb628ded5eb8
 	github.com/robfig/cron/v3 v3.0.1
 	k8s.io/api v0.28.8
@@ -27,7 +28,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect

--- a/api/v1beta1/nova_webhook.go
+++ b/api/v1beta1/nova_webhook.go
@@ -25,6 +25,7 @@ package v1beta1
 import (
 	"fmt"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/robfig/cron/v3"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -274,6 +275,8 @@ func (r *Nova) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
 	if !ok || oldNova == nil {
 		return nil, apierrors.NewInternalError(fmt.Errorf("unable to convert existing object"))
 	}
+
+	novalog.Info("validate update", "diff", cmp.Diff(oldNova, r))
 
 	errors := r.Spec.ValidateUpdate(oldNova.Spec, field.NewPath("spec"))
 	if len(errors) != 0 {

--- a/api/v1beta1/novaapi_webhook.go
+++ b/api/v1beta1/novaapi_webhook.go
@@ -23,6 +23,9 @@ limitations under the License.
 package v1beta1
 
 import (
+	"fmt"
+
+	"github.com/google/go-cmp/cmp"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -99,6 +102,12 @@ func (r *NovaAPI) ValidateCreate() (admission.Warnings, error) {
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *NovaAPI) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
 	novaapilog.Info("validate update", "name", r.Name)
+	oldNovaAPI, ok := old.(*NovaAPI)
+	if !ok || oldNovaAPI == nil {
+		return nil, apierrors.NewInternalError(fmt.Errorf("unable to convert existing object"))
+	}
+
+	novaapilog.Info("validate update", "diff", cmp.Diff(oldNovaAPI, r))
 
 	errors := ValidateAPIDefaultConfigOverwrite(
 		field.NewPath("spec").Child("defaultConfigOverwrite"),

--- a/api/v1beta1/novacell_webhook.go
+++ b/api/v1beta1/novacell_webhook.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/google/go-cmp/cmp"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -180,6 +181,8 @@ func (r *NovaCell) ValidateUpdate(old runtime.Object) (admission.Warnings, error
 	if !ok || oldCell == nil {
 		return nil, apierrors.NewInternalError(fmt.Errorf("unable to convert existing object"))
 	}
+
+	novacelllog.Info("validate update", "diff", cmp.Diff(oldCell, r))
 
 	errors := r.Spec.ValidateUpdate(oldCell.Spec, field.NewPath("spec"))
 

--- a/api/v1beta1/novacompute_webhook.go
+++ b/api/v1beta1/novacompute_webhook.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/google/go-cmp/cmp"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -104,6 +105,8 @@ func (r *NovaCompute) ValidateUpdate(old runtime.Object) (admission.Warnings, er
 	if !ok || oldNovaCompute == nil {
 		return nil, apierrors.NewInternalError(fmt.Errorf("unable to convert existing object"))
 	}
+
+	novacomputelog.Info("validate update", "diff", cmp.Diff(oldNovaCompute, r))
 
 	errors := r.Spec.ValidateUpdate(oldNovaCompute.Spec, field.NewPath("spec"))
 

--- a/api/v1beta1/novaconductor_webhook.go
+++ b/api/v1beta1/novaconductor_webhook.go
@@ -23,6 +23,9 @@ limitations under the License.
 package v1beta1
 
 import (
+	"fmt"
+
+	"github.com/google/go-cmp/cmp"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -98,6 +101,12 @@ func (r *NovaConductor) ValidateCreate() (admission.Warnings, error) {
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *NovaConductor) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
 	novaconductorlog.Info("validate update", "name", r.Name)
+	oldConductor, ok := old.(*NovaConductor)
+	if !ok || oldConductor == nil {
+		return nil, apierrors.NewInternalError(fmt.Errorf("unable to convert existing object"))
+	}
+
+	novaconductorlog.Info("validate update", "diff", cmp.Diff(oldConductor, r))
 
 	errors := r.Spec.DBPurge.Validate(
 		field.NewPath("spec").Child("dbPurge"))

--- a/api/v1beta1/novametadata_webhook.go
+++ b/api/v1beta1/novametadata_webhook.go
@@ -23,6 +23,9 @@ limitations under the License.
 package v1beta1
 
 import (
+	"fmt"
+
+	"github.com/google/go-cmp/cmp"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -99,6 +102,13 @@ func (r *NovaMetadata) ValidateCreate() (admission.Warnings, error) {
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *NovaMetadata) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
 	novametadatalog.Info("validate update", "name", r.Name)
+
+	oldMetadata, ok := old.(*NovaMetadata)
+	if !ok || oldMetadata == nil {
+		return nil, apierrors.NewInternalError(fmt.Errorf("unable to convert existing object"))
+	}
+
+	novametadatalog.Info("validate update", "diff", cmp.Diff(oldMetadata, r))
 
 	errors := ValidateMetadataDefaultConfigOverwrite(
 		field.NewPath("spec").Child("defaultConfigOverwrite"),

--- a/api/v1beta1/novanovncproxy_webhook.go
+++ b/api/v1beta1/novanovncproxy_webhook.go
@@ -23,6 +23,10 @@ limitations under the License.
 package v1beta1
 
 import (
+	"fmt"
+
+	"github.com/google/go-cmp/cmp"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -88,6 +92,13 @@ func (r *NovaNoVNCProxy) ValidateCreate() (admission.Warnings, error) {
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *NovaNoVNCProxy) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
 	novanovncproxylog.Info("validate update", "name", r.Name)
+
+	oldProxy, ok := old.(*NovaNoVNCProxy)
+	if !ok || oldProxy == nil {
+		return nil, apierrors.NewInternalError(fmt.Errorf("unable to convert existing object"))
+	}
+
+	novanovncproxylog.Info("validate update", "diff", cmp.Diff(oldProxy, r))
 
 	// TODO(user): fill in your validation logic upon object update.
 	return nil, nil

--- a/api/v1beta1/novascheduler_webhook.go
+++ b/api/v1beta1/novascheduler_webhook.go
@@ -23,6 +23,10 @@ limitations under the License.
 package v1beta1
 
 import (
+	"fmt"
+
+	"github.com/google/go-cmp/cmp"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -87,6 +91,13 @@ func (r *NovaScheduler) ValidateCreate() (admission.Warnings, error) {
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *NovaScheduler) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
 	novaschedulerlog.Info("validate update", "name", r.Name)
+
+	oldScheduler, ok := old.(*NovaScheduler)
+	if !ok || oldScheduler == nil {
+		return nil, apierrors.NewInternalError(fmt.Errorf("unable to convert existing object"))
+	}
+
+	novaschedulerlog.Info("validate update", "diff", cmp.Diff(oldScheduler, r))
 
 	// TODO(user): fill in your validation logic upon object update.
 	return nil, nil


### PR DESCRIPTION
Knowing what is changing in each resource update helps troubleshooting why a resource keeps reconciling.

You can make the diff human readable by piping it through:
```
  grep 'diff":' | cut -f 5 | jq  ".diff" | xargs -0 printf
```
e.g the following
```
  make test GINKGO_ARGS="-v --procs=1 --focus='creates cell2 NovaCell'" | grep 'diff":' | cut -f 5 | jq  ".diff" | xargs -0 printf
```
will print the nova resource updates during a test case execution