### PR TITLE
fix impled brances on fr1

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -177,19 +177,13 @@
 
 - project:
     name: openstack-k8s-operators/nova-operator
-    default-branch: main
+    default-branch: 18.0-fr1
     github-check:
       jobs:
         - openstack-meta-content-provider
         - nova-operator-kuttl
         - nova-operator-tempest-multinode
         - nova-operator-tempest-multinode-ceph
-
-- pragma:
-    implied-branch-matchers: True
-    implied-branches:
-      - main
-      - master
 
 ##########################################################
 #                                                        #


### PR DESCRIPTION
this change fixes the default branch on fr-1 and removes the implied branch
pragma which was incorrectly exposing the fr-1 variant of jobs to patches on main