### PR TITLE
Revert "Wait for DB writes to propagate (causality checks)"

### DIFF
--- a/templates/nova.conf
+++ b/templates/nova.conf
@@ -211,22 +211,12 @@ cpu_power_management=true
 {{if (index . "cell_db_address")}}
 [database]
 connection = mysql+pymysql://{{ .cell_db_user }}:{{ .cell_db_password}}@{{ .cell_db_address }}/{{ .cell_db_name }}?read_default_file=/etc/my.cnf
-
-# Wait for writes to complete when doing a read.
-# Relevant for multi-master galera deployments
-# https://mariadb.com/docs/server/ref/mdb/system-variables/wsrep_sync_wait/
-mysql_wsrep_sync_wait = 1
 {{end}}
 
 
 {{if (index . "api_db_address")}}
 [api_database]
 connection = mysql+pymysql://{{ .api_db_user }}:{{ .api_db_password }}@{{ .api_db_address }}/{{ .api_db_name }}?read_default_file=/etc/my.cnf
-
-# Wait for writes to complete when doing a read.
-# Relevant for multi-master galera deployments
-# https://mariadb.com/docs/server/ref/mdb/system-variables/wsrep_sync_wait/
-mysql_wsrep_sync_wait = 1
 {{end}}
 
 [keystone_authtoken]

--- a/test/functional/nova_controller_test.go
+++ b/test/functional/nova_controller_test.go
@@ -319,6 +319,7 @@ var _ = Describe("Nova controller", func() {
 					cell0Account.Spec.UserName, cell0Secret.Data[mariadbv1.DatabasePasswordSelector],
 					novaNames.Namespace)),
 			)
+
 			apiAccount := mariadb.GetMariaDBAccount(novaNames.APIMariaDBDatabaseAccount)
 			apiSecret := th.GetSecret(types.NamespacedName{Name: apiAccount.Spec.Secret, Namespace: novaNames.APIMariaDBDatabaseAccount.Namespace})
 
@@ -326,9 +327,6 @@ var _ = Describe("Nova controller", func() {
 				ContainSubstring(fmt.Sprintf("[api_database]\nconnection = mysql+pymysql://%s:%s@hostname-for-openstack.%s.svc/nova_api?read_default_file=/etc/my.cnf",
 					apiAccount.Spec.UserName, apiSecret.Data[mariadbv1.DatabasePasswordSelector], novaNames.Namespace)),
 			)
-
-			Expect(configData).To(ContainSubstring("mysql_wsrep_sync_wait = 1"))
-
 			// NOTE(gibi): cell mapping for cell0 should not have transport_url
 			// configured. As the nova-manage command used to create the mapping
 			// uses the transport_url from the nova.conf provided to the job


### PR DESCRIPTION
This reverts commit ab95f150cbecb6cdf03795cc56d1516914c9e2fd.

The https://github.com/openstack-k8s-operators/mariadb-operator/pull/229
switched the mariadb-operator to Active/Passive mode instead of
multimaster. This means we don't need to force synchronization from the
client config any more.

Related: [OSPRH-7405](https://issues.redhat.com//browse/OSPRH-7405)