### PR TITLE
Replace operators-content-provider with meta content provider

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -13,7 +13,7 @@
     parent: cifmw-podified-multinode-edpm-base-crc
     abstract: true
     attempts: 1
-    dependencies: ["openstack-k8s-operators-content-provider"]
+    dependencies: ["openstack-meta-content-provider"]
     required-projects:
       - github.com/openstack-k8s-operators/ci-framework
       - github.com/openstack-k8s-operators/install_yamls
@@ -27,7 +27,7 @@
 - job:
     name: nova-operator-kuttl
     parent:  nova-operator-base
-    dependencies: ["openstack-k8s-operators-content-provider"]
+    dependencies: ["openstack-meta-content-provider"]
     roles:
       - zuul: github.com/openstack-k8s-operators/ci-framework
     description: |
@@ -75,7 +75,7 @@
 - job:
     name: nova-operator-tempest-multinode
     parent: podified-multinode-edpm-deployment-crc-3comp
-    dependencies: ["openstack-k8s-operators-content-provider"]
+    dependencies: ["openstack-meta-content-provider"]
     nodeset: centos-9-medium-3x-centos-9-crc-extracted-2-39-0-3xl
     post-run:
       - ci/nova-operator-base/playbooks/collect-logs.yaml
@@ -133,7 +133,7 @@
 - job:
     name: nova-operator-tempest-multinode-ceph
     parent: podified-multinode-hci-deployment-crc-3comp
-    dependencies: ["openstack-k8s-operators-content-provider"]
+    dependencies: ["openstack-meta-content-provider"]
     nodeset: centos-9-medium-3x-centos-9-crc-extracted-2-39-0-3xl
     # Note:  When inheriting from a job (or creating a variant of a job) vars are merged with previous definitions
     post-run:
@@ -206,7 +206,7 @@
     name: openstack-k8s-operators/nova-operator
     github-check:
       jobs:
-        - openstack-k8s-operators-content-provider
+        - openstack-meta-content-provider
         - nova-operator-kuttl
         - nova-operator-tempest-multinode
         - nova-operator-tempest-multinode-ceph


### PR DESCRIPTION
Meta content provider allows us to test opendev and github changes together. Let's use the same instead of operator content provider.

Related: [OSPRH-9231](https://issues.redhat.com//browse/OSPRH-9231)