### PR TITLE
[envtest]Move q35 assert to libvirt compute config test

### DIFF
--- a/test/functional/nova_compute_ironic_controller_test.go
+++ b/test/functional/nova_compute_ironic_controller_test.go
@@ -165,7 +165,6 @@ var _ = Describe("NovaCompute controller", func() {
 				Expect(configDataMap).ShouldNot(BeNil())
 				Expect(configDataMap.Data).Should(HaveKey("01-nova.conf"))
 				configData := string(configDataMap.Data["01-nova.conf"])
-				Expect(configData).Should(ContainSubstring("hw_machine_type=x86_64=q35"))
 				Expect(configData).Should(
 					ContainSubstring("transport_url=rabbit://cell1/fake"))
 				Expect(configData).Should(

--- a/test/functional/novacell_controller_test.go
+++ b/test/functional/novacell_controller_test.go
@@ -331,6 +331,7 @@ var _ = Describe("NovaCell controller", func() {
 			// to the systemd journal. For openshift compute services, the logs are captured by the openshift
 			// logging infrastructure.
 			Expect(configData).To(Not(ContainSubstring("log_file = /var/log/nova/nova-compute.log")))
+			Expect(configData).Should(ContainSubstring("hw_machine_type=x86_64=q35"))
 
 			th.ExpectCondition(
 				cell1.CellCRName,


### PR DESCRIPTION
The bf556e9f50714654222cdf3cd13fd897ece5813a added the assert q35
machine type assert to the ironic compute test suite. Even though we
generate the machine_type config for the ironic compute
(wrongly/unnecessarily) only the libvirt computes are using that
configuration. So this patch move the assert to the libvirt compute
config test. This is needed to prevent confusion and unexpected test
failure when we improve the config generation to not generate libvirt
config to the ironic compute.
