### PR TITLE
[CI]Remove DATAPLANE_REPO from kuttl jobdef

### DIFF
--- a/ci/nova-operator-base/ci_fw_vars.yaml
+++ b/ci/nova-operator-base/ci_fw_vars.yaml
@@ -2,7 +2,6 @@
 ansible_user_dir: "{{ lookup('env', 'HOME') }}"
 cifmw_installyamls_repos: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
 cifmw_install_yamls_vars:
-  DATAPLANE_REPO: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/dataplane-operator"
   STORAGE_CLASS: crc-csi-hostpath-provisioner
   BMO_SETUP: false
 


### PR DESCRIPTION
That repository is merged into the openstack-operator and install_yamls
does not have the matching variable any more. This causes that the pre
playbook fails with:
```
'cifmw_install_yamls_vars contains a variable that is not defined in install_yamls Makefile nor cifmw_install_yamls_whitelisted_vars: DATAPLANE_REPO'
```
