### PR TITLE
Add posibilities to specify metadata password selector per cell

### DIFF
--- a/api/bases/nova.openstack.org_nova.yaml
+++ b/api/bases/nova.openstack.org_nova.yaml
@@ -1567,6 +1567,15 @@ spec:
                     description: MetadataSecret - the name of the field to get the
                       metadata secret from the Secret
                     type: string
+                  prefixMetadataCellsSecret:
+                    default: MetadataCellsSecret
+                    description: prefixMetadataCellsSecret - the prefix name of the
+                      field to get the metadata secret from the Secret for cells.
+                      Vale of metadata_proxy_shared_secret information for the nova-metadata
+                      service. This secret is shared between nova and neutron ovn-metadata
+                      inside selected cell and if this is not defined the global metadata_proxy_shared_secret
+                      secret will be used
+                    type: string
                   service:
                     default: NovaPassword
                     description: Service - Selector to get the keystone service user

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -87,6 +87,15 @@ type PasswordSelector struct {
 	// MetadataSecret - the name of the field to get the metadata secret from the
 	// Secret
 	MetadataSecret string `json:"metadataSecret"`
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default="MetadataCellsSecret"
+	// prefixMetadataCellsSecret - the prefix name of the field to get the metadata secret from the
+	// Secret for cells. Vale of metadata_proxy_shared_secret
+	// information for the nova-metadata service. This secret is shared
+	// between nova and neutron ovn-metadata inside selected cell
+	// and if this is not defined the global metadata_proxy_shared_secret
+	// secret will be used
+	PrefixMetadataCellsSecret string `json:"prefixMetadataCellsSecret"`
 }
 
 type NovaImages struct {

--- a/config/crd/bases/nova.openstack.org_nova.yaml
+++ b/config/crd/bases/nova.openstack.org_nova.yaml
@@ -1567,6 +1567,15 @@ spec:
                     description: MetadataSecret - the name of the field to get the
                       metadata secret from the Secret
                     type: string
+                  prefixMetadataCellsSecret:
+                    default: MetadataCellsSecret
+                    description: prefixMetadataCellsSecret - the prefix name of the
+                      field to get the metadata secret from the Secret for cells.
+                      Vale of metadata_proxy_shared_secret information for the nova-metadata
+                      service. This secret is shared between nova and neutron ovn-metadata
+                      inside selected cell and if this is not defined the global metadata_proxy_shared_secret
+                      secret will be used
+                    type: string
                   service:
                     default: NovaPassword
                     description: Service - Selector to get the keystone service user

--- a/controllers/nova_controller.go
+++ b/controllers/nova_controller.go
@@ -1647,7 +1647,12 @@ func (r *NovaReconciler) ensureCellSecret(
 	// If metadata is enabled in the cell then the cell secret needs the
 	// metadata shared secret
 	if *cellTemplate.MetadataServiceTemplate.Enabled {
-		data[MetadataSecretSelector] = string(externalSecret.Data[instance.Spec.PasswordSelectors.MetadataSecret])
+		val, ok := externalSecret.Data[instance.Spec.PasswordSelectors.PrefixMetadataCellsSecret+cellName]
+		if ok {
+			data[MetadataSecretSelector] = string(val)
+		} else {
+			data[MetadataSecretSelector] = string(externalSecret.Data[instance.Spec.PasswordSelectors.MetadataSecret])
+		}
 	}
 
 	// NOTE(gibi): When we switch to immutable secrets then we need to include


### PR DESCRIPTION
Now metadata password can be specified per cell using MetadataTemplate. If there is no defined MetadataSecret secret from top nova secret is used

close #524 