### PR TITLE
Clean up scaled down services based on hostname

### DIFF
--- a/controllers/novascheduler_controller.go
+++ b/controllers/novascheduler_controller.go
@@ -278,6 +278,11 @@ func (r *NovaSchedulerReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return result, err
 	}
 
+	if *instance.Spec.Replicas != instance.Status.ReadyCount {
+		Log.Info("Waiting for the ReadyCount to become equal to Replicas before doing service cleanup in nova database.")
+		return ctrl.Result{}, nil
+	}
+
 	// clean up nova services from nova db should be always a last step in reconcile
 	// to make sure that
 	err = r.cleanServiceFromNovaDb(ctx, h, instance, secret, Log)
@@ -668,6 +673,7 @@ func (r *NovaSchedulerReconciler) cleanServiceFromNovaDb(
 	if err != nil {
 		return err
 	}
+	replicaCount := instance.Spec.Replicas
 
-	return cleanNovaServiceFromNovaDb(computeClient, "nova-scheduler", l)
+	return cleanNovaServiceFromNovaDb(computeClient, "nova-scheduler", l, *replicaCount, "")
 }

--- a/test/functional/api_fixture.go
+++ b/test/functional/api_fixture.go
@@ -82,7 +82,7 @@ func AddNovaAPIFixture(log logr.Logger, server *api.FakeAPIServer) *NovaAPIFixtu
 			{
 				ID:         "1",
 				Binary:     "nova-scheduler",
-				Host:       "host1",
+				Host:       "nova-scheduler-0",
 				State:      "up",
 				Status:     "disabled",
 				ForcedDown: false,
@@ -90,7 +90,7 @@ func AddNovaAPIFixture(log logr.Logger, server *api.FakeAPIServer) *NovaAPIFixtu
 			{
 				ID:         "2",
 				Binary:     "nova-compute",
-				Host:       "host1",
+				Host:       "nova-compute-0",
 				State:      "up",
 				Status:     "disabled",
 				ForcedDown: false,
@@ -98,7 +98,7 @@ func AddNovaAPIFixture(log logr.Logger, server *api.FakeAPIServer) *NovaAPIFixtu
 			{
 				ID:         "3",
 				Binary:     "nova-scheduler",
-				Host:       "host2",
+				Host:       "nova-scheduler-1",
 				State:      "down",
 				Status:     "enabled",
 				ForcedDown: false,
@@ -106,7 +106,7 @@ func AddNovaAPIFixture(log logr.Logger, server *api.FakeAPIServer) *NovaAPIFixtu
 			{
 				ID:         "4",
 				Binary:     "nova-compute",
-				Host:       "host2",
+				Host:       "nova-compute-1",
 				State:      "down",
 				Status:     "disabled",
 				ForcedDown: false,
@@ -114,7 +114,31 @@ func AddNovaAPIFixture(log logr.Logger, server *api.FakeAPIServer) *NovaAPIFixtu
 			{
 				ID:         "5",
 				Binary:     "nova-conductor",
-				Host:       "host2",
+				Host:       "nova-cell0-conductor-0",
+				State:      "up",
+				Status:     "disabled",
+				ForcedDown: false,
+			},
+			{
+				ID:         "6",
+				Binary:     "nova-conductor",
+				Host:       "nova-cell1-conductor-0",
+				State:      "down",
+				Status:     "disabled",
+				ForcedDown: false,
+			},
+			{
+				ID:         "7",
+				Binary:     "nova-conductor",
+				Host:       "nova-cell1-conductor-1",
+				State:      "up",
+				Status:     "disabled",
+				ForcedDown: false,
+			},
+			{
+				ID:         "8",
+				Binary:     "nova-conductor",
+				Host:       "nova-cell0-conductor-1",
 				State:      "down",
 				Status:     "disabled",
 				ForcedDown: false,

--- a/test/functional/novaconductor_controller_test.go
+++ b/test/functional/novaconductor_controller_test.go
@@ -781,8 +781,12 @@ var _ = Describe("NovaConductor controller cleaning", func() {
 				corev1.ConditionTrue,
 			)
 			Expect(novaAPIServer.HasRequest("GET", "/compute/os-services/", "binary=nova-conductor")).To(BeTrue())
-			Expect(novaAPIServer.HasRequest("DELETE", "/compute/os-services/5", "")).To(BeTrue())
-			req := novaAPIServer.FindRequest("DELETE", "/compute/os-services/5", "")
+			Expect(novaAPIServer.HasRequest("DELETE", "/compute/os-services/5", "")).NotTo(BeTrue())
+			// ID(6, 7)should not delete as these are from cell1 and not from cell0
+			Expect(novaAPIServer.HasRequest("DELETE", "/compute/os-services/6", "")).NotTo(BeTrue())
+			Expect(novaAPIServer.HasRequest("DELETE", "/compute/os-services/7", "")).NotTo(BeTrue())
+			Expect(novaAPIServer.HasRequest("DELETE", "/compute/os-services/8", "")).To(BeTrue())
+			req := novaAPIServer.FindRequest("DELETE", "/compute/os-services/8", "")
 			Expect(req.Header.Get("X-OpenStack-Nova-API-Version")).To(Equal("2.95"))
 		})
 	})


### PR DESCRIPTION
- Update service objects in functional test api_fixture
- Adds a check to wait for readycount to become equal to replica
- Delete service host from nova DB by hostname on replica count update

Implements: [OSPRH-6912](https://issues.redhat.com//browse/OSPRH-6912)