### PR TITLE
update dhcp_domain and enabled_filters defaults

### DIFF
--- a/templates/nova.conf
+++ b/templates/nova.conf
@@ -84,7 +84,7 @@ workers=1
 {{ if eq .service_name "nova-scheduler"}}
 [filter_scheduler]
 available_filters = nova.scheduler.filters.all_filters
-enabled_filters = ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter,SameHostFilter,DifferentHostFilter,PciPassthroughFilter,NUMATopologyFilter
+enabled_filters = AggregateInstanceExtraSpecsFilter,ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter,SameHostFilter,DifferentHostFilter,PciPassthroughFilter,NUMATopologyFilter
 # until we can disabel upcalls we can't turn this off by default
 # track_instance_changes = false
 shuffle_best_same_weighed_hosts = true
@@ -108,8 +108,12 @@ image_metadata_prefilter=true
 ssl_minimum_version=tlsv1_3
 {{end}}
 
-{{if eq .service_name "nova-api" "nova-metadata"}}
 [api]
+# for compatibility with older release we override the default
+# to be the empty string. This ensures no domain suffix is added
+# to the instance name.
+dhcp_domain = ''
+{{if eq .service_name "nova-api" "nova-metadata"}}
 auth_strategy = keystone
 {{ if eq .service_name "nova-metadata"}}
 local_metadata_per_cell = {{ .local_metadata_per_cell }}

--- a/test/functional/nova_metadata_controller_test.go
+++ b/test/functional/nova_metadata_controller_test.go
@@ -215,6 +215,8 @@ var _ = Describe("NovaMetadata controller", func() {
 							apiAccount.Spec.UserName, apiSecret.Data[mariadbv1.DatabasePasswordSelector])),
 				)
 
+				// ensure we maintain the tripleo default for backwards compatibility
+				Expect(configData).Should(ContainSubstring("dhcp_domain = ''"))
 				Expect(configData).Should(
 					ContainSubstring("[upgrade_levels]\ncompute = auto"))
 				Expect(configData).Should(

--- a/test/functional/nova_scheduler_test.go
+++ b/test/functional/nova_scheduler_test.go
@@ -216,6 +216,20 @@ var _ = Describe("NovaScheduler controller", func() {
 				ContainSubstring("[client]\nssl=0"))
 			extraConfigData := string(configDataMap.Data["02-nova-override.conf"])
 			Expect(extraConfigData).To(Equal("foo=bar"))
+			// ensure that sepcific non default filters we expect are present
+			// the AggregateInstanceExtraSpecsFilter is enabled by default as it is
+			// one of the most common non default filters used by customers
+			Expect(configData).Should(
+				ContainSubstring("enabled_filters = AggregateInstanceExtraSpecsFilter"))
+			//  the pci_passthrough and numa_topology filters are enabled by default to
+			//  ensure numa aware schduleing works correctly out of the box
+			Expect(configData).Should(
+				ContainSubstring("PciPassthroughFilter,NUMATopologyFilter"))
+			//  the ServerGroupAntiAffinityFilter and ServerGroupAffinityFilter are enabled
+			//  by default to ensure server group aware schduleing is supported.
+			Expect(configData).Should(
+				ContainSubstring("ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter"))
+
 		})
 
 		It("stored the input hash in the Status", func() {

--- a/test/functional/novacell_controller_test.go
+++ b/test/functional/novacell_controller_test.go
@@ -312,6 +312,8 @@ var _ = Describe("NovaCell controller", func() {
 			Expect(computeConfigData).ShouldNot(BeNil())
 			Expect(computeConfigData.Data).Should(HaveKey("01-nova.conf"))
 			configData := string(computeConfigData.Data["01-nova.conf"])
+			// ensure we maintain the tripleo default for backwards compatibility
+			Expect(configData).Should(ContainSubstring("dhcp_domain = ''"))
 			Expect(configData).To(ContainSubstring("transport_url=rabbit://cell1/fake"))
 			Expect(configData).To(ContainSubstring("username = nova\npassword = service-password\n"))
 			vncURLConfig := fmt.Sprintf("novncproxy_base_url = http://%s/vnc_lite.html",


### PR DESCRIPTION
This change maintains the tripleo default for dhcp_domain
by overriding it to the empty string.

This is requried to prevent a change in behavior for adopted
cloud and to make teh configurable FQDN feature work as expected
out of the box. dhcp_domain is now set to ''

This change is required in both the metadata api config and the comptue
node config. envtest coverage is added to prevent this regressing.

the AggregateInstanceExtraSpecsFilter is one of the most commonly enabled
filters, this change adds it too our default set to reflect that

The existing envtest config coverage is extended to ensure this is enabled
as well as teh other imporant filter like the numa toplogy filter.

These filters are enabled to ensure correct operatorion fo feature such as
pci passthough and servergroups by default in order to simplfy the ux for
admins.
