### PR TITLE
Ensure golangci-lint runs on all files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,5 +67,5 @@ repos:
 - repo: https://github.com/golangci/golangci-lint
   rev: v1.55.2
   hooks:
-    - id: golangci-lint
+    - id: golangci-lint-full
       args: ["-v"]

--- a/api/bases/nova.openstack.org_nova.yaml
+++ b/api/bases/nova.openstack.org_nova.yaml
@@ -466,8 +466,8 @@ spec:
                       properties:
                         archiveAge:
                           default: 30
-                          description: ArchiveAge defines the minimuma age of the
-                            records in days that can be moved to the shadow tables.
+                          description: ArchiveAge defines the minimum age of the records
+                            in days that can be moved to the shadow tables.
                           minimum: 1
                           type: integer
                         purgeAge:

--- a/api/bases/nova.openstack.org_novacells.yaml
+++ b/api/bases/nova.openstack.org_novacells.yaml
@@ -155,7 +155,7 @@ spec:
                 properties:
                   archiveAge:
                     default: 30
-                    description: ArchiveAge defines the minimuma age of the records
+                    description: ArchiveAge defines the minimum age of the records
                       in days that can be moved to the shadow tables.
                     minimum: 1
                     type: integer
@@ -463,7 +463,7 @@ spec:
                     type: object
                 type: object
               noVNCProxyServiceTemplate:
-                description: NoVNCProxyServiceTemplate - defines the novvncproxy service
+                description: NoVNCProxyServiceTemplate - defines the novncproxy service
                   dedicated for the cell.
                 properties:
                   customServiceConfig:

--- a/api/bases/nova.openstack.org_novaconductors.yaml
+++ b/api/bases/nova.openstack.org_novaconductors.yaml
@@ -89,7 +89,7 @@ spec:
                 properties:
                   archiveAge:
                     default: 30
-                    description: ArchiveAge defines the minimuma age of the records
+                    description: ArchiveAge defines the minimum age of the records
                       in days that can be moved to the shadow tables.
                     minimum: 1
                     type: integer

