### PR TITLE
Kolla config cleanup

### DIFF
--- a/templates/nova-manage/config/cell-delete-config.json
+++ b/templates/nova-manage/config/cell-delete-config.json
@@ -14,13 +14,6 @@
             "perm": "0600"
         },
         {
-            "source": "/var/lib/openstack/config/02-nova-override.conf",
-            "dest": "/etc/nova/nova.conf.d/02-nova-override.conf",
-            "owner": "nova",
-            "perm": "0600",
-            "optional": true
-        },
-        {
             "source": "/var/lib/openstack/bin/delete_cell.sh",
             "dest": "/bin/",
             "owner": "nova",

--- a/templates/nova-manage/config/cell-mapping-config.json
+++ b/templates/nova-manage/config/cell-mapping-config.json
@@ -14,13 +14,6 @@
             "perm": "0600"
         },
         {
-            "source": "/var/lib/openstack/config/02-nova-override.conf",
-            "dest": "/etc/nova/nova.conf.d/02-nova-override.conf",
-            "owner": "nova",
-            "perm": "0600",
-            "optional": true
-        },
-        {
             "source": "/var/lib/openstack/bin/ensure_cell_mapping.sh",
             "dest": "/bin/",
             "owner": "nova",

--- a/templates/nova-manage/config/host-discover-config.json
+++ b/templates/nova-manage/config/host-discover-config.json
@@ -14,13 +14,6 @@
             "perm": "0600"
         },
         {
-            "source": "/var/lib/openstack/config/02-nova-override.conf",
-            "dest": "/etc/nova/nova.conf.d/02-nova-override.conf",
-            "owner": "nova",
-            "perm": "0600",
-            "optional": true
-        },
-        {
             "source": "/var/lib/openstack/bin/host_discover.sh",
             "dest": "/bin/",
             "owner": "nova",


### PR DESCRIPTION
The nova-cellx-manage-config-data secret does not have any config override added. So the jobs using this secret does not need a 02-nova-override.conf in their kolla config as that file will never be present.

Note that the cell level dbsync and dbpurge jobs get 02-nova-override.conf based on the customServiceConfig from the relevant NovaConductor CR, so there the kolla config is kept.