### PR TITLE
Restore condition transition time at the right place

### DIFF
--- a/controllers/nova_controller.go
+++ b/controllers/nova_controller.go
@@ -159,8 +159,8 @@ func (r *NovaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 			instance.Status.Conditions.Set(
 				instance.Status.Conditions.Mirror(condition.ReadyCondition))
 		}
-		err := h.PatchInstance(ctx, instance)
 		condition.RestoreLastTransitionTimes(&instance.Status.Conditions, savedConditions)
+		err := h.PatchInstance(ctx, instance)
 		if err != nil {
 			_err = err
 			return

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/go-logr/logr v1.4.2
+	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/gophercloud/gophercloud v1.12.0
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0
@@ -42,7 +43,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20240424215950-a892ee059fd6 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect


### PR DESCRIPTION
As we are resetting the condition list in each reconcile we have the
logic to restore the last transition timestamp of the unchanged
conditions in at the end of the reconcile. However in the nova
controller the restore call was after the instance is was persisted and
therefore it was ineffective. This could lead to extra reconciles in
openstack-operator even if the nova-operator needed to update nothing in
the underlying resources.
