### PR TITLE
[zuul]Pin local storage job to 4.15

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -76,6 +76,7 @@
     name: nova-operator-tempest-multinode
     parent: podified-multinode-edpm-deployment-crc-3comp
     dependencies: ["openstack-k8s-operators-content-provider"]
+    nodeset: centos-9-medium-3x-centos-9-crc-extracted-2-36-0-3xl
     post-run:
       - ci/nova-operator-base/playbooks/collect-logs.yaml
     vars:


### PR DESCRIPTION
It seems the base job is moved to ocp 4.16 and since then the job fails
to deploy a stable crc. Pinning back to 4.15 while we separately working
on making 4.16 based job green.

Trying 4.16 in https://github.com/openstack-k8s-operators/nova-operator/pull/827
