### PR TITLE
Make sure to log error in findObjectsForSrc()

### DIFF
--- a/controllers/nova_controller.go
+++ b/controllers/nova_controller.go
@@ -1922,7 +1922,8 @@ func (r *NovaReconciler) findObjectsForSrc(ctx context.Context, src client.Objec
 		}
 		err := r.Client.List(ctx, crList, listOps)
 		if err != nil {
-			return []reconcile.Request{}
+			l.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
+			return requests
 		}
 
 		for _, item := range crList.Items {

--- a/controllers/novaapi_controller.go
+++ b/controllers/novaapi_controller.go
@@ -856,7 +856,8 @@ func (r *NovaAPIReconciler) findObjectsForSrc(ctx context.Context, src client.Ob
 		}
 		err := r.Client.List(ctx, crList, listOps)
 		if err != nil {
-			return []reconcile.Request{}
+			l.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
+			return requests
 		}
 
 		for _, item := range crList.Items {

--- a/controllers/novacell_controller.go
+++ b/controllers/novacell_controller.go
@@ -861,7 +861,8 @@ func (r *NovaCellReconciler) findObjectsForSrc(ctx context.Context, src client.O
 		}
 		err := r.Client.List(ctx, crList, listOps)
 		if err != nil {
-			return []reconcile.Request{}
+			l.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
+			return requests
 		}
 
 		for _, item := range crList.Items {

--- a/controllers/novacompute_controller.go
+++ b/controllers/novacompute_controller.go
@@ -459,7 +459,8 @@ func (r *NovaComputeReconciler) findObjectsForSrc(ctx context.Context, src clien
 		}
 		err := r.Client.List(ctx, crList, listOps)
 		if err != nil {
-			return []reconcile.Request{}
+			l.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
+			return requests
 		}
 
 		for _, item := range crList.Items {

--- a/controllers/novaconductor_controller.go
+++ b/controllers/novaconductor_controller.go
@@ -646,7 +646,8 @@ func (r *NovaConductorReconciler) findObjectsForSrc(ctx context.Context, src cli
 		}
 		err := r.Client.List(ctx, crList, listOps)
 		if err != nil {
-			return []reconcile.Request{}
+			l.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
+			return requests
 		}
 
 		for _, item := range crList.Items {

--- a/controllers/novametadata_controller.go
+++ b/controllers/novametadata_controller.go
@@ -854,7 +854,8 @@ func (r *NovaMetadataReconciler) findObjectsForSrc(ctx context.Context, src clie
 		}
 		err := r.Client.List(ctx, crList, listOps)
 		if err != nil {
-			return []reconcile.Request{}
+			l.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
+			return requests
 		}
 
 		for _, item := range crList.Items {

--- a/controllers/novanovncproxy_controller.go
+++ b/controllers/novanovncproxy_controller.go
@@ -717,7 +717,8 @@ func (r *NovaNoVNCProxyReconciler) findObjectsForSrc(ctx context.Context, src cl
 		}
 		err := r.Client.List(ctx, crList, listOps)
 		if err != nil {
-			return []reconcile.Request{}
+			l.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
+			return requests
 		}
 
 		for _, item := range crList.Items {

--- a/controllers/novascheduler_controller.go
+++ b/controllers/novascheduler_controller.go
@@ -314,7 +314,8 @@ func (r *NovaSchedulerReconciler) findObjectsForSrc(ctx context.Context, src cli
 		}
 		err := r.Client.List(ctx, crList, listOps)
 		if err != nil {
-			return []reconcile.Request{}
+			l.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
+			return requests
 		}
 
 		for _, item := range crList.Items {


### PR DESCRIPTION
It is hidden right now if there is an error in configured named fields and index. Lets log the error and return the current state of requests.

With this the findObjectsForSrc() will exit with an hidden error like:

```
"error": "Index with name field:.spec.ksmTls.caBundleSecretName does not exist"
```