### PR TITLE
Added a parameter 'apiTimeout' to allow customization

### DIFF
--- a/api/bases/nova.openstack.org_nova.yaml
+++ b/api/bases/nova.openstack.org_nova.yaml
@@ -355,6 +355,11 @@ spec:
                         type: string
                     type: object
                 type: object
+              apiTimeout:
+                default: 60
+                description: APITimeout for Route and Apache
+                minimum: 10
+                type: integer
               cellTemplates:
                 additionalProperties:
                   description: NovaCellTemplate defines the input parameters specified

--- a/api/bases/nova.openstack.org_novaapis.yaml
+++ b/api/bases/nova.openstack.org_novaapis.yaml
@@ -57,6 +57,11 @@ spec:
                 description: APIDatabaseHostname - hostname to use when accessing
                   the API DB
                 type: string
+              apiTimeout:
+                default: 60
+                description: APITimeout for Route and Apache
+                minimum: 10
+                type: integer
               cell0DatabaseAccount:
                 default: nova-cell0
                 description: APIDatabaseAccount - MariaDBAccount to use when accessing

--- a/api/bases/nova.openstack.org_novacells.yaml
+++ b/api/bases/nova.openstack.org_novacells.yaml
@@ -46,6 +46,11 @@ spec:
                   filed is Required for cell0. TODO(gibi): Add a webhook to validate
                   cell0 constraint'
                 type: string
+              apiTimeout:
+                default: 60
+                description: APITimeout for Route and Apache
+                minimum: 10
+                type: integer
               cellDatabaseAccount:
                 default: nova
                 description: CellDatabaseAccount - MariaDBAccount to use when accessing

--- a/api/bases/nova.openstack.org_novametadata.yaml
+++ b/api/bases/nova.openstack.org_novametadata.yaml
@@ -58,6 +58,11 @@ spec:
                   the API DB. This filed is Required if the CellName is not provided
                   TODO(gibi): Add a webhook to validate the CellName constraint'
                 type: string
+              apiTimeout:
+                default: 60
+                description: APITimeout for Route and Apache
+                minimum: 10
+                type: integer
               cellDatabaseAccount:
                 default: nova
                 description: CellDatabaseAccount - MariaDBAccount to use when accessing

