### PR TITLE
Make the ceph job non voting until fixed

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -129,6 +129,7 @@
     name: nova-operator-tempest-multinode-ceph
     parent: podified-multinode-hci-deployment-crc-3comp
     dependencies: ["openstack-k8s-operators-content-provider"]
+    voting: false
     # Note:  When inheriting from a job (or creating a variant of a job) vars are merged with previous definitions
     vars:
       cifmw_extras:


### PR DESCRIPTION
The job might be back to green after
openstack-k8s-operators/ci-framework#1757
and openstack-k8s-operators/dataplane-operator#896 lands
