### PR TITLE
[DNM] Osprh 14486 impl

### DIFF
--- a/api/bases/nova.openstack.org_nova.yaml
+++ b/api/bases/nova.openstack.org_nova.yaml
@@ -1136,6 +1136,17 @@ spec:
                       description: NodeSelector to target subset of worker nodes running
                         cell.
                       type: object
+                    notificationsBusInstance:
+                      default: ""
+                      description: |-
+                        NotificationsBusInstance is the name of the RabbitMqCluster CR to select
+                        the Message Bus Service instance used by the nova cell services to publish notifications.
+                        An empty value inherits the top scope notification driver configuration for a cell.
+                        Avoid colocating it with APIMessageBusInstance or CellMessageBusInstance used for PRC.
+                        Overriding a top scope NotificationsBusInstance for cells implies that consumers of
+                        notifications can maintain simultanous AMQP connections via multiple transport_url endpoints.
+                        Notifications cannot be disabled for a particular cell, it is all or nothing.
+                      type: string
                     novaComputeTemplates:
                       additionalProperties:
                         description: |-
@@ -1624,6 +1635,17 @@ spec:
                   NodeSelector here acts as a default value and can be overridden by service
                   specific NodeSelector Settings.
                 type: object
+              notificationsBusInstance:
+                default: ""
+                description: |-
+                  NotificationsBusInstance is the name of the RabbitMqCluster CR to select
+                  the Message Bus Service instance used by the Nova top level services and all cells to publish notifications.
+                  An empty value leaves the notification drivers unconfigured and emitting no notifications at all.
+                  Avoid colocating it with APIMessageBusInstance or CellMessageBusInstance used for PRC.
+                  Overriding it with NotificationsBusInstance for cells implies that consumers of notifications
+                  can maintain simultanous AMQP connections via multiple transport_url endpoints.
+                  Notifications cannot be disabled for a particular cell, it is all or nothing.
+                type: string
               novncproxyContainerImageURL:
                 description: NoVNCContainerImageURL
                 type: string

