### PR TITLE
[kuttl][pre-commit]Check for multiple TestAsserts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,3 +69,10 @@ repos:
   hooks:
     - id: golangci-lint-full
       args: ["-v"]
+
+- repo: https://github.com/openstack-k8s-operators/openstack-k8s-operators-ci
+  # NOTE(gibi): we cannot automatically track main here
+  # see https://pre-commit.com/#using-the-latest-version-for-a-repository
+  rev: e30d72fcbced0ab8a7b6d23be1dee129e2a7b849
+  hooks:
+    - id: kuttl-single-test-assert


### PR DESCRIPTION
Kuttl only execute the last TestAssert in a assert file and ignores the
previous TestAsserts silently. This can lead to false positive test
results. A new pre-commit check is added to catch this.

Depends-On: https://github.com/openstack-k8s-operators/openstack-k8s-operators-ci/pull/105