--- a/api/v1beta1/nova_types.go
+++ b/api/v1beta1/nova_types.go
@@ -66,6 +66,12 @@ type NovaSpecCore struct {
 	// APIDatabaseAccount - MariaDBAccount to use when accessing the API DB
 	APIDatabaseAccount string `json:"apiDatabaseAccount"`
 
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=60
+	// +kubebuilder:validation:Minimum=10
+	// APITimeout for Route and Apache
+	APITimeout int `json:"apiTimeout"`
+
 	// +kubebuilder:validation:Required
 	// Secret is the name of the Secret instance containing password
 	// information for nova like the keystone service password and DB passwords

--- a/api/v1beta1/novaapi_types.go
+++ b/api/v1beta1/novaapi_types.go
@@ -87,6 +87,12 @@ type NovaAPISpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=60
+	// +kubebuilder:validation:Minimum=10
+	// APITimeout for Route and Apache
+	APITimeout int `json:"apiTimeout"`
+
 	// +kubebuilder:validation:Required
 	// Secret is the name of the Secret instance containing password
 	// information for the nova-api service. This secret is expected to be

--- a/api/v1beta1/novacell_types.go
+++ b/api/v1beta1/novacell_types.go
@@ -107,6 +107,12 @@ type NovaCellSpec struct {
 	// the deployment.
 	CellName string `json:"cellName"`
 
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=60
+	// +kubebuilder:validation:Minimum=10
+	// APITimeout for Route and Apache
+	APITimeout int `json:"apiTimeout"`
+
 	// +kubebuilder:validation:Required
 	// Secret is the name of the Secret instance containing password
 	// information for the nova cell. This secret is expected to be

--- a/api/v1beta1/novametadata_types.go
+++ b/api/v1beta1/novametadata_types.go
@@ -103,6 +103,12 @@ type NovaMetadataSpec struct {
 	// If not provided then the metadata serving every cells in the deployment
 	CellName string `json:"cellName,omitempty"`
 
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=60
+	// +kubebuilder:validation:Minimum=10
+	// APITimeout for Route and Apache
+	APITimeout int `json:"apiTimeout"`
+
 	// +kubebuilder:validation:Required
 	// Secret is the name of the Secret instance containing password
 	// information for the nova-conductor service. This secret is expected to
@@ -265,6 +271,7 @@ func NewNovaMetadataSpec(
 		TLS:                    novaCell.MetadataServiceTemplate.TLS,
 		DefaultConfigOverwrite: novaCell.MetadataServiceTemplate.DefaultConfigOverwrite,
 		MemcachedInstance:      novaCell.MemcachedInstance,
+		APITimeout:             novaCell.APITimeout,
 	}
 
 	if metadataSpec.NodeSelector == nil {

--- a/config/crd/bases/nova.openstack.org_nova.yaml
+++ b/config/crd/bases/nova.openstack.org_nova.yaml
@@ -355,6 +355,11 @@ spec:
                         type: string
                     type: object
                 type: object
+              apiTimeout:
+                default: 60
+                description: APITimeout for Route and Apache
+                minimum: 10
+                type: integer
               cellTemplates:
                 additionalProperties:
                   description: NovaCellTemplate defines the input parameters specified

--- a/config/crd/bases/nova.openstack.org_novaapis.yaml
+++ b/config/crd/bases/nova.openstack.org_novaapis.yaml
@@ -57,6 +57,11 @@ spec:
                 description: APIDatabaseHostname - hostname to use when accessing
                   the API DB
                 type: string
+              apiTimeout:
+                default: 60
+                description: APITimeout for Route and Apache
+                minimum: 10
+                type: integer
               cell0DatabaseAccount:
                 default: nova-cell0
                 description: APIDatabaseAccount - MariaDBAccount to use when accessing

--- a/config/crd/bases/nova.openstack.org_novacells.yaml
+++ b/config/crd/bases/nova.openstack.org_novacells.yaml
@@ -46,6 +46,11 @@ spec:
                   filed is Required for cell0. TODO(gibi): Add a webhook to validate
                   cell0 constraint'
                 type: string
+              apiTimeout:
+                default: 60
+                description: APITimeout for Route and Apache
+                minimum: 10
+                type: integer
               cellDatabaseAccount:
                 default: nova
                 description: CellDatabaseAccount - MariaDBAccount to use when accessing

--- a/config/crd/bases/nova.openstack.org_novametadata.yaml
+++ b/config/crd/bases/nova.openstack.org_novametadata.yaml
@@ -58,6 +58,11 @@ spec:
                   the API DB. This filed is Required if the CellName is not provided
                   TODO(gibi): Add a webhook to validate the CellName constraint'
                 type: string
+              apiTimeout:
+                default: 60
+                description: APITimeout for Route and Apache
+                minimum: 10
+                type: integer
               cellDatabaseAccount:
                 default: nova
                 description: CellDatabaseAccount - MariaDBAccount to use when accessing

--- a/controllers/nova_controller.go
+++ b/controllers/nova_controller.go
@@ -1108,6 +1108,7 @@ func (r *NovaReconciler) ensureCell(
 		ServiceUser:     instance.Spec.ServiceUser,
 		KeystoneAuthURL: keystoneAuthURL,
 		ServiceAccount:  instance.RbacResourceName(),
+		APITimeout:      instance.Spec.APITimeout,
 		// The assumption is that the CA bundle for ironic compute in the cell
 		// and the conductor in the cell always the same as the NovaAPI
 		TLS:               instance.Spec.APIServiceTemplate.TLS.Ca,
@@ -1280,6 +1281,7 @@ func (r *NovaReconciler) ensureAPI(
 		TLS:                    instance.Spec.APIServiceTemplate.TLS,
 		DefaultConfigOverwrite: instance.Spec.APIServiceTemplate.DefaultConfigOverwrite,
 		MemcachedInstance:      getMemcachedInstance(instance, cell0Template),
+		APITimeout:             instance.Spec.APITimeout,
 	}
 	api := &novav1.NovaAPI{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1711,6 +1713,7 @@ func (r *NovaReconciler) ensureMetadata(
 		TLS:                    instance.Spec.MetadataServiceTemplate.TLS,
 		DefaultConfigOverwrite: instance.Spec.MetadataServiceTemplate.DefaultConfigOverwrite,
 		MemcachedInstance:      getMemcachedInstance(instance, cell0Template),
+		APITimeout:             instance.Spec.APITimeout,
 	}
 	metadata = &novav1.NovaMetadata{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/novaapi_controller.go
+++ b/controllers/novaapi_controller.go
@@ -487,6 +487,7 @@ func (r *NovaAPIReconciler) generateConfigs(
 		endptConfig := map[string]interface{}{}
 		endptConfig["ServerName"] = fmt.Sprintf("nova-%s.%s.svc", endpt.String(), instance.Namespace)
 		endptConfig["tls"] = false // default TLS to false, and set it bellow to true if enabled
+		endptConfig["TimeOut"] = instance.Spec.APITimeout
 		if instance.Spec.TLS.API.Enabled(endpt) {
 			templateParameters["tls"] = true
 			endptConfig["tls"] = true
@@ -494,6 +495,7 @@ func (r *NovaAPIReconciler) generateConfigs(
 			endptConfig["SSLCertificateKeyFile"] = fmt.Sprintf("/etc/pki/tls/private/%s.key", endpt.String())
 		}
 		httpdVhostConfig[endpt.String()] = endptConfig
+
 	}
 	templateParameters["VHosts"] = httpdVhostConfig
 

--- a/controllers/novametadata_controller.go
+++ b/controllers/novametadata_controller.go
@@ -476,6 +476,7 @@ func (r *NovaMetadataReconciler) generateConfigs(
 		"MemcachedServers":         memcachedInstance.GetMemcachedServerListString(),
 		"MemcachedServersWithInet": memcachedInstance.GetMemcachedServerListWithInetString(),
 		"MemcachedTLS":             memcachedInstance.GetMemcachedTLSSupport(),
+		"TimeOut":                  instance.Spec.APITimeout,
 	}
 
 	var db *mariadbv1.Database

--- a/templates/novaapi/config/httpd.conf
+++ b/templates/novaapi/config/httpd.conf
@@ -38,6 +38,7 @@ LogLevel info
   SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
 
   ServerName {{ $vhost.ServerName }}
+  TimeOut {{ $vhost.TimeOut }}
 
   ## Vhost docroot
   DocumentRoot "/var/www/cgi-bin"

--- a/templates/novametadata/config/httpd.conf
+++ b/templates/novametadata/config/httpd.conf
@@ -36,6 +36,7 @@ LogLevel info
   SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
 
   ServerName {{ .ServerName }}
+  TimeOut {{ .TimeOut }}
 
   ErrorLog /dev/stdout
   CustomLog /dev/stdout combined env=!forwarded

--- a/test/functional/nova_metadata_controller_test.go
+++ b/test/functional/nova_metadata_controller_test.go
@@ -985,6 +985,8 @@ var _ = Describe("NovaMetadata controller", func() {
 			Expect(configData).Should(ContainSubstring("SSLEngine on"))
 			Expect(configData).Should(ContainSubstring("SSLCertificateFile      \"/etc/pki/tls/certs/nova-metadata.crt\""))
 			Expect(configData).Should(ContainSubstring("SSLCertificateKeyFile   \"/etc/pki/tls/private/nova-metadata.key\""))
+			Expect(configData).Should(
+				ContainSubstring("TimeOut 60"))
 
 			configData = string(configDataMap.Data["01-nova.conf"])
 			Expect(configData).Should(

--- a/test/functional/nova_multicell_test.go
+++ b/test/functional/nova_multicell_test.go
@@ -949,6 +949,14 @@ var _ = Describe("Nova multi cell", func() {
 				HaveKeyWithValue(controllers.MetadataSecretSelector, []byte("metadata-secret")))
 			Expect(cell0Secret.Data).NotTo(
 				HaveKeyWithValue(controllers.MetadataSecretSelector, []byte("metadata-secret-cell1")))
+			configDataMap := th.GetSecret(cell1.MetadataConfigDataName)
+			Expect(configDataMap).ShouldNot(BeNil())
+			Expect(configDataMap.Data).Should(HaveKey("httpd.conf"))
+			Expect(configDataMap.Data).Should(HaveKey("ssl.conf"))
+			configData := string(configDataMap.Data["httpd.conf"])
+			Expect(configData).Should(
+				ContainSubstring("TimeOut 60"))
+
 		})
 	})
 })

--- a/test/functional/novaapi_controller_test.go
+++ b/test/functional/novaapi_controller_test.go
@@ -1037,6 +1037,8 @@ var _ = Describe("NovaAPI controller", func() {
 			Expect(configData).Should(ContainSubstring("SSLCertificateKeyFile   \"/etc/pki/tls/private/internal.key\""))
 			Expect(configData).Should(ContainSubstring("SSLCertificateFile      \"/etc/pki/tls/certs/public.crt\""))
 			Expect(configData).Should(ContainSubstring("SSLCertificateKeyFile   \"/etc/pki/tls/private/public.key\""))
+			Expect(configData).Should(
+				ContainSubstring("TimeOut 60"))
 
 			configData = string(configDataMap.Data["01-nova.conf"])
 			Expect(configData).Should(


### PR DESCRIPTION
Added a parameter 'apiTimeout' to allow customization to the Apache timeout.
The default is set to 120s which we do set for
HAProxy timeouts currently.

To be able to change the HAProxy value based on the apiTimeout with any update (and not just the first time) the code adds a custom annotation "api.neutron.openstack.org/timeout" with the value that was initially set, this way flags it as being set by the nova-operator.

Timeout is global for both api and metadata and they are set from nova lvl

There will be follow up patch in openstack-operator to utilize the method 'SetDefaultRouteAnnotations' to set these default route annotations in openstack-operator

Resolve: https://issues.redhat.com/browse/OSPRH-10955