### PR TITLE
Improve build and use of crd-schema-checker

### DIFF
--- a/hack/build-crd-schema-checker.sh
+++ b/hack/build-crd-schema-checker.sh
@@ -4,12 +4,18 @@ set -euxo pipefail
 if [ -f "$INSTALL_DIR/crd-schema-checker" ]; then
     exit 0
 fi
+if [ -f ~/crd-schema-checker ]; then
+    cp ~/crd-schema-checker "$INSTALL_DIR/"
+    exit
+fi
 
 mkdir -p "$INSTALL_DIR/git-tmp"
 git clone https://github.com/openshift/crd-schema-checker.git \
-    -b "$CRD_SCHEMA_CHECKER_VERSION" "$INSTALL_DIR/git-tmp"
+    -b "$CRD_SCHEMA_CHECKER_VERSION" "$INSTALL_DIR/git-tmp" || true
 pushd "$INSTALL_DIR/git-tmp"
+grep -q 'SHELL=/bin/bash' Makefile || sed -i '1 i\SHELL=/bin/bash' Makefile
 GOWORK=off make
+cp crd-schema-checker ~/
 cp crd-schema-checker "$INSTALL_DIR/"
 popd
 rm -rf "$INSTALL_DIR/git-tmp"


### PR DESCRIPTION
When bin directory removed, crd schema checker go build triggers again, which takes extra time.

Save a copy of a built tool into the user home dir to use it afterwards Also do not clone the repo if it is already there.

Fix SHELL for GNU make to use /bin/bash, when building the tool. Otherwise, the make binary uses /bin/sh, and fails to set -o pipefile.