### PR TITLE
Fixes config vars in nova.conf

### DIFF
--- a/templates/nova.conf
+++ b/templates/nova.conf
@@ -3,7 +3,9 @@
 # overall then serializing live migrations so set this to 1 explictly
 max_concurrent_live_migrations=1
 state_path = /var/lib/nova
+{{if eq .service_name "nova-api"}}
 allow_resize_to_same_host = true
+{{end}}
 # enable log rotation in oslo config by default
 max_logfile_count=1
 max_logfile_size_mb=20
@@ -25,13 +27,12 @@ instance_usage_audit_period = hour
 initial_cpu_allocation_ratio=4.0
 initial_ram_allocation_ratio=1.0
 initial_disk_allocation_ratio=0.9
-{{end}}
 {{/*using a config drive will void issues with ovn and metadata*/}}
 force_config_drive=True
+{{end}}
 {{ if (index . "transport_url") }}
 transport_url={{.transport_url}}
 {{end}}
-
 {{if eq .service_name "nova-api"}}
 # scaling should be done by running more pods
 osapi_compute_workers=1
@@ -41,7 +42,6 @@ enabled_apis=osapi_compute
 metadata_workers=1
 enabled_apis=metadata
 {{end}}
-
 {{if eq .service_name "nova-novncproxy"}}
 {{ if (index . "SSLCertificateFile") }}
 ssl_only=true
@@ -182,19 +182,22 @@ tls_enabled={{ .MemcachedTLS }}
 backend = oslo_cache.dict
 {{end}}
 
+{{ if eq .service_name "nova-scheduler"}}
 [workarounds]
 disable_fallback_pcpu_query=true
+{{end}}
 {{ if eq .service_name "nova-compute"}}
+[workarounds]
 enable_qemu_monitor_announce_self=true
 reserve_disk_resource_for_image_cache=true
-
 # NOTE(gibi): We need this as live migration does not work with
 # cpu_mode=host-model . See https://bugs.launchpad.net/nova/+bug/2039803
 skip_cpu_compare_on_dest = true
-
 {{end}}
 
-{{ if eq .service_name "nova-compute"}}
+
+{{ if eq .service_name "nova-compute" }}
+{{ if eq .compute_driver "libvirt.LibvirtDriver" }}
 [libvirt]
 live_migration_permit_post_copy=true
 live_migration_permit_auto_converge=true
@@ -213,6 +216,7 @@ live_migration_uri = qemu+ssh://nova@%s/system?keyfile=/var/lib/nova/.ssh/ssh-pr
 # https://issues.redhat.com/browse/OSPRH-8806
 # https://issues.redhat.com/browse/OSPRH-8712
 cpu_power_management=false
+{{end}}
 {{end}}
 
 {{if (index . "cell_db_address")}}


### PR DESCRIPTION
- moves `allow_resize_to_same_host` under nvoa-api
- moves `[workarounds].disable_fallback_pcpu_query=true` under scheduler only and rest under nova-compute
- moves `[libvirt] conf` under `libvirt.LibvirtDriver` driver

Closes #144