### PR TITLE
Add endpoint_id to [oslo_limit] config

### DIFF
--- a/controllers/novaapi_controller.go
+++ b/controllers/novaapi_controller.go
@@ -499,6 +499,7 @@ func (r *NovaAPIReconciler) generateConfigs(
 		"MemcachedServers":           memcachedInstance.GetMemcachedServerListString(),
 		"MemcachedServersWithInet":   memcachedInstance.GetMemcachedServerListWithInetString(),
 		"MemcachedTLS":               memcachedInstance.GetMemcachedTLSSupport(),
+		"nova_endpoint_id":           r.getNovaEndpointID(ctx, h, instance.Namespace),
 	}
 	// create httpd  vhost template parameters
 	httpdVhostConfig := map[string]interface{}{}

--- a/controllers/novaconductor_controller.go
+++ b/controllers/novaconductor_controller.go
@@ -449,6 +449,7 @@ func (r *NovaConductorReconciler) generateConfigs(
 		"MemcachedServers":           memcachedInstance.GetMemcachedServerListString(),
 		"MemcachedServersWithInet":   memcachedInstance.GetMemcachedServerListWithInetString(),
 		"MemcachedTLS":               memcachedInstance.GetMemcachedTLSSupport(),
+		"nova_endpoint_id":           r.getNovaEndpointID(ctx, h, instance.Namespace),
 	}
 	if len(instance.Spec.APIDatabaseHostname) > 0 {
 		apiDatabaseAccount, apiDbSecret, err := mariadbv1.GetAccountAndSecret(ctx, h, instance.Spec.APIDatabaseAccount, instance.Namespace)

--- a/templates/nova.conf
+++ b/templates/nova.conf
@@ -331,6 +331,7 @@ project_name = service
 username = {{ .nova_keystone_user }}
 password = {{ .nova_keystone_password }}
 
+{{ if eq .service_name "nova-api" "nova-conductor" }}
 [oslo_limit]
 system_scope = all
 endpoint_interface = internal
@@ -341,6 +342,10 @@ auth_type = password
 user_domain_name = {{ .default_user_domain}}
 username = {{ .nova_keystone_user }}
 password = {{ .nova_keystone_password }}
+{{ if (index . "nova_endpoint_id") }}
+endpoint_id = {{ .nova_endpoint_id }}
+{{ end }}
+{{ end }}
 
 {{ if (index . "compute_driver") }}
 {{if eq .compute_driver "ironic.IronicDriver"}}


### PR DESCRIPTION
This builds on https://github.com/openstack-k8s-operators/nova-operator/pull/920 to query for the Nova endpoint ID and add it to the
[oslo_limit] config for the nova-api and nova-conductor services.

Related: [OSPRH-9518](https://issues.redhat.com//browse/OSPRH-9518)