### PR TITLE
stop setting  mem_stats_period_seconds=0

### DIFF
--- a/templates/nova.conf
+++ b/templates/nova.conf
@@ -198,7 +198,6 @@ live_migration_timeout_action=force_complete
 cpu_mode=host-model
 hw_machine_type=x86_64=q35
 sysinfo_serial=unique
-mem_stats_period_seconds=0
 num_pcie_ports=24
 images_type=qcow2
 rx_queue_size=512


### PR DESCRIPTION
mem_stats_period_seconds=0 was the upstream way to disable
the virtio memory ballon in libvirt guest however several release
ago libvirt started adding the mem balloan device if not present
in the xml

when using sev the mem ballon device also needs
  <driver iommu='on'/>
which is not added by default by libvirt

since this is not working as intened and disableing the
memballon device this change just removed the override
to ensure sev guest work correctly.

Related: [OSPRH-6880](https://issues.redhat.com//browse/OSPRH-6880)
