### PR TITLE
use shared content provider job

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,20 +1,5 @@
 ---
 - job:
-    name: nova-operator-content-provider
-    parent: content-provider-base
-    description: |
-      This job builds the nova-operator and provides it to child jobs
-      It also rebuilds the openstack-operator using the updated nova operator.
-    provides:
-      - "nova-operator-content"
-    vars:
-      cifmw_operator_build_org: openstack-k8s-operators
-      cifmw_operator_build_operators:
-        - name: "openstack-operator"
-          src: "~/src/github.com/{{ cifmw_operator_build_org }}/openstack-operator"
-          image_base: nova
-
-- job:
     name: nova-operator-base
     description: |
       This is the base job for all nova-operator tests that will deploy
@@ -28,12 +13,10 @@
     parent: cifmw-podified-multinode-edpm-base-crc
     abstract: true
     attempts: 1
-    dependencies: ["nova-operator-content-provider"]
+    dependencies: ["openstack-k8s-operators-content-provider"]
     required-projects:
       - github.com/openstack-k8s-operators/ci-framework
       - github.com/openstack-k8s-operators/install_yamls
-    requires:
-      - "nova-operator-content"
     roles:
       - zuul: github.com/openstack-k8s-operators/ci-framework
     pre-run:
@@ -44,15 +27,13 @@
 - job:
     name: nova-operator-kuttl
     parent:  nova-operator-base
-    dependencies: ["nova-operator-content-provider"]
+    dependencies: ["openstack-k8s-operators-content-provider"]
     roles:
       - zuul: github.com/openstack-k8s-operators/ci-framework
     description: |
       This job deploy a basic "Compute Starter Kit" topology
       https://www.openstack.org/software/sample-configs#compute-starter-kit
       that is the minium set of openstack services required to boot a vm.
-    requires:
-      - "nova-operator-content"
     pre-run:
       - ci/nova-operator-kuttl/playbooks/deploy-deps.yaml
     run:
@@ -94,7 +75,7 @@
 - job:
     name: nova-operator-tempest-multinode
     parent: podified-multinode-edpm-deployment-crc-3comp
-    dependencies: ["nova-operator-content-provider"]
+    dependencies: ["openstack-k8s-operators-content-provider"]
     vars:
       cifmw_run_test_role: test_operator
       cifmw_test_operator_concurrency: 4
@@ -152,6 +133,6 @@
     name: openstack-k8s-operators/nova-operator
     github-check:
       jobs:
-        - nova-operator-content-provider
+        - openstack-k8s-operators-content-provider
         - nova-operator-kuttl
         - nova-operator-tempest-multinode


### PR DESCRIPTION
This change replaces the nova-operator-content-provider
with the openstack-k8s-operators-content-provider.

The openstack-k8s-operators-content-provider has all the
same functionality of the nova-operator-content-provider
plus it support depends on to other operators i.e.
the neuton-operator which was not supported by the
nova-operator-content-provider
