### PR TITLE
Improve api logs

### DIFF
--- a/pkg/novaapi/deployment.go
+++ b/pkg/novaapi/deployment.go
@@ -154,10 +154,9 @@ func StatefulSet(
 							Args: []string{
 								"--single-child",
 								"--",
-								"/usr/bin/tail",
-								"-n+1",
-								"-F",
-								"/var/log/nova/nova-api.log",
+								"/bin/sh",
+								"-c",
+								"/usr/bin/tail -n+1 -F /var/log/nova/nova-api.log 2>/dev/null",
 							},
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{

--- a/pkg/novametadata/deployment.go
+++ b/pkg/novametadata/deployment.go
@@ -142,10 +142,9 @@ func StatefulSet(
 							Args: []string{
 								"--single-child",
 								"--",
-								"/usr/bin/tail",
-								"-n+1",
-								"-F",
-								"/var/log/nova/nova-metadata.log",
+								"/bin/sh",
+								"-c",
+								"/usr/bin/tail -n+1 -F /var/log/nova/nova-metadata.log 2>/dev/null",
 							},
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{

--- a/templates/nova.conf
+++ b/templates/nova.conf
@@ -5,8 +5,8 @@ max_concurrent_live_migrations=1
 state_path = /var/lib/nova
 allow_resize_to_same_host = true
 # enable log rotation in oslo config by default
-max_logfile_count=5
-max_logfile_size_mb=50
+max_logfile_count=1
+max_logfile_size_mb=20
 log_rotation_type=size
 {{if (index . "log_file") }}
 log_file = {{ .log_file }}


### PR DESCRIPTION
When the log gets rotated in the api or metadata containers our logs
will get polluted with the following messages from the tail command:

```
tail: '/var/log/nova/nova-api.log' has become inaccessible: No such file or directory
tail: '/var/log/nova/nova-api.log' has appeared;  following new file
```

To prevent his from happening we will redirect the stderr from the
tail command into /dev/null.

This PR also reduces the size used by useless rotated logs.

The log file configured in nova is only used to pass the data to
the log sidecar, which then outputs the data to stdout and then goes to
/var/log/pods and/or a centralized logging service.

Considering this, there is no need to keep 5 rotated logs, since we'll
also have them in the other locations and there is no way to get them
without actually going manually into the specific container within the
pod.

This patch proposes having a single rotated log (because passing 0 as
max_logfile_count doesn't work as we want in oslo.log) and reducing the
size to rotate from 50MB to 20MB.