--- a/api/v1beta1/novacell_types.go
+++ b/api/v1beta1/novacell_types.go
@@ -164,7 +164,7 @@ type NovaCellSpec struct {
 	MetadataServiceTemplate NovaMetadataTemplate `json:"metadataServiceTemplate"`
 
 	// +kubebuilder:validation:Required
-	// NoVNCProxyServiceTemplate - defines the novvncproxy service dedicated for
+	// NoVNCProxyServiceTemplate - defines the novncproxy service dedicated for
 	// the cell.
 	NoVNCProxyServiceTemplate NovaNoVNCProxyTemplate `json:"noVNCProxyServiceTemplate"`
 
@@ -207,7 +207,7 @@ type NovaCellDBPurge struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=30
 	// +kubebuilder:validation:Minimum=1
-	// ArchiveAge defines the minimuma age of the records in days that can be
+	// ArchiveAge defines the minimum age of the records in days that can be
 	// moved to the shadow tables.
 	ArchiveAge *int `json:"archiveAge"`
 

--- a/api/v1beta1/novacompute_types.go
+++ b/api/v1beta1/novacompute_types.go
@@ -194,7 +194,7 @@ func NewNovaComputeSpec(
 	computeTemplate NovaComputeTemplate,
 	novaComputeName string,
 ) NovaComputeSpec {
-	novacomputeSpec := NovaComputeSpec{
+	novaComputeSpec := NovaComputeSpec{
 		CellName:    novaCell.CellName,
 		ComputeName: novaComputeName,
 		Secret:      novaCell.Secret,
@@ -213,5 +213,5 @@ func NewNovaComputeSpec(
 		TLS:                    novaCell.TLS,
 		DefaultConfigOverwrite: computeTemplate.DefaultConfigOverwrite,
 	}
-	return novacomputeSpec
+	return novaComputeSpec
 }

--- a/config/crd/bases/nova.openstack.org_nova.yaml
+++ b/config/crd/bases/nova.openstack.org_nova.yaml
@@ -466,8 +466,8 @@ spec:
                       properties:
                         archiveAge:
                           default: 30
-                          description: ArchiveAge defines the minimuma age of the
-                            records in days that can be moved to the shadow tables.
+                          description: ArchiveAge defines the minimum age of the records
+                            in days that can be moved to the shadow tables.
                           minimum: 1
                           type: integer
                         purgeAge:

--- a/config/crd/bases/nova.openstack.org_novacells.yaml
+++ b/config/crd/bases/nova.openstack.org_novacells.yaml
@@ -155,7 +155,7 @@ spec:
                 properties:
                   archiveAge:
                     default: 30
-                    description: ArchiveAge defines the minimuma age of the records
+                    description: ArchiveAge defines the minimum age of the records
                       in days that can be moved to the shadow tables.
                     minimum: 1
                     type: integer
@@ -463,7 +463,7 @@ spec:
                     type: object
                 type: object
               noVNCProxyServiceTemplate:
-                description: NoVNCProxyServiceTemplate - defines the novvncproxy service
+                description: NoVNCProxyServiceTemplate - defines the novncproxy service
                   dedicated for the cell.
                 properties:
                   customServiceConfig:

--- a/config/crd/bases/nova.openstack.org_novaconductors.yaml
+++ b/config/crd/bases/nova.openstack.org_novaconductors.yaml
@@ -89,7 +89,7 @@ spec:
                 properties:
                   archiveAge:
                     default: 30
-                    description: ArchiveAge defines the minimuma age of the records
+                    description: ArchiveAge defines the minimum age of the records
                       in days that can be moved to the shadow tables.
                     minimum: 1
                     type: integer

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -454,7 +454,7 @@ type GetSecret interface {
 	client.Object
 }
 
-// getlogger returns a logger object with a prefix of "conroller.name" and aditional controller context fields
+// GetLogger returns a logger object with a prefix of "controller.name" and additional controller context fields
 func (r *ReconcilerBase) GetLogger(ctx context.Context) logr.Logger {
 	return log.FromContext(ctx).WithName("Controllers").WithName("ReconcilerBase")
 }
@@ -548,10 +548,10 @@ func ensureMemcached(
 	ctx context.Context,
 	h *helper.Helper,
 	namespaceName string,
-	mamcachedName string,
+	memcachedName string,
 	conditionUpdater conditionUpdater,
 ) (*memcachedv1.Memcached, error) {
-	memcached, err := memcachedv1.GetMemcachedByName(ctx, h, mamcachedName, namespaceName)
+	memcached, err := memcachedv1.GetMemcachedByName(ctx, h, memcachedName, namespaceName)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
 			conditionUpdater.Set(condition.FalseCondition(
@@ -559,7 +559,7 @@ func ensureMemcached(
 				condition.RequestedReason,
 				condition.SeverityInfo,
 				condition.MemcachedReadyWaitingMessage))
-			return nil, fmt.Errorf("memcached %s not found", mamcachedName)
+			return nil, fmt.Errorf("memcached %s not found", memcachedName)
 		}
 		conditionUpdater.Set(condition.FalseCondition(
 			condition.MemcachedReadyCondition,
@@ -576,7 +576,7 @@ func ensureMemcached(
 			condition.RequestedReason,
 			condition.SeverityInfo,
 			condition.MemcachedReadyWaitingMessage))
-		return nil, fmt.Errorf("memcached %s is not ready", mamcachedName)
+		return nil, fmt.Errorf("memcached %s is not ready", memcachedName)
 	}
 	conditionUpdater.MarkTrue(condition.MemcachedReadyCondition, condition.MemcachedReadyMessage)
 

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -109,7 +109,6 @@ type conditionsGetter interface {
 }
 
 func cleanNovaServiceFromNovaDb(
-	ctx context.Context,
 	computeClient *gophercloud.ServiceClient,
 	serviceName string,
 ) error {
@@ -175,7 +174,7 @@ func ensureSecret(
 			return "",
 				ctrl.Result{RequeueAfter: requeueTimeout},
 				*secret,
-				fmt.Errorf("Secret %s not found", secretName)
+				fmt.Errorf("secret %s not found", secretName)
 		}
 		conditionUpdater.Set(condition.FalseCondition(
 			condition.InputReadyCondition,
@@ -282,9 +281,9 @@ type Reconciler interface {
 	SetRequeueTimeout(timeout time.Duration)
 }
 
-// NewReconcilerBase constructs a ReconcilerBase given a name manager and Kclient.
+// NewReconcilerBase constructs a ReconcilerBase given a manager and Kclient.
 func NewReconcilerBase(
-	name string, mgr ctrl.Manager, kclient kubernetes.Interface,
+	mgr ctrl.Manager, kclient kubernetes.Interface,
 ) ReconcilerBase {
 	return ReconcilerBase{
 		Client:         mgr.GetClient(),
@@ -310,28 +309,28 @@ func NewReconcilers(mgr ctrl.Manager, kclient *kubernetes.Clientset) *Reconciler
 	return &Reconcilers{
 		reconcilers: map[string]Reconciler{
 			"Nova": &NovaReconciler{
-				ReconcilerBase: NewReconcilerBase("Nova", mgr, kclient),
+				ReconcilerBase: NewReconcilerBase(mgr, kclient),
 			},
 			"NovaCell": &NovaCellReconciler{
-				ReconcilerBase: NewReconcilerBase("NovaCell", mgr, kclient),
+				ReconcilerBase: NewReconcilerBase(mgr, kclient),
 			},
 			"NovaAPI": &NovaAPIReconciler{
-				ReconcilerBase: NewReconcilerBase("NovaAPI", mgr, kclient),
+				ReconcilerBase: NewReconcilerBase(mgr, kclient),
 			},
 			"NovaScheduler": &NovaSchedulerReconciler{
-				ReconcilerBase: NewReconcilerBase("NovaScheduler", mgr, kclient),
+				ReconcilerBase: NewReconcilerBase(mgr, kclient),
 			},
 			"NovaConductor": &NovaConductorReconciler{
-				ReconcilerBase: NewReconcilerBase("NovaConductor", mgr, kclient),
+				ReconcilerBase: NewReconcilerBase(mgr, kclient),
 			},
 			"NovaMetadata": &NovaMetadataReconciler{
-				ReconcilerBase: NewReconcilerBase("NovaMetadata", mgr, kclient),
+				ReconcilerBase: NewReconcilerBase(mgr, kclient),
 			},
 			"NovaNoVNCProxy": &NovaNoVNCProxyReconciler{
-				ReconcilerBase: NewReconcilerBase("NovaNoVNCProxy", mgr, kclient),
+				ReconcilerBase: NewReconcilerBase(mgr, kclient),
 			},
 			"NovaCompute": &NovaComputeReconciler{
-				ReconcilerBase: NewReconcilerBase("NovaCompute", mgr, kclient),
+				ReconcilerBase: NewReconcilerBase(mgr, kclient),
 			},
 		}}
 }
@@ -472,7 +471,6 @@ func OwnedBy(owned client.Object, owner client.Object) bool {
 
 func (r *ReconcilerBase) ensureMetadataDeleted(
 	ctx context.Context,
-	h *helper.Helper,
 	instance client.Object,
 ) error {
 	Log := r.GetLogger(ctx)
@@ -511,7 +509,6 @@ type keystoneAuth interface {
 }
 
 func getNovaClient(
-	ctx context.Context, h *helper.Helper,
 	keystoneAuth keystoneAuth, password string,
 	l logr.Logger,
 ) (*gophercloud.ServiceClient, error) {

--- a/controllers/nova_controller.go
+++ b/controllers/nova_controller.go
@@ -65,7 +65,7 @@ type NovaReconciler struct {
 	ReconcilerBase
 }
 
-// getlogger returns a logger object with a prefix of "conroller.name" and aditional controller context fields
+// GetLogger returns a logger object with a prefix of "controller.name" and additional controller context fields
 func (r *NovaReconciler) GetLogger(ctx context.Context) logr.Logger {
 	return log.FromContext(ctx).WithName("Controllers").WithName("Nova")
 }
@@ -134,7 +134,7 @@ func (r *NovaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 	}
 	Log.Info("Reconciling")
 
-	// Save a copy of the condtions so that we can restore the LastTransitionTime
+	// Save a copy of the conditions so that we can restore the LastTransitionTime
 	// when a condition's state doesn't change.
 	savedConditions := instance.Status.Conditions.DeepCopy()
 
@@ -912,7 +912,7 @@ func (r *NovaReconciler) ensureCell(
 		ServiceUser:     instance.Spec.ServiceUser,
 		KeystoneAuthURL: keystoneAuthURL,
 		ServiceAccount:  instance.RbacResourceName(),
-		// The assumtpion is that the CA bundle for ironic compute in the cell
+		// The assumption is that the CA bundle for ironic compute in the cell
 		// and the conductor in the cell always the same as the NovaAPI
 		TLS:               instance.Spec.APIServiceTemplate.TLS.Ca,
 		PreserveJobs:      instance.Spec.PreserveJobs,
@@ -975,7 +975,7 @@ func (r *NovaReconciler) ensureCell(
 		return cell, status, err
 	}
 
-	// We need to discover computes when cell have computetemplates and mapping is done
+	// We need to discover computes when cell have compute templates and mapping is done
 	status, err = r.ensureNovaComputeDiscover(
 		ctx, h, instance, cell, cellTemplate, scriptName, configName)
 

--- a/controllers/novaapi_controller.go
+++ b/controllers/novaapi_controller.go
@@ -63,7 +63,7 @@ type NovaAPIReconciler struct {
 	ReconcilerBase
 }
 
-// getlogger returns a logger object with a prefix of "conroller.name" and aditional controller context fields
+// GetLogger returns a logger object with a prefix of "controller.name" and additional controller context fields
 func (r *NovaAPIReconciler) GetLogger(ctx context.Context) logr.Logger {
 	return log.FromContext(ctx).WithName("Controllers").WithName("NovaAPI")
 }
@@ -122,7 +122,7 @@ func (r *NovaAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 	}
 	Log.Info("Reconciling")
 
-	// Save a copy of the condtions so that we can restore the LastTransitionTime
+	// Save a copy of the conditions so that we can restore the LastTransitionTime
 	// when a condition's state doesn't change.
 	savedConditions := instance.Status.Conditions.DeepCopy()
 	// initialize status fields
@@ -301,7 +301,7 @@ func (r *NovaAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 
 	// Only expose the service is the deployment succeeded
 	if !instance.Status.Conditions.IsTrue(condition.DeploymentReadyCondition) {
-		Log.Info("Waiting for the Deployment to become Ready before exposing the sevice in Keystone")
+		Log.Info("Waiting for the Deployment to become Ready before exposing the service in Keystone")
 		return ctrl.Result{}, nil
 	}
 

--- a/controllers/novacell_controller.go
+++ b/controllers/novacell_controller.go
@@ -53,7 +53,7 @@ type NovaCellReconciler struct {
 	ReconcilerBase
 }
 
-// getlogger returns a logger object with a prefix of "conroller.name" and aditional controller context fields
+// GetLogger returns a logger object with a prefix of "controller.name" and additional controller context fields
 func (r *NovaCellReconciler) GetLogger(ctx context.Context) logr.Logger {
 	return log.FromContext(ctx).WithName("Controllers").WithName("NovaCell")
 }
@@ -105,7 +105,7 @@ func (r *NovaCellReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 	}
 	Log.Info("Reconciling")
 
-	// Save a copy of the condtions so that we can restore the LastTransitionTime
+	// Save a copy of the conditions so that we can restore the LastTransitionTime
 	// when a condition's state doesn't change.
 	savedConditions := instance.Status.Conditions.DeepCopy()
 	// initialize status fields

--- a/controllers/novacompute_controller.go
+++ b/controllers/novacompute_controller.go
@@ -55,7 +55,7 @@ type NovaComputeReconciler struct {
 	ReconcilerBase
 }
 
-// getlogger returns a logger object with a prefix of "conroller.name" and aditional controller context fields
+// GetLOgger returns a logger object with a prefix of "controller.name" and additional controller context fields
 func (r *NovaComputeReconciler) GetLogger(ctx context.Context) logr.Logger {
 	return log.FromContext(ctx).WithName("Controllers").WithName("NovaCompute")
 }
@@ -113,7 +113,7 @@ func (r *NovaComputeReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 	Log.Info("Reconciling")
 
-	// Save a copy of the condtions so that we can restore the LastTransitionTime
+	// Save a copy of the conditions so that we can restore the LastTransitionTime
 	// when a condition's state doesn't change.
 	savedConditions := instance.Status.Conditions.DeepCopy()
 	// initialize status fields

--- a/controllers/novaconductor_controller.go
+++ b/controllers/novaconductor_controller.go
@@ -58,7 +58,7 @@ type NovaConductorReconciler struct {
 	ReconcilerBase
 }
 
-// getlogger returns a logger object with a prefix of "conroller.name" and aditional controller context fields
+// GetLogger returns a logger object with a prefix of "controller.name" and additional controller context fields
 func (r *NovaConductorReconciler) GetLogger(ctx context.Context) logr.Logger {
 	return log.FromContext(ctx).WithName("Controllers").WithName("NovaConductor")
 }
@@ -116,7 +116,7 @@ func (r *NovaConductorReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 	Log.Info("Reconciling")
 
-	// Save a copy of the condtions so that we can restore the LastTransitionTime
+	// Save a copy of the conditions so that we can restore the LastTransitionTime
 	// when a condition's state doesn't change.
 	savedConditions := instance.Status.Conditions.DeepCopy()
 	// initialize status fields

--- a/controllers/novametadata_controller.go
+++ b/controllers/novametadata_controller.go
@@ -60,7 +60,7 @@ type NovaMetadataReconciler struct {
 	ReconcilerBase
 }
 
-// getlogger returns a logger object with a prefix of "conroller.name" and aditional controller context fields
+// GetLogger returns a logger object with a prefix of "controller.name" and additional controller context fields
 func (r *NovaMetadataReconciler) GetLogger(ctx context.Context) logr.Logger {
 	return log.FromContext(ctx).WithName("Controllers").WithName("NovaMetadata")
 }
@@ -117,7 +117,7 @@ func (r *NovaMetadataReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	Log.Info("Reconciling")
 
-	// Save a copy of the condtions so that we can restore the LastTransitionTime
+	// Save a copy of the conditions so that we can restore the LastTransitionTime
 	// when a condition's state doesn't change.
 	savedConditions := instance.Status.Conditions.DeepCopy()
 	// initialize status fields

--- a/controllers/novametadata_controller.go
+++ b/controllers/novametadata_controller.go
@@ -121,7 +121,7 @@ func (r *NovaMetadataReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// when a condition's state doesn't change.
 	savedConditions := instance.Status.Conditions.DeepCopy()
 	// initialize status fields
-	if err = r.initStatus(ctx, h, instance); err != nil {
+	if err = r.initStatus(instance); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -319,9 +319,9 @@ func (r *NovaMetadataReconciler) Reconcile(ctx context.Context, req ctrl.Request
 }
 
 func (r *NovaMetadataReconciler) initStatus(
-	ctx context.Context, h *helper.Helper, instance *novav1.NovaMetadata,
+	instance *novav1.NovaMetadata,
 ) error {
-	if err := r.initConditions(ctx, h, instance); err != nil {
+	if err := r.initConditions(instance); err != nil {
 		return err
 	}
 
@@ -336,7 +336,7 @@ func (r *NovaMetadataReconciler) initStatus(
 }
 
 func (r *NovaMetadataReconciler) initConditions(
-	ctx context.Context, h *helper.Helper, instance *novav1.NovaMetadata,
+	instance *novav1.NovaMetadata,
 ) error {
 	if instance.Status.Conditions == nil {
 		instance.Status.Conditions = condition.Conditions{}
@@ -827,7 +827,7 @@ func (r *NovaMetadataReconciler) generateNeutronConfigs(
 func (r *NovaMetadataReconciler) findObjectsForSrc(ctx context.Context, src client.Object) []reconcile.Request {
 	requests := []reconcile.Request{}
 
-	l := log.FromContext(context.Background()).WithName("Controllers").WithName("NovaMetadata")
+	l := log.FromContext(ctx).WithName("Controllers").WithName("NovaMetadata")
 
 	for _, field := range metaWatchFields {
 		crList := &novav1.NovaMetadataList{}
@@ -835,7 +835,7 @@ func (r *NovaMetadataReconciler) findObjectsForSrc(ctx context.Context, src clie
 			FieldSelector: fields.OneTermEqualSelector(field, src.GetName()),
 			Namespace:     src.GetNamespace(),
 		}
-		err := r.Client.List(context.TODO(), crList, listOps)
+		err := r.Client.List(ctx, crList, listOps)
 		if err != nil {
 			return []reconcile.Request{}
 		}

--- a/controllers/novanovncproxy_controller.go
+++ b/controllers/novanovncproxy_controller.go
@@ -121,7 +121,7 @@ func (r *NovaNoVNCProxyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	savedConditions := instance.Status.Conditions.DeepCopy()
 
 	// initialize status fields
-	if err = r.initStatus(ctx, h, instance); err != nil {
+	if err = r.initStatus(instance); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -293,9 +293,9 @@ func (r *NovaNoVNCProxyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 }
 
 func (r *NovaNoVNCProxyReconciler) initStatus(
-	ctx context.Context, h *helper.Helper, instance *novav1.NovaNoVNCProxy,
+	instance *novav1.NovaNoVNCProxy,
 ) error {
-	if err := r.initConditions(ctx, h, instance); err != nil {
+	if err := r.initConditions(instance); err != nil {
 		return err
 	}
 
@@ -332,7 +332,7 @@ func (r *NovaNoVNCProxyReconciler) ensureConfigs(
 }
 
 func (r *NovaNoVNCProxyReconciler) initConditions(
-	ctx context.Context, h *helper.Helper, instance *novav1.NovaNoVNCProxy,
+	instance *novav1.NovaNoVNCProxy,
 ) error {
 	if instance.Status.Conditions == nil {
 		instance.Status.Conditions = condition.Conditions{}
@@ -662,7 +662,7 @@ func getNoVNCProxyServiceLabels(cell string) map[string]string {
 func (r *NovaNoVNCProxyReconciler) findObjectsForSrc(ctx context.Context, src client.Object) []reconcile.Request {
 	requests := []reconcile.Request{}
 
-	l := log.FromContext(context.Background()).WithName("Controllers").WithName("NovaNoVNCProxy")
+	l := log.FromContext(ctx).WithName("Controllers").WithName("NovaNoVNCProxy")
 
 	for _, field := range noVNCProxyWatchFields {
 		crList := &novav1.NovaNoVNCProxyList{}
@@ -670,7 +670,7 @@ func (r *NovaNoVNCProxyReconciler) findObjectsForSrc(ctx context.Context, src cl
 			FieldSelector: fields.OneTermEqualSelector(field, src.GetName()),
 			Namespace:     src.GetNamespace(),
 		}
-		err := r.Client.List(context.TODO(), crList, listOps)
+		err := r.Client.List(ctx, crList, listOps)
 		if err != nil {
 			return []reconcile.Request{}
 		}

--- a/controllers/novanovncproxy_controller.go
+++ b/controllers/novanovncproxy_controller.go
@@ -57,7 +57,7 @@ type NovaNoVNCProxyReconciler struct {
 	ReconcilerBase
 }
 
-// getlogger returns a logger object with a prefix of "conroller.name" and aditional controller context fields
+// GetLogger returns a logger object with a prefix of "controller.name" and additional controller context fields
 func (r *NovaNoVNCProxyReconciler) GetLogger(ctx context.Context) logr.Logger {
 	return log.FromContext(ctx).WithName("Controllers").WithName("NovaNoVNCProxy")
 }
@@ -116,7 +116,7 @@ func (r *NovaNoVNCProxyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	Log.Info("Reconciling")
 
-	// Save a copy of the condtions so that we can restore the LastTransitionTime
+	// Save a copy of the conditions so that we can restore the LastTransitionTime
 	// when a condition's state doesn't change.
 	savedConditions := instance.Status.Conditions.DeepCopy()
 

--- a/controllers/novascheduler_controller.go
+++ b/controllers/novascheduler_controller.go
@@ -57,7 +57,7 @@ type NovaSchedulerReconciler struct {
 	ReconcilerBase
 }
 
-// getlogger returns a logger object with a prefix of "conroller.name" and aditional controller context fields
+// GetLogger returns a logger object with a prefix of "controller.name" and additional controller context fields
 func (r *NovaSchedulerReconciler) GetLogger(ctx context.Context) logr.Logger {
 	return log.FromContext(ctx).WithName("Controllers").WithName("NovaScheduler")
 }
@@ -114,7 +114,7 @@ func (r *NovaSchedulerReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 	Log.Info("Reconciling")
 
-	// Save a copy of the condtions so that we can restore the LastTransitionTime
+	// Save a copy of the conditions so that we can restore the LastTransitionTime
 	// when a condition's state doesn't change.
 	savedConditions := instance.Status.Conditions.DeepCopy()
 

--- a/pkg/novaconductor/deployment.go
+++ b/pkg/novaconductor/deployment.go
@@ -74,7 +74,7 @@ func StatefulSet(
 
 	envVars := map[string]env.Setter{}
 	envVars["KOLLA_CONFIG_STRATEGY"] = env.SetValue("COPY_ALWAYS")
-	// NOTE(gibi): The stateafulset does not use this hash directly. We store it
+	// NOTE(gibi): The statefulset does not use this hash directly. We store it
 	// in the environment to trigger a Pod restart if any input of the
 	// statefulset has changed. The k8s will trigger a restart automatically if
 	// the env changes.

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -20,8 +20,9 @@ import (
 	"net/http"
 	"time"
 
+	. "github.com/onsi/gomega" //revive:disable:dot-imports
+
 	"github.com/go-logr/logr"
-	. "github.com/onsi/gomega"
 	"golang.org/x/exp/maps"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/test/functional/nova_compute_ironic_controller_test.go
+++ b/test/functional/nova_compute_ironic_controller_test.go
@@ -19,11 +19,13 @@ import (
 	"encoding/json"
 	"fmt"
 
-	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
+
+	//revive:disable-next-line:dot-imports
 	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
 
+	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/test/functional/nova_compute_ironic_controller_test.go
+++ b/test/functional/nova_compute_ironic_controller_test.go
@@ -277,7 +277,7 @@ var _ = Describe("NovaCompute controller", func() {
 
 var _ = Describe("NovaCompute with ironic diver controller", func() {
 
-	When("with configure cellname", func() {
+	When("with configure cell name", func() {
 		BeforeEach(func() {
 			spec := GetDefaultNovaComputeSpec(cell1)
 			novaCompute := CreateNovaCompute(cell1.NovaComputeName, spec)

--- a/test/functional/nova_controller_test.go
+++ b/test/functional/nova_controller_test.go
@@ -552,7 +552,7 @@ var _ = Describe("Nova controller", func() {
 			th.SimulateJobFailure(cell0.DBSyncJobName)
 		})
 
-		It("does not set the cell db sync ready condtion to true", func() {
+		It("does not set the cell db sync ready condition to true", func() {
 			th.ExpectCondition(
 				cell0.ConductorName,
 				ConditionGetterFunc(NovaConductorConditionGetter),

--- a/test/functional/nova_controller_test.go
+++ b/test/functional/nova_controller_test.go
@@ -18,10 +18,13 @@ package functional_test
 import (
 	"fmt"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
+
+	//revive:disable-next-line:dot-imports
 	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
+
+	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -698,7 +701,7 @@ var _ = Describe("Nova controller", func() {
 			infra.SimulateTransportURLReady(cell0.TransportURLName)
 
 			cell0DBSync := th.GetJob(cell0.DBSyncJobName)
-			Expect(len(cell0DBSync.Spec.Template.Spec.InitContainers)).To(Equal(0))
+			Expect(cell0DBSync.Spec.Template.Spec.InitContainers).To(BeEmpty())
 			configDataMap := th.GetSecret(cell0.ConductorConfigDataName)
 			Expect(configDataMap.Data).Should(HaveKey("01-nova.conf"))
 			configData := string(configDataMap.Data["01-nova.conf"])
@@ -1149,7 +1152,7 @@ var _ = Describe("Nova controller", func() {
 				g.Expect(nova.Status.APIServiceReadyCount).To(Equal(int32(1)))
 				g.Expect(nova.Status.SchedulerServiceReadyCount).To(Equal(int32(1)))
 				g.Expect(nova.Status.MetadataServiceReadyCount).To(Equal(int32(1)))
-			})
+			}, timeout, interval).Should(Succeed())
 		},
 		// update to a new account name
 		UpdateAccount: func(accountName types.NamespacedName) {
@@ -1254,7 +1257,7 @@ var _ = Describe("Nova controller", func() {
 				g.Expect(nova.Status.APIServiceReadyCount).To(Equal(int32(1)))
 				g.Expect(nova.Status.SchedulerServiceReadyCount).To(Equal(int32(1)))
 				g.Expect(nova.Status.MetadataServiceReadyCount).To(Equal(int32(1)))
-			})
+			}, timeout, interval).Should(Succeed())
 		},
 		// update to a new account name
 		UpdateAccount: func(accountName types.NamespacedName) {

--- a/test/functional/nova_metadata_controller_test.go
+++ b/test/functional/nova_metadata_controller_test.go
@@ -19,12 +19,14 @@ import (
 	"encoding/json"
 	"fmt"
 
-	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
+
+	//revive:disable-next-line:dot-imports
 	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
 
+	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
 	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/test/functional/nova_multicell_test.go
+++ b/test/functional/nova_multicell_test.go
@@ -34,7 +34,7 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-var _ = Describe("Nova multicell", func() {
+var _ = Describe("Nova multi cell", func() {
 	BeforeEach(func() {
 		apiMariaDBAccount, apiMariaDBSecret := mariadb.CreateMariaDBAccountAndSecret(
 			novaNames.APIMariaDBDatabaseAccount, mariadbv1.MariaDBAccountSpec{})

--- a/test/functional/nova_multicell_test.go
+++ b/test/functional/nova_multicell_test.go
@@ -18,13 +18,15 @@ package functional_test
 import (
 	"fmt"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
-	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
-	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
 
+	//revive:disable-next-line:dot-imports
+	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
+
+	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
+	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 	novav1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/nova-operator/controllers"
 	corev1 "k8s.io/api/core/v1"
@@ -144,7 +146,7 @@ var _ = Describe("Nova multicell", func() {
 			)
 			// assert that cell0 conductor is using the same DB as the API
 			dbSync := th.GetJob(cell0.DBSyncJobName)
-			Expect(dbSync.Spec.Template.Spec.InitContainers).To(HaveLen(0))
+			Expect(dbSync.Spec.Template.Spec.InitContainers).To(BeEmpty())
 
 			configDataMap := th.GetSecret(cell0.ConductorConfigDataName)
 			Expect(configDataMap.Data).Should(HaveKey("01-nova.conf"))
@@ -344,7 +346,7 @@ var _ = Describe("Nova multicell", func() {
 			)
 			// assert that cell1 using its own DB but has access to the API DB
 			dbSync := th.GetJob(cell1.DBSyncJobName)
-			Expect(dbSync.Spec.Template.Spec.InitContainers).To(HaveLen(0))
+			Expect(dbSync.Spec.Template.Spec.InitContainers).To(BeEmpty())
 			configDataMap := th.GetSecret(cell1.ConductorConfigDataName)
 			Expect(configDataMap.Data).Should(HaveKey("01-nova.conf"))
 			configData := string(configDataMap.Data["01-nova.conf"])
@@ -467,7 +469,7 @@ var _ = Describe("Nova multicell", func() {
 			)
 			// assert that cell2 using its own DB but has *no* access to the API DB
 			dbSync := th.GetJob(cell2.DBSyncJobName)
-			Expect(dbSync.Spec.Template.Spec.InitContainers).To(HaveLen(0))
+			Expect(dbSync.Spec.Template.Spec.InitContainers).To(BeEmpty())
 			configDataMap := th.GetSecret(cell2.ConductorConfigDataName)
 			Expect(configDataMap.Data).Should(HaveKey("01-nova.conf"))
 			configData := string(configDataMap.Data["01-nova.conf"])

--- a/test/functional/nova_novncproxy_test.go
+++ b/test/functional/nova_novncproxy_test.go
@@ -506,8 +506,8 @@ var _ = Describe("NovaNoVNCProxy controller", func() {
 				"service": serviceOverride,
 			}
 
-			noVNCP := CreateNovaNoVNCProxy(cell1.NoVNCProxyName, spec)
-			DeferCleanup(th.DeleteInstance, noVNCP)
+			noVNC := CreateNovaNoVNCProxy(cell1.NoVNCProxyName, spec)
+			DeferCleanup(th.DeleteInstance, noVNC)
 		})
 
 		It("creates ClusterIP service", func() {
@@ -559,8 +559,8 @@ var _ = Describe("NovaNoVNCProxy controller", func() {
 				"service": serviceOverride,
 			}
 
-			noVNCP := CreateNovaNoVNCProxy(cell1.NoVNCProxyName, spec)
-			DeferCleanup(th.DeleteInstance, noVNCP)
+			noVNC := CreateNovaNoVNCProxy(cell1.NoVNCProxyName, spec)
+			DeferCleanup(th.DeleteInstance, noVNC)
 		})
 
 		It("creates LoadBalancer service", func() {

--- a/test/functional/nova_novncproxy_test.go
+++ b/test/functional/nova_novncproxy_test.go
@@ -17,12 +17,15 @@ import (
 	"encoding/json"
 	"fmt"
 
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
+
+	//revive:disable-next-line:dot-imports
+	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
+
 	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
-	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 	novav1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"

--- a/test/functional/nova_reconfiguration_test.go
+++ b/test/functional/nova_reconfiguration_test.go
@@ -111,7 +111,7 @@ func CreateNovaWith3CellsAndEnsureReady(novaNames NovaNames) {
 	DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 	infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)
 	keystone.SimulateKeystoneServiceReady(novaNames.KeystoneServiceName)
-	// END of common logic with Nova multicell test
+	// END of common logic with Nova multi cell test
 
 	mariadb.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
 	mariadb.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
@@ -199,7 +199,7 @@ var _ = Describe("Nova reconfiguration", func() {
 			}, timeout, interval).Should(Succeed())
 		})
 	})
-	When("networkAttachemnt is added to a conductor while the definition is missing", func() {
+	When("networkAttachment is added to a conductor while the definition is missing", func() {
 		It("applies new NetworkAttachments configuration to that Conductor", func() {
 			Eventually(func(g Gomega) {
 				nova := GetNova(novaNames.NovaName)
@@ -711,7 +711,7 @@ var _ = Describe("Nova reconfiguration", func() {
 		}, timeout, interval).Should(Succeed())
 	})
 
-	It("reconfigures DB Pruge job", func() {
+	It("reconfigures DB Purge job", func() {
 		Eventually(func(g Gomega) {
 			nova := GetNova(novaNames.NovaName)
 			cell0 := nova.Spec.CellTemplates["cell0"]

--- a/test/functional/nova_reconfiguration_test.go
+++ b/test/functional/nova_reconfiguration_test.go
@@ -18,8 +18,10 @@ package functional_test
 import (
 	"fmt"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
+
+	//revive:disable-next-line:dot-imports
 	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
 
 	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"

--- a/test/functional/nova_scheduler_test.go
+++ b/test/functional/nova_scheduler_test.go
@@ -665,7 +665,7 @@ var _ = Describe("NovaScheduler controller cleaning", func() {
 		It("during reconciling", func() {
 			// We can assert the service cleanup behavior or the reconciler as the cleanup is triggered
 			// unconditionally at the end of every successful reconciliation. So we don't actually need
-			// to trigger a scaledown to see the down services are deleted. The novaAPIFixture is
+			// to trigger a scale down to see the down services are deleted. The novaAPIFixture is
 			// set up in a way that it always respond with a list of services in down state.
 			th.SimulateStatefulSetReplicaReady(novaNames.SchedulerStatefulSetName)
 			th.ExpectCondition(

--- a/test/functional/nova_scheduler_test.go
+++ b/test/functional/nova_scheduler_test.go
@@ -18,9 +18,13 @@ import (
 	"fmt"
 	"net/http"
 
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
+
+	//revive:disable-next-line:dot-imports
+	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
+
 	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
 	keystone_helper "github.com/openstack-k8s-operators/keystone-operator/api/test/helpers"
 	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
@@ -32,8 +36,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
-
-	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
 )
 
 var _ = Describe("NovaScheduler controller", func() {
@@ -80,17 +82,17 @@ var _ = Describe("NovaScheduler controller", func() {
 				}
 			}})
 		DeferCleanup(f.Cleanup)
-		keystone_name := keystone.CreateKeystoneAPIWithFixture(novaNames.NovaName.Namespace, f)
-		keystone_instance := keystone.GetKeystoneAPI(keystone_name)
-		keystone_instance.Status = keystonev1.KeystoneAPIStatus{
+		keystoneName := keystone.CreateKeystoneAPIWithFixture(novaNames.NovaName.Namespace, f)
+		keystoneInstance := keystone.GetKeystoneAPI(keystoneName)
+		keystoneInstance.Status = keystonev1.KeystoneAPIStatus{
 			APIEndpoints: map[string]string{
 				"public":   f.Endpoint(),
 				"internal": f.Endpoint(),
 			},
 		}
-		Expect(th.K8sClient.Status().Update(th.Ctx, keystone_instance.DeepCopy())).Should(Succeed())
+		Expect(th.K8sClient.Status().Update(th.Ctx, keystoneInstance.DeepCopy())).Should(Succeed())
 
-		DeferCleanup(keystone.DeleteKeystoneAPI, keystone_name)
+		DeferCleanup(keystone.DeleteKeystoneAPI, keystoneName)
 		DeferCleanup(
 			k8sClient.Delete, ctx, CreateNovaSecret(novaNames.NovaName.Namespace, SecretName))
 

--- a/test/functional/novaapi_controller_test.go
+++ b/test/functional/novaapi_controller_test.go
@@ -19,21 +19,22 @@ import (
 	"encoding/json"
 	"fmt"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
+
+	//revive:disable-next-line:dot-imports
 	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
 
 	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
+	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 	novav1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
-
-	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
-	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 )
 
 var _ = Describe("NovaAPI controller", func() {
@@ -881,8 +882,8 @@ var _ = Describe("NovaAPI controller", func() {
 			DeferCleanup(th.DeleteInstance, api)
 		})
 		It("has the expected container image default", func() {
-			novaApiDefault := GetNovaAPI(novaNames.APIName)
-			Expect(novaApiDefault.Spec.ContainerImage).To(Equal(util.GetEnvVar("RELATED_IMAGE_NOVA_API_IMAGE_URL_DEFAULT", novav1.NovaAPIContainerImage)))
+			novaAPIDefault := GetNovaAPI(novaNames.APIName)
+			Expect(novaAPIDefault.Spec.ContainerImage).To(Equal(util.GetEnvVar("RELATED_IMAGE_NOVA_API_IMAGE_URL_DEFAULT", novav1.NovaAPIContainerImage)))
 		})
 	})
 })

--- a/test/functional/novacell_controller_test.go
+++ b/test/functional/novacell_controller_test.go
@@ -752,7 +752,7 @@ var _ = Describe("NovaCell controller", func() {
 				g.Expect(k8sClient.Update(ctx, novaCell)).To(Succeed())
 			}, timeout, interval).Should(Succeed())
 
-			// Check that the Metdata is now deployed
+			// Check that the Metadata is now deployed
 			GetNovaMetadata(cell2.MetadataName)
 			th.ExpectCondition(
 				cell2.CellCRName,

--- a/test/functional/novacell_controller_test.go
+++ b/test/functional/novacell_controller_test.go
@@ -18,21 +18,22 @@ package functional_test
 import (
 	"fmt"
 
-	"github.com/google/uuid"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
-	"github.com/openstack-k8s-operators/lib-common/modules/common/service"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
+
+	//revive:disable-next-line:dot-imports
 	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
 
+	"github.com/google/uuid"
+	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
+	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/service"
+	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
+	novav1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
-	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
-	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
-	novav1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
 )
 
 var _ = Describe("NovaCell controller", func() {
@@ -313,9 +314,9 @@ var _ = Describe("NovaCell controller", func() {
 			configData := string(computeConfigData.Data["01-nova.conf"])
 			Expect(configData).To(ContainSubstring("transport_url=rabbit://cell1/fake"))
 			Expect(configData).To(ContainSubstring("username = nova\npassword = service-password\n"))
-			vncUrlConfig := fmt.Sprintf("novncproxy_base_url = http://%s/vnc_lite.html",
+			vncURLConfig := fmt.Sprintf("novncproxy_base_url = http://%s/vnc_lite.html",
 				fmt.Sprintf("nova-novncproxy-%s-public.%s.svc:6080", cell1.CellName, cell1.CellCRName.Namespace))
-			Expect(configData).To(ContainSubstring(vncUrlConfig))
+			Expect(configData).To(ContainSubstring(vncURLConfig))
 			Expect(configData).To(ContainSubstring("[vnc]\nenabled = True"))
 			Expect(configData).Should(
 				ContainSubstring("[upgrade_levels]\ncompute = auto"))
@@ -374,8 +375,8 @@ var _ = Describe("NovaCell controller", func() {
 			configData := string(computeConfigData.Data["01-nova.conf"])
 			Expect(configData).To(ContainSubstring("transport_url=rabbit://cell1/fake"))
 			Expect(configData).To(ContainSubstring("username = nova\npassword = service-password\n"))
-			vncUrlConfig := "novncproxy_base_url = http://foo/vnc_lite.html"
-			Expect(configData).To(ContainSubstring(vncUrlConfig))
+			vncURLConfig := "novncproxy_base_url = http://foo/vnc_lite.html"
+			Expect(configData).To(ContainSubstring(vncURLConfig))
 			Expect(configData).To(ContainSubstring("[vnc]\nenabled = True"))
 
 			th.ExpectCondition(
@@ -630,9 +631,9 @@ var _ = Describe("NovaCell controller", func() {
 			Expect(computeConfigData).ShouldNot(BeNil())
 			Expect(computeConfigData.Data).Should(HaveKey("01-nova.conf"))
 			configData := string(computeConfigData.Data["01-nova.conf"])
-			vncUrlConfig := fmt.Sprintf("novncproxy_base_url = http://%s/vnc_lite.html",
+			vncURLConfig := fmt.Sprintf("novncproxy_base_url = http://%s/vnc_lite.html",
 				fmt.Sprintf("nova-novncproxy-%s-public.%s.svc:6080", cell2.CellName, cell2.CellCRName.Namespace))
-			Expect(configData).To(ContainSubstring(vncUrlConfig))
+			Expect(configData).To(ContainSubstring(vncURLConfig))
 			Expect(configData).To(ContainSubstring("[vnc]\nenabled = True"))
 
 			Expect(GetNovaCell(cell2.CellCRName).Status.Hash[cell2.ComputeConfigSecretName.Name]).NotTo(BeNil())

--- a/test/functional/novaconductor_controller_test.go
+++ b/test/functional/novaconductor_controller_test.go
@@ -18,22 +18,23 @@ import (
 	"fmt"
 	"net/http"
 
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
+
+	//revive:disable-next-line:dot-imports
+	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
+
 	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
 	keystone_helper "github.com/openstack-k8s-operators/keystone-operator/api/test/helpers"
-	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
+	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	api "github.com/openstack-k8s-operators/lib-common/modules/test/apis"
 	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 	novav1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
-
-	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
-	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 )
 
 var _ = Describe("NovaConductor controller", func() {
@@ -275,7 +276,7 @@ var _ = Describe("NovaConductor controller", func() {
 			job := th.GetJob(cell0.DBSyncJobName)
 			Expect(job.Spec.Template.Spec.ServiceAccountName).To(Equal("nova-sa"))
 			Expect(job.Spec.Template.Spec.Volumes).To(HaveLen(2))
-			Expect(job.Spec.Template.Spec.InitContainers).To(HaveLen(0))
+			Expect(job.Spec.Template.Spec.InitContainers).To(BeEmpty())
 			Expect(job.Spec.Template.Spec.Containers).To(HaveLen(1))
 			container := job.Spec.Template.Spec.Containers[0]
 			Expect(container.VolumeMounts).To(HaveLen(3))

--- a/test/functional/sample_test.go
+++ b/test/functional/sample_test.go
@@ -19,8 +19,8 @@ import (
 	"os"
 	"path/filepath"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
 	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/types"
 )

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -110,7 +110,7 @@ var _ = BeforeSuite(func() {
 		"github.com/openstack-k8s-operators/infra-operator/apis", gomod, "bases")
 	Expect(err).ShouldNot(HaveOccurred())
 	// NOTE(gibi): there are packages where the CRD directory has other
-	// yamls files as well, then we need to specify the extac file to load
+	// yamls files as well, then we need to specify the exact file to load
 	networkv1CRD, err := test.GetCRDDirFromModule(
 		"github.com/k8snetworkplumbingwg/network-attachment-definition-client", gomod, "artifacts/networks-crd.yaml")
 	Expect(err).ShouldNot(HaveOccurred())
@@ -270,7 +270,7 @@ var _ = BeforeEach(func() {
 	// we run the test in an existing cluster.
 	DeferCleanup(th.DeleteNamespace, namespace)
 
-	// We need to limit the lenght of the name of the Nova CR as the operator generates names
+	// We need to limit the length of the name of the Nova CR as the operator generates names
 	// for the sub CRs from this name as a prefix.
 	// E.g. <nova-CR-name>-<cell name>-metadata-internal
 	// K8s limits the name of a CR to 63 chars so we can easily hit that limit with uuids as names

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -27,8 +27,8 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
 	"go.uber.org/zap/zapcore"
 
 	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"

--- a/test/functional/validation_webhook_test.go
+++ b/test/functional/validation_webhook_test.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"strings"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"


### PR DESCRIPTION
This needed the following adjustments:

* rename variables to follow style
* removed unused function parameters
* changed error string to start with lower case
* added missing error handling
* ignore revive dot-imports rule for ginkgo and gomega
* added missing assert of Eventually block
* improved gomega assert usage