--- a/api/v1beta1/conditions.go
+++ b/api/v1beta1/conditions.go
@@ -36,6 +36,8 @@ const (
 	NovaAllCellsReadyCondition condition.Type = "NovaAllCellReady"
 	// NovaAPIMQReadyCondition indicated that the top level message bus is ready
 	NovaAPIMQReadyCondition condition.Type = "NovaAPIMQReady"
+	// NovaNotificationsMQReadyCondition indicated that the top level notifications message bus is ready (it is also used by cells services)
+	NovaNotificationsMQReadyCondition condition.Type = "NovaNotificationsMQReady"
 	// NovaAllCellsMQReadyCondition indicates that the message bus for each
 	// configured Cell is created successfully
 	NovaAllCellsMQReadyCondition condition.Type = "NovaAllCellsMQReady"
@@ -98,14 +100,26 @@ const (
 	// NovaAPIMQReadyInitMessage
 	NovaAPIMQReadyInitMessage = "API message bus not started"
 
+	// NovaNotificationsReadyInitMessage
+	NovaNotificationsReadyInitMessage = "Notifications message bus not started"
+
 	// NovaAPIMQReadyErrorMessage
 	NovaAPIMQReadyErrorMessage = "API message bus creation failed: %s"
+
+	// NovaNotificationsReadyErrorMessage
+	NovaNotificationsReadyErrorMessage = "Notifications message bus creation failed: %s"
 
 	// NovaAPIMQReadyMessage
 	NovaAPIMQReadyMessage = "API message bus creation successfully"
 
+	// NovaNotificationsReadyMessage
+	NovaNotificationsReadyMessage = "Notifications message bus creation successfully"
+
 	// NovaAPIMQReadyCreatingMessage
 	NovaAPIMQReadyCreatingMessage = "API message bus creation ongoing"
+
+	// NovaNotificationsReadyCreatingMessage
+	NovaNotificationsReadyCreatingMessage = "Notifications message bus creation ongoing"
 
 	// NovaAllCellsMQReadyInitMessage
 	NovaAllCellsMQReadyInitMessage = "Message bus creation not started"

--- a/api/v1beta1/nova_types.go
+++ b/api/v1beta1/nova_types.go
@@ -17,9 +17,9 @@ limitations under the License.
 package v1beta1
 
 import (
+	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -48,6 +48,17 @@ type NovaSpecCore struct {
 	// the Message Bus Service instance used by the Nova top level services to
 	// communicate.
 	APIMessageBusInstance string `json:"apiMessageBusInstance"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=""
+	// NotificationsBusInstance is the name of the RabbitMqCluster CR to select
+	// the Message Bus Service instance used by the Nova top level services and all cells to publish notifications.
+	// An empty value leaves the notification drivers unconfigured and emitting no notifications at all.
+	// Avoid colocating it with APIMessageBusInstance or CellMessageBusInstance used for PRC.
+	// Overriding it with NotificationsBusInstance for cells implies that consumers of notifications
+	// can maintain simultanous AMQP connections via multiple transport_url endpoints.
+	// Notifications cannot be disabled for a particular cell, it is all or nothing.
+	NotificationsBusInstance string `json:"notificationsBusInstance"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default={cell0: {cellDatabaseAccount: nova-cell0, hasAPIAccess: true}, cell1: {cellDatabaseAccount: nova-cell1, cellDatabaseInstance: openstack-cell1, cellMessageBusInstance: rabbitmq-cell1, hasAPIAccess: true}}

--- a/api/v1beta1/novacell_types.go
+++ b/api/v1beta1/novacell_types.go
@@ -17,10 +17,10 @@ limitations under the License.
 package v1beta1
 
 import (
+	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/tls"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -50,6 +50,17 @@ type NovaCellTemplate struct {
 	// the Message Bus Service instance used by the nova services to
 	// communicate in this cell. For cell0 it is unused.
 	CellMessageBusInstance string `json:"cellMessageBusInstance"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=""
+	// NotificationsBusInstance is the name of the RabbitMqCluster CR to select
+	// the Message Bus Service instance used by the nova cell services to publish notifications.
+	// An empty value inherits the top scope notification driver configuration for a cell.
+	// Avoid colocating it with APIMessageBusInstance or CellMessageBusInstance used for PRC.
+	// Overriding a top scope NotificationsBusInstance for cells implies that consumers of
+	// notifications can maintain simultanous AMQP connections via multiple transport_url endpoints.
+	// Notifications cannot be disabled for a particular cell, it is all or nothing.
+	NotificationsBusInstance string `json:"notificationsBusInstance"`
 
 	// +kubebuilder:validation:Required
 	// HasAPIAccess defines if this Cell is configured to have access to the

--- a/config/crd/bases/nova.openstack.org_nova.yaml
+++ b/config/crd/bases/nova.openstack.org_nova.yaml
@@ -1136,6 +1136,17 @@ spec:
                       description: NodeSelector to target subset of worker nodes running
                         cell.
                       type: object
+                    notificationsBusInstance:
+                      default: ""
+                      description: |-
+                        NotificationsBusInstance is the name of the RabbitMqCluster CR to select
+                        the Message Bus Service instance used by the nova cell services to publish notifications.
+                        An empty value inherits the top scope notification driver configuration for a cell.
+                        Avoid colocating it with APIMessageBusInstance or CellMessageBusInstance used for PRC.
+                        Overriding a top scope NotificationsBusInstance for cells implies that consumers of
+                        notifications can maintain simultanous AMQP connections via multiple transport_url endpoints.
+                        Notifications cannot be disabled for a particular cell, it is all or nothing.
+                      type: string
                     novaComputeTemplates:
                       additionalProperties:
                         description: |-
@@ -1624,6 +1635,17 @@ spec:
                   NodeSelector here acts as a default value and can be overridden by service
                   specific NodeSelector Settings.
                 type: object
+              notificationsBusInstance:
+                default: ""
+                description: |-
+                  NotificationsBusInstance is the name of the RabbitMqCluster CR to select
+                  the Message Bus Service instance used by the Nova top level services and all cells to publish notifications.
+                  An empty value leaves the notification drivers unconfigured and emitting no notifications at all.
+                  Avoid colocating it with APIMessageBusInstance or CellMessageBusInstance used for PRC.
+                  Overriding it with NotificationsBusInstance for cells implies that consumers of notifications
+                  can maintain simultanous AMQP connections via multiple transport_url endpoints.
+                  Notifications cannot be disabled for a particular cell, it is all or nothing.
+                type: string
               novncproxyContainerImageURL:
                 description: NoVNCContainerImageURL
                 type: string

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -95,6 +95,9 @@ const (
 	// TransportURLSelector is the name of key in the internal cell
 	// Secret for the cell message bus transport URL
 	TransportURLSelector = "transport_url"
+	// NotificationsTransportURLSelector is the name of key in the internal cell
+	// Secret for the cell notifications bus transport URL
+	NotificationsTransportURLSelector = "notifications_transport_url"
 
 	// fields to index to reconcile when change
 	passwordSecretField        = ".spec.secret"

--- a/controllers/novaapi_controller.go
+++ b/controllers/novaapi_controller.go
@@ -468,28 +468,30 @@ func (r *NovaAPIReconciler) generateConfigs(
 		"keystone_internal_url": instance.Spec.KeystoneAuthURL,
 		// NOTE(gibi): As per the definition of www_authenticate_uri this
 		// always needs to point to the public keystone endpoint.
-		"www_authenticate_uri":     instance.Spec.KeystonePublicAuthURL,
-		"nova_keystone_user":       instance.Spec.ServiceUser,
-		"nova_keystone_password":   string(secret.Data[ServicePasswordSelector]),
-		"api_db_name":              NovaAPIDatabaseName,
-		"api_db_user":              apiDatabaseAccount.Spec.UserName,
-		"api_db_password":          string(apiDbSecret.Data[mariadbv1.DatabasePasswordSelector]),
-		"api_db_address":           instance.Spec.APIDatabaseHostname,
-		"api_db_port":              3306,
-		"cell_db_name":             NovaCell0DatabaseName,
-		"cell_db_user":             cellDatabaseAccount.Spec.UserName,
-		"cell_db_password":         string(cellDbSecret.Data[mariadbv1.DatabasePasswordSelector]),
-		"cell_db_address":          instance.Spec.Cell0DatabaseHostname,
-		"cell_db_port":             3306,
-		"openstack_region_name":    "regionOne", // fixme
-		"default_project_domain":   "Default",   // fixme
-		"default_user_domain":      "Default",   // fixme
-		"transport_url":            string(secret.Data[TransportURLSelector]),
-		"log_file":                 "/var/log/nova/nova-api.log",
-		"tls":                      false,
-		"MemcachedServers":         memcachedInstance.GetMemcachedServerListString(),
-		"MemcachedServersWithInet": memcachedInstance.GetMemcachedServerListWithInetString(),
-		"MemcachedTLS":             memcachedInstance.GetMemcachedTLSSupport(),
+		"www_authenticate_uri":           instance.Spec.KeystonePublicAuthURL,
+		"nova_keystone_user":             instance.Spec.ServiceUser,
+		"nova_keystone_password":         string(secret.Data[ServicePasswordSelector]),
+		"api_db_name":                    NovaAPIDatabaseName,
+		"api_db_user":                    apiDatabaseAccount.Spec.UserName,
+		"api_db_password":                string(apiDbSecret.Data[mariadbv1.DatabasePasswordSelector]),
+		"api_db_address":                 instance.Spec.APIDatabaseHostname,
+		"api_db_port":                    3306,
+		"cell_db_name":                   NovaCell0DatabaseName,
+		"cell_db_user":                   cellDatabaseAccount.Spec.UserName,
+		"cell_db_password":               string(cellDbSecret.Data[mariadbv1.DatabasePasswordSelector]),
+		"cell_db_address":                instance.Spec.Cell0DatabaseHostname,
+		"cell_db_port":                   3306,
+		"openstack_region_name":          "regionOne", // fixme
+		"default_project_domain":         "Default",   // fixme
+		"default_user_domain":            "Default",   // fixme
+		"transport_url":                  string(secret.Data[TransportURLSelector]),
+		"nova_cell_notify_transport_url": string(secret.Data[NotificationsTransportURLSelector]),
+		"nova_enabled_notification":      nil, // false if instance.spec.NotificationsBusInstance == "", or true
+		"log_file":                       "/var/log/nova/nova-api.log",
+		"tls":                            false,
+		"MemcachedServers":               memcachedInstance.GetMemcachedServerListString(),
+		"MemcachedServersWithInet":       memcachedInstance.GetMemcachedServerListWithInetString(),
+		"MemcachedTLS":                   memcachedInstance.GetMemcachedTLSSupport(),
 	}
 	// create httpd  vhost template parameters
 	httpdVhostConfig := map[string]interface{}{}

--- a/controllers/novacell_controller.go
+++ b/controllers/novacell_controller.go
@@ -762,15 +762,17 @@ func (r *NovaCellReconciler) generateComputeConfigs(
 	secret corev1.Secret, vncProxyURL *string,
 ) error {
 	templateParameters := map[string]interface{}{
-		"service_name":           "nova-compute",
-		"keystone_internal_url":  instance.Spec.KeystoneAuthURL,
-		"nova_keystone_user":     instance.Spec.ServiceUser,
-		"nova_keystone_password": string(secret.Data[ServicePasswordSelector]),
-		"openstack_region_name":  "regionOne", // fixme
-		"default_project_domain": "Default",   // fixme
-		"default_user_domain":    "Default",   // fixme
-		"compute_driver":         "libvirt.LibvirtDriver",
-		"transport_url":          string(secret.Data[TransportURLSelector]),
+		"service_name":                   "nova-compute",
+		"keystone_internal_url":          instance.Spec.KeystoneAuthURL,
+		"nova_keystone_user":             instance.Spec.ServiceUser,
+		"nova_keystone_password":         string(secret.Data[ServicePasswordSelector]),
+		"openstack_region_name":          "regionOne", // fixme
+		"default_project_domain":         "Default",   // fixme
+		"default_user_domain":            "Default",   // fixme
+		"compute_driver":                 "libvirt.LibvirtDriver",
+		"transport_url":                  string(secret.Data[TransportURLSelector]),
+		"nova_cell_notify_transport_url": string(secret.Data[NotificationsTransportURLSelector]),
+		"nova_enabled_notification":      nil, // false or true, but based on the 'upcall' instance.spec.NotificationsBusInstance
 	}
 	// vnc is optional so we only need to configure it for the compute
 	// if the proxy service is deployed in the cell

--- a/controllers/novascheduler_controller.go
+++ b/controllers/novascheduler_controller.go
@@ -513,27 +513,29 @@ func (r *NovaSchedulerReconciler) generateConfigs(
 	}
 
 	templateParameters := map[string]interface{}{
-		"service_name":             "nova-scheduler",
-		"keystone_internal_url":    instance.Spec.KeystoneAuthURL,
-		"nova_keystone_user":       instance.Spec.ServiceUser,
-		"nova_keystone_password":   string(secret.Data[ServicePasswordSelector]),
-		"api_db_name":              NovaAPIDatabaseName,
-		"api_db_user":              apiDatabaseAccount.Spec.UserName,
-		"api_db_password":          string(apiDbSecret.Data[mariadbv1.DatabasePasswordSelector]),
-		"api_db_address":           instance.Spec.APIDatabaseHostname,
-		"api_db_port":              3306,
-		"cell_db_name":             NovaCell0DatabaseName,
-		"cell_db_user":             cellDatabaseAccount.Spec.UserName,
-		"cell_db_password":         string(cellDbSecret.Data[mariadbv1.DatabasePasswordSelector]),
-		"cell_db_address":          instance.Spec.Cell0DatabaseHostname,
-		"cell_db_port":             3306,
-		"openstack_region_name":    "regionOne", // fixme
-		"default_project_domain":   "Default",   // fixme
-		"default_user_domain":      "Default",   // fixme
-		"transport_url":            string(secret.Data[TransportURLSelector]),
-		"MemcachedServers":         memcachedInstance.GetMemcachedServerListString(),
-		"MemcachedServersWithInet": memcachedInstance.GetMemcachedServerListWithInetString(),
-		"MemcachedTLS":             memcachedInstance.GetMemcachedTLSSupport(),
+		"service_name":                   "nova-scheduler",
+		"keystone_internal_url":          instance.Spec.KeystoneAuthURL,
+		"nova_keystone_user":             instance.Spec.ServiceUser,
+		"nova_keystone_password":         string(secret.Data[ServicePasswordSelector]),
+		"api_db_name":                    NovaAPIDatabaseName,
+		"api_db_user":                    apiDatabaseAccount.Spec.UserName,
+		"api_db_password":                string(apiDbSecret.Data[mariadbv1.DatabasePasswordSelector]),
+		"api_db_address":                 instance.Spec.APIDatabaseHostname,
+		"api_db_port":                    3306,
+		"cell_db_name":                   NovaCell0DatabaseName,
+		"cell_db_user":                   cellDatabaseAccount.Spec.UserName,
+		"cell_db_password":               string(cellDbSecret.Data[mariadbv1.DatabasePasswordSelector]),
+		"cell_db_address":                instance.Spec.Cell0DatabaseHostname,
+		"cell_db_port":                   3306,
+		"openstack_region_name":          "regionOne", // fixme
+		"default_project_domain":         "Default",   // fixme
+		"default_user_domain":            "Default",   // fixme
+		"transport_url":                  string(secret.Data[TransportURLSelector]),
+		"nova_cell_notify_transport_url": string(secret.Data[NotificationsTransportURLSelector]),
+		"nova_enabled_notification":      nil, // false or true
+		"MemcachedServers":               memcachedInstance.GetMemcachedServerListString(),
+		"MemcachedServersWithInet":       memcachedInstance.GetMemcachedServerListWithInetString(),
+		"MemcachedTLS":                   memcachedInstance.GetMemcachedTLSSupport(),
 	}
 
 	var tlsCfg *tls.Service

--- a/pkg/nova/common.go
+++ b/pkg/nova/common.go
@@ -109,3 +109,9 @@ type MessageBus struct {
 	TransportURL string
 	Status       MessageBusStatus
 }
+
+// NotificationsBus -
+type NotificationsBus struct {
+	NotificationsTransportURL string
+	Status                    MessageBusStatus
+}


### PR DESCRIPTION
This is an initial pass for @auniyal61 to take over and continue on

> use the internal secret that is already generated by the nova controller and contains the transport_url for the RPC bus and already passed down via the existing secret field in the NovaAPI (and other service CRDs). Then we don't need to touch the service CRDs. The information will be transferred via the existing internal secret via notifications_transport_url key as the transport_url key is already taken by the RPC bus value.

Jira: [OSPRH-15392](https://issues.redhat.com//browse/OSPRH-15392)