### PR TITLE
Return nil error in case NotFound and to use RequeueAfter

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -199,6 +199,7 @@ func ensureSecret(
 	err := reader.Get(ctx, secretName, secret)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
+			log.FromContext(ctx).Info(fmt.Sprintf("secret %s not found", secretName))
 			conditionUpdater.Set(condition.FalseCondition(
 				condition.InputReadyCondition,
 				condition.RequestedReason,
@@ -207,7 +208,7 @@ func ensureSecret(
 			return "",
 				ctrl.Result{RequeueAfter: requeueTimeout},
 				*secret,
-				fmt.Errorf("secret %s not found", secretName)
+				nil
 		}
 		conditionUpdater.Set(condition.FalseCondition(
 			condition.InputReadyCondition,
@@ -268,13 +269,14 @@ func ensureNetworkAttachments(
 		_, err := nad.GetNADWithName(ctx, h, netAtt, h.GetBeforeObject().GetNamespace())
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				log.FromContext(ctx).Info(fmt.Sprintf("network-attachment-definition %s not found", netAtt))
 				conditionUpdater.Set(condition.FalseCondition(
 					condition.NetworkAttachmentsReadyCondition,
 					condition.RequestedReason,
 					condition.SeverityInfo,
 					condition.NetworkAttachmentsReadyWaitingMessage,
 					netAtt))
-				return nadAnnotations, ctrl.Result{RequeueAfter: requeueTimeout}, fmt.Errorf("network-attachment-definition %s not found", netAtt)
+				return nadAnnotations, ctrl.Result{RequeueAfter: requeueTimeout}, nil
 			}
 			conditionUpdater.Set(condition.FalseCondition(
 				condition.NetworkAttachmentsReadyCondition,

--- a/controllers/novaapi_controller.go
+++ b/controllers/novaapi_controller.go
@@ -190,7 +190,7 @@ func (r *NovaAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		&instance.Status.Conditions,
 		r.RequeueTimeout,
 	)
-	if err != nil {
+	if (err != nil || result != ctrl.Result{}) {
 		return result, err
 	}
 

--- a/controllers/novacell_controller.go
+++ b/controllers/novacell_controller.go
@@ -149,7 +149,7 @@ func (r *NovaCellReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 		&instance.Status.Conditions,
 		r.RequeueTimeout,
 	)
-	if err != nil {
+	if (err != nil || result != ctrl.Result{}) {
 		return result, err
 	}
 

--- a/controllers/novacompute_controller.go
+++ b/controllers/novacompute_controller.go
@@ -162,7 +162,7 @@ func (r *NovaComputeReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		&instance.Status.Conditions,
 		r.RequeueTimeout,
 	)
-	if err != nil {
+	if (err != nil || result != ctrl.Result{}) {
 		return result, err
 	}
 

--- a/controllers/novaconductor_controller.go
+++ b/controllers/novaconductor_controller.go
@@ -186,7 +186,7 @@ func (r *NovaConductorReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		&instance.Status.Conditions,
 		r.RequeueTimeout,
 	)
-	if err != nil {
+	if (err != nil || result != ctrl.Result{}) {
 		return result, err
 	}
 

--- a/controllers/novametadata_controller.go
+++ b/controllers/novametadata_controller.go
@@ -183,7 +183,7 @@ func (r *NovaMetadataReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		&instance.Status.Conditions,
 		r.RequeueTimeout,
 	)
-	if err != nil {
+	if (err != nil || result != ctrl.Result{}) {
 		return result, err
 	}
 

--- a/controllers/novanovncproxy_controller.go
+++ b/controllers/novanovncproxy_controller.go
@@ -180,7 +180,7 @@ func (r *NovaNoVNCProxyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		&instance.Status.Conditions,
 		r.RequeueTimeout,
 	)
-	if err != nil {
+	if (err != nil || result != ctrl.Result{}) {
 		return result, err
 	}
 

--- a/controllers/novascheduler_controller.go
+++ b/controllers/novascheduler_controller.go
@@ -184,7 +184,7 @@ func (r *NovaSchedulerReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		&instance.Status.Conditions,
 		r.RequeueTimeout,
 	)
-	if err != nil {
+	if (err != nil || result != ctrl.Result{}) {
 		return result, err
 	}
 


### PR DESCRIPTION
Currently the reconciler returned both a non-zero result and a non-nil error.
The result will always be ignored if the error is non-nil and the non-nil error causes reqeueuing with exponential backoff.

In case of NotFound return nil that the ReqeueAfter is used.

For more details, see: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/reconcile#Reconciler