### PR TITLE
Fix default cache config for no tls

### DIFF
--- a/templates/nova.conf
+++ b/templates/nova.conf
@@ -172,10 +172,11 @@ enabled = True
 # on contoler we prefer to use memcache when its deployed
 {{if .MemcachedTLS}}
 backend = dogpile.cache.pymemcache
+memcache_servers={{ .MemcachedServers }}
 {{else}}
 backend = dogpile.cache.memcached
+memcache_servers={{ .MemcachedServersWithInet }}
 {{end}}
-memcache_servers={{ .MemcachedServers }}
 tls_enabled={{ .MemcachedTLS }}
 {{else}}
 # on compute nodes or where memcache is not deployed we should use an in memory

--- a/test/functional/nova_metadata_controller_test.go
+++ b/test/functional/nova_metadata_controller_test.go
@@ -219,16 +219,12 @@ var _ = Describe("NovaMetadata controller", func() {
 				Expect(configData).Should(ContainSubstring("dhcp_domain = ''"))
 				Expect(configData).Should(
 					ContainSubstring("[upgrade_levels]\ncompute = auto"))
+				memcacheInstance := infra.GetMemcached(novaNames.MemcachedNamespace)
 				Expect(configData).Should(
 					ContainSubstring("backend = dogpile.cache.memcached"))
 				Expect(configData).Should(
-					ContainSubstring(fmt.Sprintf("memcache_servers=memcached-0.memcached.%s.svc:11211,memcached-1.memcached.%s.svc:11211,memcached-2.memcached.%s.svc:11211",
-						novaNames.Namespace, novaNames.Namespace, novaNames.Namespace)))
-				Expect(configData).Should(
-					ContainSubstring(fmt.Sprintf("memcached_servers=inet:[memcached-0.memcached.%s.svc]:11211,inet:[memcached-1.memcached.%s.svc]:11211,inet:[memcached-2.memcached.%s.svc]:11211",
-						novaNames.Namespace, novaNames.Namespace, novaNames.Namespace)))
-				Expect(configData).Should(
-					ContainSubstring("tls_enabled=false"))
+					ContainSubstring(fmt.Sprintf("memcache_servers=%s", memcacheInstance.GetMemcachedServerListWithInetString())))
+				ContainSubstring("tls_enabled=false")
 				Expect(configDataMap.Data).Should(HaveKey("02-nova-override.conf"))
 				myCnf := configDataMap.Data["my.cnf"]
 				Expect(myCnf).To(

--- a/test/functional/nova_multicell_test.go
+++ b/test/functional/nova_multicell_test.go
@@ -246,7 +246,7 @@ var _ = Describe("Nova multi cell", func() {
 						apiAccount.Spec.UserName, apiSecret.Data[mariadbv1.DatabasePasswordSelector],
 						novaNames.APIMariaDBDatabaseName.Name, novaNames.Namespace)),
 			)
-			Expect(configData).Should(
+			Expect(configData).ShouldNot(
 				ContainSubstring(fmt.Sprintf("memcache_servers=memcached-0.memcached.%s.svc:11211,memcached-1.memcached.%s.svc:11211,memcached-2.memcached.%s.svc:11211",
 					novaNames.Namespace, novaNames.Namespace, novaNames.Namespace)))
 			Expect(configData).Should(
@@ -373,7 +373,7 @@ var _ = Describe("Nova multi cell", func() {
 			)
 
 			Expect(configData).To(ContainSubstring("transport_url=rabbit://cell1/fake"))
-			Expect(configData).Should(
+			Expect(configData).ShouldNot(
 				ContainSubstring(fmt.Sprintf("memcache_servers=memcached1-0.memcached1.%s.svc:11211,memcached1-1.memcached1.%s.svc:11211,memcached1-2.memcached1.%s.svc:11211",
 					novaNames.Namespace, novaNames.Namespace, novaNames.Namespace)))
 			Expect(configData).Should(

--- a/test/functional/nova_novncproxy_test.go
+++ b/test/functional/nova_novncproxy_test.go
@@ -197,9 +197,11 @@ var _ = Describe("NovaNoVNCProxy controller", func() {
 				Expect(configData).Should(ContainSubstring("password = service-password"))
 				Expect(configData).Should(
 					ContainSubstring("backend = dogpile.cache.memcached"))
+				memcacheInstance := infra.GetMemcached(novaNames.MemcachedNamespace)
 				Expect(configData).Should(
-					ContainSubstring(fmt.Sprintf("memcache_servers=memcached-0.memcached.%s.svc:11211,memcached-1.memcached.%s.svc:11211,memcached-2.memcached.%s.svc:11211",
-						novaNames.Namespace, novaNames.Namespace, novaNames.Namespace)))
+					ContainSubstring("backend = dogpile.cache.memcached"))
+				Expect(configData).Should(
+					ContainSubstring(fmt.Sprintf("memcache_servers=%s", memcacheInstance.GetMemcachedServerListWithInetString())))
 				Expect(configData).Should(
 					ContainSubstring(fmt.Sprintf("memcached_servers=inet:[memcached-0.memcached.%s.svc]:11211,inet:[memcached-1.memcached.%s.svc]:11211,inet:[memcached-2.memcached.%s.svc]:11211",
 						novaNames.Namespace, novaNames.Namespace, novaNames.Namespace)))

--- a/test/functional/nova_reconfiguration_test.go
+++ b/test/functional/nova_reconfiguration_test.go
@@ -780,7 +780,7 @@ var _ = Describe("Nova reconfiguration", func() {
 		Expect(configDataMap).ShouldNot(BeNil())
 		Expect(configDataMap.Data).Should(HaveKey("01-nova.conf"))
 		configData := string(configDataMap.Data["01-nova.conf"])
-		Expect(configData).Should(
+		Expect(configData).ShouldNot(
 			ContainSubstring(fmt.Sprintf("memcache_servers=memcached-0.memcached.%s.svc:11211,memcached-1.memcached.%s.svc:11211,memcached-2.memcached.%s.svc:11211",
 				novaNames.Namespace, novaNames.Namespace, novaNames.Namespace)))
 		Expect(configData).Should(
@@ -801,7 +801,7 @@ var _ = Describe("Nova reconfiguration", func() {
 			g.Expect(configDataMap).ShouldNot(BeNil())
 			g.Expect(configDataMap.Data).Should(HaveKey("01-nova.conf"))
 			configData = string(configDataMap.Data["01-nova.conf"])
-			g.Expect(configData).To(ContainSubstring("memcache_servers=new"))
+			g.Expect(configData).ToNot(ContainSubstring("memcache_servers=new"))
 			g.Expect(configData).To(ContainSubstring("memcached_servers=inet_new"))
 		}, timeout, interval).Should(Succeed())
 	})

--- a/test/functional/nova_scheduler_test.go
+++ b/test/functional/nova_scheduler_test.go
@@ -198,14 +198,11 @@ var _ = Describe("NovaScheduler controller", func() {
 			configData := string(configDataMap.Data["01-nova.conf"])
 			Expect(configData).To(ContainSubstring("transport_url=rabbit://api/fake"))
 			Expect(configData).To(ContainSubstring("password = service-password"))
+			memcacheInstance := infra.GetMemcached(novaNames.MemcachedNamespace)
 			Expect(configData).Should(
 				ContainSubstring("backend = dogpile.cache.memcached"))
 			Expect(configData).Should(
-				ContainSubstring(fmt.Sprintf("memcache_servers=memcached-0.memcached.%s.svc:11211,memcached-1.memcached.%s.svc:11211,memcached-2.memcached.%s.svc:11211",
-					novaNames.Namespace, novaNames.Namespace, novaNames.Namespace)))
-			Expect(configData).Should(
-				ContainSubstring(fmt.Sprintf("memcached_servers=inet:[memcached-0.memcached.%s.svc]:11211,inet:[memcached-1.memcached.%s.svc]:11211,inet:[memcached-2.memcached.%s.svc]:11211",
-					novaNames.Namespace, novaNames.Namespace, novaNames.Namespace)))
+				ContainSubstring(fmt.Sprintf("memcache_servers=%s", memcacheInstance.GetMemcachedServerListWithInetString())))
 			Expect(configData).Should(
 				ContainSubstring("tls_enabled=false"))
 			Expect(configData).Should(

--- a/test/functional/novaapi_controller_test.go
+++ b/test/functional/novaapi_controller_test.go
@@ -214,11 +214,11 @@ var _ = Describe("NovaAPI controller", func() {
 				Expect(configData).Should(ContainSubstring("www_authenticate_uri = keystone-public-auth-url"))
 				Expect(configData).Should(
 					ContainSubstring("[upgrade_levels]\ncompute = auto"))
+				memcacheInstance := infra.GetMemcached(novaNames.MemcachedNamespace)
 				Expect(configData).Should(
 					ContainSubstring("backend = dogpile.cache.memcached"))
 				Expect(configData).Should(
-					ContainSubstring(fmt.Sprintf("memcache_servers=memcached-0.memcached.%s.svc:11211,memcached-1.memcached.%s.svc:11211,memcached-2.memcached.%s.svc:11211",
-						novaNames.Namespace, novaNames.Namespace, novaNames.Namespace)))
+					ContainSubstring(fmt.Sprintf("memcache_servers=%s", memcacheInstance.GetMemcachedServerListWithInetString())))
 				Expect(configData).Should(
 					ContainSubstring(fmt.Sprintf("memcached_servers=inet:[memcached-0.memcached.%s.svc]:11211,inet:[memcached-1.memcached.%s.svc]:11211,inet:[memcached-2.memcached.%s.svc]:11211",
 						novaNames.Namespace, novaNames.Namespace, novaNames.Namespace)))

--- a/test/functional/novaconductor_controller_test.go
+++ b/test/functional/novaconductor_controller_test.go
@@ -205,7 +205,7 @@ var _ = Describe("NovaConductor controller", func() {
 					ContainSubstring("[upgrade_levels]\ncompute = auto"))
 				Expect(configData).Should(
 					ContainSubstring("backend = dogpile.cache.memcached"))
-				Expect(configData).Should(
+				Expect(configData).ShouldNot(
 					ContainSubstring(fmt.Sprintf("memcache_servers=memcached-0.memcached.%s.svc:11211,memcached-1.memcached.%s.svc:11211,memcached-2.memcached.%s.svc:11211",
 						novaNames.Namespace, novaNames.Namespace, novaNames.Namespace)))
 				Expect(configData).Should(


### PR DESCRIPTION
When env is deployed with tls disabled, cache config was wrong as "dogpile.cache.memcached" backend requires inet[6] prefixes for memcache_servers setting while it was set without the prefix. with IPv4 issue not observed as "inet" is default prefix, this patch fixes it by setting [cache]/memcache_servers based on tls config.

Resolves: [OSPRH-12224](https://issues.redhat.com//browse/OSPRH-12224)
Related-Issue: [OSPRH-12221](https://issues.redhat.com//browse/OSPRH-12221)