### PR TITLE
[kuttl]Fix config tests

### DIFF
--- a/test/kuttl/test-suites/default/config-tests/01-assert.yaml
+++ b/test/kuttl/test-suites/default/config-tests/01-assert.yaml
@@ -131,6 +131,7 @@ kind: TestAssert
 namespaced: true
 commands:
   - script: |
+      set -euxo pipefail
       oc exec -n $NAMESPACE openstackclient -- openstack flavor create my-flavor 2>&1 |
           grep "Policy doesn't allow os_compute_api:os-flavor-manage:create to be performed"
 ---
@@ -139,5 +140,6 @@ kind: TestAssert
 namespaced: true
 commands:
   - script: |
+      set -euxo pipefail
       RP_UUID=$(oc exec -n $NAMESPACE openstackclient -- openstack resource provider list --name nova-kuttl-cell1-compute-fake1-compute-0 -f value -c uuid)
       oc exec -n $NAMESPACE openstackclient -- openstack resource provider trait list $RP_UUID | grep CUSTOM_FOO

--- a/test/kuttl/test-suites/default/config-tests/01-assert.yaml
+++ b/test/kuttl/test-suites/default/config-tests/01-assert.yaml
@@ -134,11 +134,6 @@ commands:
       set -euxo pipefail
       oc exec -n $NAMESPACE openstackclient -- openstack flavor create my-flavor 2>&1 |
           grep "Policy doesn't allow os_compute_api:os-flavor-manage:create to be performed"
----
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-namespaced: true
-commands:
   - script: |
       set -euxo pipefail
       RP_UUID=$(oc exec -n $NAMESPACE openstackclient -- openstack resource provider list --name nova-kuttl-cell1-compute-fake1-compute-0 -f value -c uuid)

--- a/test/kuttl/test-suites/default/config-tests/01-assert.yaml
+++ b/test/kuttl/test-suites/default/config-tests/01-assert.yaml
@@ -132,8 +132,8 @@ namespaced: true
 commands:
   - script: |
       set -euxo pipefail
-      oc exec -n $NAMESPACE openstackclient -- openstack flavor create my-flavor 2>&1 |
-          grep "Policy doesn't allow os_compute_api:os-flavor-manage:create to be performed"
+      MESSAGE=$(oc exec -n $NAMESPACE openstackclient -- openstack flavor create my-flavor 2>&1) || true
+      echo $MESSAGE | grep "Policy doesn't allow os_compute_api:os-flavor-manage:create to be performed"
   - script: |
       set -euxo pipefail
       RP_UUID=$(oc exec -n $NAMESPACE openstackclient -- openstack resource provider list --name nova-kuttl-cell1-compute-fake1-compute-0 -f value -c uuid)


### PR DESCRIPTION
* added `set -euxo pipefail` to scripts
* squashed TestAsserts as kuttl only execute one TestAssert per assert file the other is ignored.
So the two TestAssert is combined to a single one having two commands.
* fixed the false positive policy assert
