### PR TITLE
[renovate]Enable bumps on 18.0-fr1

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "extends": [
     "github>openstack-k8s-operators/renovate-config:default.json5"
   ],
-  "baseBranches": ["main"],
+  "baseBranches": ["main", "18.0-fr1"],
   "useBaseBranchConfig": "merge",
   "packageRules": [
     {


### PR DESCRIPTION
This enables renovate run on 18.0-fr1 branch. Please note that we have a special config for 18.0-fr1 enabled in #509

Related: [OSPRH-8355](https://issues.redhat.com//browse/OSPRH-8355)