### PR TITLE
ensure nova-operator is always required

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -234,12 +234,20 @@
       jobs:
         - openstack-meta-content-provider:
             override-checkout: main
+            # when run from nova we need to ensure we list the nova-operator
+            # so that it will be built by the meta content provider
+            required-projects:
+              - github.com/openstack-k8s-operators/nova-operator
             vars:
               cifmw_bop_openstack_release: master
               cifmw_bop_dlrn_baseurl: "https://trunk.rdoproject.org/centos9-master"
               cifmw_repo_setup_branch: master
         - nova-operator-tempest-multinode: &job_vars
             override-checkout: main
+            # when run from nova we need to ensure we list the nova-operator
+            # so that it will be built by the meta content provider
+            required-projects:
+              - github.com/openstack-k8s-operators/nova-operator
             vars:
               cifmw_repo_setup_branch: master
         - nova-operator-tempest-multinode-ceph: *job_vars


### PR DESCRIPTION
This change ensures that if we trigger a job without a chagne to the
nova operator repo via upstream nova that we include it as a
required project so that the meta content provider will include
the nova operator image.
