### PR TITLE
Default heal_instance_info_cache_interval=-1

### DIFF
--- a/templates/nova.conf
+++ b/templates/nova.conf
@@ -50,6 +50,7 @@ cert={{.SSLCertificateFile}}
 key={{.SSLCertificateKeyFile}}
 {{end}}
 {{end}}
+heal_instance_info_cache_interval=-1
 
 [oslo_concurrency]
 lock_path = /var/lib/nova/tmp


### PR DESCRIPTION
The supported networking backends expected to work without the periodic
healing of the cache in nova. So turning the periodic healing off can be
done to gain performance.

Resolves: [OSPRH-10744](https://issues.redhat.com//browse/OSPRH-10744)
