### PR TITLE
Add --vebose to host discover

### DIFF
--- a/templates/nova-manage/bin/host_discover.sh
+++ b/templates/nova-manage/bin/host_discover.sh
@@ -15,4 +15,4 @@
 
 set -xe
 
-nova-manage cell_v2 discover_hosts --by-service
+nova-manage cell_v2 discover_hosts --by-service --verbose


### PR DESCRIPTION
The nova cell controller runs nova-manage cell_v2 discover_hosts
in a Job when a new compute's statefulset becomes ready. This PR just
adds --verbose to the command to get more information about the mapped
computes.
