### PR TITLE
Adds notification bus 

### DIFF
--- a/api/v1beta1/conditions.go
+++ b/api/v1beta1/conditions.go
@@ -54,6 +54,10 @@ const (
 	NovaAllControlPlaneComputesReadyCondition condition.Type = "NovaAllControlPlaneComputesReady"
 	//NovaCellsDeletionCondition indicates that the NovaCells deletion is in progress
 	NovaCellsDeletionCondition condition.Type = "NovaCellsDeletion"
+
+	// notifications
+	// NovaNotificationMQReadyCondition indicated that the top level notification message bus is ready
+	NovaNotificationMQReadyCondition condition.Type = "NovaNotificationMQReady"
 )
 
 // Common Messages used by API objects.
@@ -183,4 +187,16 @@ const (
 
 	// NovaCellsDeletionConditionReadyMessage
 	NovaCellsDeletionConditionReadyMessage = "There is no more NovaCells to delete"
+	// notifications
+	// NovaNotificationMQReadyInitMessage
+	NovaNotificationMQReadyInitMessage = "Notification message bus not started"
+
+	// NovaNotificationMQReadyErrorMessage
+	NovaNotificationMQReadyErrorMessage = "Notification message bus creation failed: %s"
+
+	// NovaNotificationMQReadyCreatingMessage
+	NovaNotificationMQReadyCreatingMessage = "Notification message bus creation ongoing"
+
+	// NovaNotificationMQReadyMessage
+	NovaNotificationMQReadyMessage = "Notification message bus created successfully"
 )

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -96,6 +96,10 @@ const (
 	// Secret for the cell message bus transport URL
 	TransportURLSelector = "transport_url"
 
+	// NotificationTransportURLSelector is the name of
+	// top level notification message bus transport URL
+	NotificationTransportURLSelector = "notification_transport_url"
+
 	// fields to index to reconcile when change
 	passwordSecretField        = ".spec.secret"
 	caBundleSecretNameField    = ".spec.tls.caBundleSecretName" // #nosec G101

--- a/controllers/novaapi_controller.go
+++ b/controllers/novaapi_controller.go
@@ -183,16 +183,19 @@ func (r *NovaAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 	// detect if something is changed.
 	hashes := make(map[string]env.Setter)
 
-	secretHash, result, secret, err := ensureSecret(
-		ctx,
-		types.NamespacedName{Namespace: instance.Namespace, Name: instance.Spec.Secret},
+	requiredSecretFields := []string{
 		// TODO(gibi): add keystoneAuthURL here is that is also passed via
 		// the Secret. Also add DB and MQ user name here too if those are
 		// passed via the Secret
-		[]string{
-			ServicePasswordSelector,
-			TransportURLSelector,
-		},
+		ServicePasswordSelector,
+		TransportURLSelector,
+		NotificationTransportURLSelector,
+	}
+
+	secretHash, result, secret, err := ensureSecret(
+		ctx,
+		types.NamespacedName{Namespace: instance.Namespace, Name: instance.Spec.Secret},
+		requiredSecretFields,
 		h.GetClient(),
 		&instance.Status.Conditions,
 		r.RequeueTimeout,
@@ -473,28 +476,29 @@ func (r *NovaAPIReconciler) generateConfigs(
 		"keystone_internal_url": instance.Spec.KeystoneAuthURL,
 		// NOTE(gibi): As per the definition of www_authenticate_uri this
 		// always needs to point to the public keystone endpoint.
-		"www_authenticate_uri":     instance.Spec.KeystonePublicAuthURL,
-		"nova_keystone_user":       instance.Spec.ServiceUser,
-		"nova_keystone_password":   string(secret.Data[ServicePasswordSelector]),
-		"api_db_name":              NovaAPIDatabaseName,
-		"api_db_user":              apiDatabaseAccount.Spec.UserName,
-		"api_db_password":          string(apiDbSecret.Data[mariadbv1.DatabasePasswordSelector]),
-		"api_db_address":           instance.Spec.APIDatabaseHostname,
-		"api_db_port":              3306,
-		"cell_db_name":             NovaCell0DatabaseName,
-		"cell_db_user":             cellDatabaseAccount.Spec.UserName,
-		"cell_db_password":         string(cellDbSecret.Data[mariadbv1.DatabasePasswordSelector]),
-		"cell_db_address":          instance.Spec.Cell0DatabaseHostname,
-		"cell_db_port":             3306,
-		"openstack_region_name":    "regionOne", // fixme
-		"default_project_domain":   "Default",   // fixme
-		"default_user_domain":      "Default",   // fixme
-		"transport_url":            string(secret.Data[TransportURLSelector]),
-		"log_file":                 "/var/log/nova/nova-api.log",
-		"tls":                      false,
-		"MemcachedServers":         memcachedInstance.GetMemcachedServerListString(),
-		"MemcachedServersWithInet": memcachedInstance.GetMemcachedServerListWithInetString(),
-		"MemcachedTLS":             memcachedInstance.GetMemcachedTLSSupport(),
+		"www_authenticate_uri":       instance.Spec.KeystonePublicAuthURL,
+		"nova_keystone_user":         instance.Spec.ServiceUser,
+		"nova_keystone_password":     string(secret.Data[ServicePasswordSelector]),
+		"api_db_name":                NovaAPIDatabaseName,
+		"api_db_user":                apiDatabaseAccount.Spec.UserName,
+		"api_db_password":            string(apiDbSecret.Data[mariadbv1.DatabasePasswordSelector]),
+		"api_db_address":             instance.Spec.APIDatabaseHostname,
+		"api_db_port":                3306,
+		"cell_db_name":               NovaCell0DatabaseName,
+		"cell_db_user":               cellDatabaseAccount.Spec.UserName,
+		"cell_db_password":           string(cellDbSecret.Data[mariadbv1.DatabasePasswordSelector]),
+		"cell_db_address":            instance.Spec.Cell0DatabaseHostname,
+		"cell_db_port":               3306,
+		"openstack_region_name":      "regionOne", // fixme
+		"default_project_domain":     "Default",   // fixme
+		"default_user_domain":        "Default",   // fixme
+		"transport_url":              string(secret.Data[TransportURLSelector]),
+		"notification_transport_url": string(secret.Data[NotificationTransportURLSelector]),
+		"log_file":                   "/var/log/nova/nova-api.log",
+		"tls":                        false,
+		"MemcachedServers":           memcachedInstance.GetMemcachedServerListString(),
+		"MemcachedServersWithInet":   memcachedInstance.GetMemcachedServerListWithInetString(),
+		"MemcachedTLS":               memcachedInstance.GetMemcachedTLSSupport(),
 	}
 	// create httpd  vhost template parameters
 	httpdVhostConfig := map[string]interface{}{}

--- a/controllers/novacell_controller.go
+++ b/controllers/novacell_controller.go
@@ -144,14 +144,17 @@ func (r *NovaCellReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 		}
 	}()
 
+	requiredSecretFields := []string{
+		ServicePasswordSelector,
+		TransportURLSelector,
+		NotificationTransportURLSelector,
+	}
+
 	// For the compute config generation we need to read the input secrets
 	_, result, secret, err := ensureSecret(
 		ctx,
 		types.NamespacedName{Namespace: instance.Namespace, Name: instance.Spec.Secret},
-		[]string{
-			ServicePasswordSelector,
-			TransportURLSelector,
-		},
+		requiredSecretFields,
 		h.GetClient(),
 		&instance.Status.Conditions,
 		r.RequeueTimeout,
@@ -767,15 +770,16 @@ func (r *NovaCellReconciler) generateComputeConfigs(
 	secret corev1.Secret, vncProxyURL *string,
 ) error {
 	templateParameters := map[string]interface{}{
-		"service_name":           "nova-compute",
-		"keystone_internal_url":  instance.Spec.KeystoneAuthURL,
-		"nova_keystone_user":     instance.Spec.ServiceUser,
-		"nova_keystone_password": string(secret.Data[ServicePasswordSelector]),
-		"openstack_region_name":  "regionOne", // fixme
-		"default_project_domain": "Default",   // fixme
-		"default_user_domain":    "Default",   // fixme
-		"compute_driver":         "libvirt.LibvirtDriver",
-		"transport_url":          string(secret.Data[TransportURLSelector]),
+		"service_name":               "nova-compute",
+		"keystone_internal_url":      instance.Spec.KeystoneAuthURL,
+		"nova_keystone_user":         instance.Spec.ServiceUser,
+		"nova_keystone_password":     string(secret.Data[ServicePasswordSelector]),
+		"openstack_region_name":      "regionOne", // fixme
+		"default_project_domain":     "Default",   // fixme
+		"default_user_domain":        "Default",   // fixme
+		"compute_driver":             "libvirt.LibvirtDriver",
+		"transport_url":              string(secret.Data[TransportURLSelector]),
+		"notification_transport_url": string(secret.Data[NotificationTransportURLSelector]),
 	}
 	// vnc is optional so we only need to configure it for the compute
 	// if the proxy service is deployed in the cell

--- a/controllers/novaconductor_controller.go
+++ b/controllers/novaconductor_controller.go
@@ -182,6 +182,7 @@ func (r *NovaConductorReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	requiredSecretFields := []string{
 		ServicePasswordSelector,
 		TransportURLSelector,
+		NotificationTransportURLSelector,
 	}
 
 	secretHash, result, secret, err := ensureSecret(
@@ -431,22 +432,23 @@ func (r *NovaConductorReconciler) generateConfigs(
 	cellDbSecret := cellDB.GetSecret()
 
 	templateParameters := map[string]interface{}{
-		"service_name":             "nova-conductor",
-		"keystone_internal_url":    instance.Spec.KeystoneAuthURL,
-		"nova_keystone_user":       instance.Spec.ServiceUser,
-		"nova_keystone_password":   string(secret.Data[ServicePasswordSelector]),
-		"cell_db_name":             getCellDatabaseName(instance.Spec.CellName),
-		"cell_db_user":             cellDatabaseAccount.Spec.UserName,
-		"cell_db_password":         string(cellDbSecret.Data[mariadbv1.DatabasePasswordSelector]),
-		"cell_db_address":          instance.Spec.CellDatabaseHostname,
-		"cell_db_port":             3306,
-		"openstack_region_name":    "regionOne", // fixme
-		"default_project_domain":   "Default",   // fixme
-		"default_user_domain":      "Default",   // fixme
-		"transport_url":            string(secret.Data[TransportURLSelector]),
-		"MemcachedServers":         memcachedInstance.GetMemcachedServerListString(),
-		"MemcachedServersWithInet": memcachedInstance.GetMemcachedServerListWithInetString(),
-		"MemcachedTLS":             memcachedInstance.GetMemcachedTLSSupport(),
+		"service_name":               "nova-conductor",
+		"keystone_internal_url":      instance.Spec.KeystoneAuthURL,
+		"nova_keystone_user":         instance.Spec.ServiceUser,
+		"nova_keystone_password":     string(secret.Data[ServicePasswordSelector]),
+		"cell_db_name":               getCellDatabaseName(instance.Spec.CellName),
+		"cell_db_user":               cellDatabaseAccount.Spec.UserName,
+		"cell_db_password":           string(cellDbSecret.Data[mariadbv1.DatabasePasswordSelector]),
+		"cell_db_address":            instance.Spec.CellDatabaseHostname,
+		"cell_db_port":               3306,
+		"openstack_region_name":      "regionOne", // fixme
+		"default_project_domain":     "Default",   // fixme
+		"default_user_domain":        "Default",   // fixme
+		"transport_url":              string(secret.Data[TransportURLSelector]),
+		"notification_transport_url": string(secret.Data[NotificationTransportURLSelector]),
+		"MemcachedServers":           memcachedInstance.GetMemcachedServerListString(),
+		"MemcachedServersWithInet":   memcachedInstance.GetMemcachedServerListWithInetString(),
+		"MemcachedTLS":               memcachedInstance.GetMemcachedTLSSupport(),
 	}
 	if len(instance.Spec.APIDatabaseHostname) > 0 {
 		apiDatabaseAccount, apiDbSecret, err := mariadbv1.GetAccountAndSecret(ctx, h, instance.Spec.APIDatabaseAccount, instance.Namespace)

--- a/controllers/novascheduler_controller.go
+++ b/controllers/novascheduler_controller.go
@@ -177,16 +177,19 @@ func (r *NovaSchedulerReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// detect if something is changed.
 	hashes := make(map[string]env.Setter)
 
-	secretHash, result, secret, err := ensureSecret(
-		ctx,
-		types.NamespacedName{Namespace: instance.Namespace, Name: instance.Spec.Secret},
+	requiredSecretFields := []string{
 		// TODO(gibi): add keystoneAuthURL here is that is also passed via
 		// the Secret. Also add DB and MQ user name here too if those are
 		// passed via the Secret
-		[]string{
-			ServicePasswordSelector,
-			TransportURLSelector,
-		},
+		ServicePasswordSelector,
+		TransportURLSelector,
+		NotificationTransportURLSelector,
+	}
+
+	secretHash, result, secret, err := ensureSecret(
+		ctx,
+		types.NamespacedName{Namespace: instance.Namespace, Name: instance.Spec.Secret},
+		requiredSecretFields,
 		h.GetClient(),
 		&instance.Status.Conditions,
 		r.RequeueTimeout,
@@ -518,27 +521,28 @@ func (r *NovaSchedulerReconciler) generateConfigs(
 	}
 
 	templateParameters := map[string]interface{}{
-		"service_name":             "nova-scheduler",
-		"keystone_internal_url":    instance.Spec.KeystoneAuthURL,
-		"nova_keystone_user":       instance.Spec.ServiceUser,
-		"nova_keystone_password":   string(secret.Data[ServicePasswordSelector]),
-		"api_db_name":              NovaAPIDatabaseName,
-		"api_db_user":              apiDatabaseAccount.Spec.UserName,
-		"api_db_password":          string(apiDbSecret.Data[mariadbv1.DatabasePasswordSelector]),
-		"api_db_address":           instance.Spec.APIDatabaseHostname,
-		"api_db_port":              3306,
-		"cell_db_name":             NovaCell0DatabaseName,
-		"cell_db_user":             cellDatabaseAccount.Spec.UserName,
-		"cell_db_password":         string(cellDbSecret.Data[mariadbv1.DatabasePasswordSelector]),
-		"cell_db_address":          instance.Spec.Cell0DatabaseHostname,
-		"cell_db_port":             3306,
-		"openstack_region_name":    "regionOne", // fixme
-		"default_project_domain":   "Default",   // fixme
-		"default_user_domain":      "Default",   // fixme
-		"transport_url":            string(secret.Data[TransportURLSelector]),
-		"MemcachedServers":         memcachedInstance.GetMemcachedServerListString(),
-		"MemcachedServersWithInet": memcachedInstance.GetMemcachedServerListWithInetString(),
-		"MemcachedTLS":             memcachedInstance.GetMemcachedTLSSupport(),
+		"service_name":               "nova-scheduler",
+		"keystone_internal_url":      instance.Spec.KeystoneAuthURL,
+		"nova_keystone_user":         instance.Spec.ServiceUser,
+		"nova_keystone_password":     string(secret.Data[ServicePasswordSelector]),
+		"api_db_name":                NovaAPIDatabaseName,
+		"api_db_user":                apiDatabaseAccount.Spec.UserName,
+		"api_db_password":            string(apiDbSecret.Data[mariadbv1.DatabasePasswordSelector]),
+		"api_db_address":             instance.Spec.APIDatabaseHostname,
+		"api_db_port":                3306,
+		"cell_db_name":               NovaCell0DatabaseName,
+		"cell_db_user":               cellDatabaseAccount.Spec.UserName,
+		"cell_db_password":           string(cellDbSecret.Data[mariadbv1.DatabasePasswordSelector]),
+		"cell_db_address":            instance.Spec.Cell0DatabaseHostname,
+		"cell_db_port":               3306,
+		"openstack_region_name":      "regionOne", // fixme
+		"default_project_domain":     "Default",   // fixme
+		"default_user_domain":        "Default",   // fixme
+		"transport_url":              string(secret.Data[TransportURLSelector]),
+		"notification_transport_url": string(secret.Data[NotificationTransportURLSelector]),
+		"MemcachedServers":           memcachedInstance.GetMemcachedServerListString(),
+		"MemcachedServersWithInet":   memcachedInstance.GetMemcachedServerListWithInetString(),
+		"MemcachedTLS":               memcachedInstance.GetMemcachedTLSSupport(),
 	}
 
 	var tlsCfg *tls.Service

--- a/templates/nova.conf
+++ b/templates/nova.conf
@@ -126,19 +126,24 @@ enable_proxy_headers_parsing = True
 api_paste_config = /etc/nova/api-paste.ini
 {{end}}
 
-[oslo_messaging_notifications]
-{{ if (index . "nova_enabled_notification") }}
-transport_url =  {{ .nova_cell_notify_transport_url }}
-driver = messagingv2
-notification_format=versioned
-{{ else }}
-driver = noop
-{{end}}
-
-{{if (index . "enable_ceilometer") }}
+{{ if (index . "notification_transport_url")}}
 [notifications]
 notify_on_state_change = vm_and_task_state
+notification_format=both
+# notification_format=both specific to ceilometer as it depends on unversioned notifications
+# bug https://bugs.launchpad.net/ceilometer/+bug/1665449
+# while other services support versioned
+# so we emit both verioned and unversioned if notifications are enabled.
 {{ end }}
+
+[oslo_messaging_notifications]
+{{ if (index . "notification_transport_url")}}
+transport_url = {{.notification_transport_url}}
+driver = messagingv2
+{{ else }}
+driver = noop
+{{ end }}
+
 
 {{ if eq .service_name "nova-novncproxy"}}
 [vnc]

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -679,9 +679,10 @@ func CreateInternalTopLevelSecret(novaNames NovaNames) *corev1.Secret {
 	return th.CreateSecret(
 		novaNames.InternalTopLevelSecretName,
 		map[string][]byte{
-			"ServicePassword": []byte("service-password"),
-			"MetadataSecret":  []byte("metadata-secret"),
-			"transport_url":   []byte("rabbit://api/fake"),
+			"ServicePassword":            []byte("service-password"),
+			"MetadataSecret":             []byte("metadata-secret"),
+			"transport_url":              []byte("rabbit://api/fake"),
+			"notification_transport_url": []byte("rabbit://notifications/fake"),
 		},
 	)
 }
@@ -751,8 +752,9 @@ func GetDefaultNovaNoVNCProxySpec(cell CellNames) map[string]interface{} {
 func CreateCellInternalSecret(cell CellNames, additionalValues map[string][]byte) *corev1.Secret {
 
 	secretMap := map[string][]byte{
-		"ServicePassword": []byte("service-password"),
-		"transport_url":   []byte(fmt.Sprintf("rabbit://%s/fake", cell.CellName)),
+		"ServicePassword":            []byte("service-password"),
+		"transport_url":              []byte(fmt.Sprintf("rabbit://%s/fake", cell.CellName)),
+		"notification_transport_url": []byte("rabbit://notifications/fake"),
 	}
 	// (ksambor) this can be replaced with maps.Copy directly from maps
 	// not experimental package when we move to go 1.21

--- a/test/functional/nova_controller_test.go
+++ b/test/functional/nova_controller_test.go
@@ -38,6 +38,125 @@ import (
 	"github.com/openstack-k8s-operators/nova-operator/controllers"
 )
 
+var _ = Describe("Nova controller - notifications", func() {
+
+	When("Nova CR instance is created", func() {
+		BeforeEach(func() {
+			DeferCleanup(
+				k8sClient.Delete, ctx, CreateNovaSecret(novaNames.NovaName.Namespace, SecretName))
+			DeferCleanup(
+				k8sClient.Delete, ctx, CreateNovaMessageBusSecret(cell0))
+			DeferCleanup(
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(
+					novaNames.NovaName.Namespace,
+					"openstack",
+					corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{{Port: 3306}},
+					},
+				),
+			)
+			memcachedSpec := infra.GetDefaultMemcachedSpec()
+
+			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
+			infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)
+
+			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(novaNames.NovaName.Namespace))
+
+			DeferCleanup(th.DeleteInstance, CreateNovaWithCell0(novaNames.NovaName))
+
+			keystone.SimulateKeystoneServiceReady(novaNames.KeystoneServiceName)
+			mariadb.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
+			mariadb.SimulateMariaDBAccountCompleted(novaNames.APIMariaDBDatabaseAccount)
+			mariadb.SimulateMariaDBDatabaseCompleted(cell0.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBAccountCompleted(cell0.MariaDBAccountName)
+			infra.SimulateTransportURLReady(cell0.TransportURLName)
+			SimulateReadyOfNovaTopServices()
+		})
+		It("notification transport url is not set", func() {
+
+			// assert that a the top level internal internal secret is created
+			// with the proper data
+			internalTopLevelSecret := th.GetSecret(novaNames.InternalTopLevelSecretName)
+			// verify if nova secret has notification-transport-url
+			Expect(internalTopLevelSecret.Data).To(HaveKey("notification_transport_url"))
+			Expect(internalTopLevelSecret.Data).To(
+				HaveKeyWithValue("notification_transport_url", []byte("")))
+
+			// verify if confs are updated with notification-transport-url under oslo_messaging_notifications
+			// assert in nova-api conf
+			configDataMap := th.GetSecret(novaNames.APIConfigDataName)
+			Expect(configDataMap.Data).Should(HaveKey("01-nova.conf"))
+			configData := string(configDataMap.Data["01-nova.conf"])
+			AssertNotHaveNotificationTransportURL(configData)
+
+			// assert in sch conf
+			configDataMap = th.GetSecret(novaNames.SchedulerConfigDataName)
+			Expect(configDataMap.Data).Should(HaveKey("01-nova.conf"))
+			configData = string(configDataMap.Data["01-nova.conf"])
+			AssertNotHaveNotificationTransportURL(configData)
+
+			// assert in cell0-conductor conf
+			configDataMap = th.GetSecret(cell0.ConductorConfigDataName)
+			Expect(configDataMap.Data).Should(HaveKey("01-nova.conf"))
+			configData = string(configDataMap.Data["01-nova.conf"])
+			AssertNotHaveNotificationTransportURL(configData)
+
+		})
+
+		It("notification transport url is set with new rabbit", func() {
+
+			// add new-rabbit in Nova CR
+			notificationsBus := GetNotificationsBusNames(novaNames.NovaName)
+			DeferCleanup(k8sClient.Delete, ctx, CreateNotificiationTransportURLSecret(notificationsBus))
+
+			Eventually(func(g Gomega) {
+				nova := GetNova(novaNames.NovaName)
+				nova.Spec.NotificationsBusInstance = &notificationsBus.BusName
+				g.Expect(k8sClient.Update(ctx, nova)).Should(Succeed())
+			}, timeout, interval).Should(Succeed())
+
+			// as new-rabbit already exists in cluster, infra operator will create transporturl for it
+			// simulating same
+			infra.SimulateTransportURLReady(notificationsBus.TransportURLName)
+			transportURLName := infra.GetTransportURL(notificationsBus.TransportURLName)
+			Expect(transportURLName.Spec.RabbitmqClusterName).To(Equal(notificationsBus.BusName))
+
+			th.ExpectCondition(
+				novaNames.NovaName,
+				ConditionGetterFunc(NovaConditionGetter),
+				novav1.NovaNotificationMQReadyCondition,
+				corev1.ConditionTrue,
+			)
+
+			// the nova secret(i.e top level secret) should have notification_transport_url value set
+			internalTopLevelSecret := th.GetSecret(novaNames.InternalTopLevelSecretName)
+			Expect(internalTopLevelSecret.Data).To(HaveKey("notification_transport_url"))
+			Expect(internalTopLevelSecret.Data["notification_transport_url"]).ShouldNot(BeEmpty())
+
+			// assert in nova-api conf
+			configDataMap := th.GetSecret(novaNames.APIConfigDataName)
+			Expect(configDataMap.Data).Should(HaveKey("01-nova.conf"))
+			configData := string(configDataMap.Data["01-nova.conf"])
+			AssertHaveNotificationTransportURL(notificationsBus.TransportURLName.Name, configData)
+
+			// assert in sch conf
+			configDataMap = th.GetSecret(novaNames.SchedulerConfigDataName)
+			Expect(configDataMap.Data).Should(HaveKey("01-nova.conf"))
+			configData = string(configDataMap.Data["01-nova.conf"])
+			AssertHaveNotificationTransportURL(notificationsBus.TransportURLName.Name, configData)
+
+			// assert in cell0-conductor conf
+			configDataMap = th.GetSecret(cell0.ConductorConfigDataName)
+			Expect(configDataMap.Data).Should(HaveKey("01-nova.conf"))
+			configData = string(configDataMap.Data["01-nova.conf"])
+			AssertHaveNotificationTransportURL(notificationsBus.TransportURLName.Name, configData)
+
+		})
+	})
+
+})
+
 var _ = Describe("Nova controller", func() {
 	When("Nova CR instance is created without a proper secret", func() {
 		BeforeEach(func() {
@@ -265,6 +384,8 @@ var _ = Describe("Nova controller", func() {
 				HaveKeyWithValue(controllers.ServicePasswordSelector, []byte("service-password")))
 			Expect(internalCellSecret.Data).To(
 				HaveKeyWithValue("transport_url", []byte("rabbit://cell0/fake")))
+			Expect(internalCellSecret.Data).To(
+				HaveKeyWithValue("notification_transport_url", []byte("")))
 
 			Expect(cell.Spec.Secret).To(Equal(cell0.InternalCellSecretName.Name))
 			Expect(conductor.Spec.Secret).To(Equal(cell0.InternalCellSecretName.Name))
@@ -381,6 +502,8 @@ var _ = Describe("Nova controller", func() {
 				HaveKeyWithValue(controllers.MetadataSecretSelector, []byte("metadata-secret")))
 			Expect(internalTopLevelSecret.Data).To(
 				HaveKeyWithValue("transport_url", []byte("rabbit://cell0/fake")))
+			Expect(internalTopLevelSecret.Data).To(
+				HaveKeyWithValue("notification_transport_url", []byte("")))
 		})
 
 		It("creates NovaAPI", func() {

--- a/test/functional/nova_controller_test.go
+++ b/test/functional/nova_controller_test.go
@@ -260,7 +260,7 @@ var _ = Describe("Nova controller", func() {
 			// proper content and the cell subCRs are configured to use the
 			// internal secret
 			internalCellSecret := th.GetSecret(cell0.InternalCellSecretName)
-			Expect(internalCellSecret.Data).To(HaveLen(2))
+			Expect(internalCellSecret.Data).To(HaveLen(3))
 			Expect(internalCellSecret.Data).To(
 				HaveKeyWithValue(controllers.ServicePasswordSelector, []byte("service-password")))
 			Expect(internalCellSecret.Data).To(
@@ -374,7 +374,7 @@ var _ = Describe("Nova controller", func() {
 			// assert that a the top level internal internal secret is created
 			// with the proper data
 			internalTopLevelSecret := th.GetSecret(novaNames.InternalTopLevelSecretName)
-			Expect(internalTopLevelSecret.Data).To(HaveLen(3))
+			Expect(internalTopLevelSecret.Data).To(HaveLen(4))
 			Expect(internalTopLevelSecret.Data).To(
 				HaveKeyWithValue(controllers.ServicePasswordSelector, []byte("service-password")))
 			Expect(internalTopLevelSecret.Data).To(

--- a/test/functional/nova_scheduler_test.go
+++ b/test/functional/nova_scheduler_test.go
@@ -163,6 +163,44 @@ var _ = Describe("NovaScheduler controller", func() {
 		})
 	})
 
+	When("the Secret is created but notification fields is missing", func() {
+		BeforeEach(func() {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      novaNames.InternalTopLevelSecretName.Name,
+					Namespace: novaNames.InternalTopLevelSecretName.Namespace,
+				},
+				Data: map[string][]byte{
+					"ServicePassword": []byte("12345678"),
+					"transport_url":   []byte("rabbit://api/fake"),
+					// notification_transport_url is missing
+				},
+			}
+			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
+			DeferCleanup(k8sClient.Delete, ctx, secret)
+		})
+
+		It("is not Ready", func() {
+			th.ExpectCondition(
+				novaNames.SchedulerName,
+				ConditionGetterFunc(NovaSchedulerConditionGetter),
+				condition.ReadyCondition,
+				corev1.ConditionFalse,
+			)
+		})
+
+		It("reports that the inputs are not ready", func() {
+			th.ExpectConditionWithDetails(
+				novaNames.SchedulerName,
+				ConditionGetterFunc(NovaSchedulerConditionGetter),
+				condition.InputReadyCondition,
+				corev1.ConditionFalse,
+				condition.ErrorReason,
+				fmt.Sprintf("Input data error occurred field not found in Secret: 'notification_transport_url' not found in secret/%s", novaNames.InternalTopLevelSecretName.Name),
+			)
+		})
+	})
+
 	When("the Secret is created with all the expected fields", func() {
 		BeforeEach(func() {
 			DeferCleanup(
@@ -192,6 +230,8 @@ var _ = Describe("NovaScheduler controller", func() {
 			Expect(configDataMap).ShouldNot(BeNil())
 			Expect(configDataMap.Data).Should(HaveKey("01-nova.conf"))
 			configData := string(configDataMap.Data["01-nova.conf"])
+			AssertHaveNotificationTransportURL("notifications", configData)
+
 			Expect(configData).To(ContainSubstring("transport_url=rabbit://api/fake"))
 			Expect(configData).To(ContainSubstring("password = service-password"))
 			memcacheInstance := infra.GetMemcached(novaNames.MemcachedNamespace)

--- a/test/functional/novaapi_controller_test.go
+++ b/test/functional/novaapi_controller_test.go
@@ -162,6 +162,44 @@ var _ = Describe("NovaAPI controller", func() {
 			})
 		})
 
+		When("the Secret is created but notification_transport_url field is missing", func() {
+			BeforeEach(func() {
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      novaNames.InternalTopLevelSecretName.Name,
+						Namespace: novaNames.InternalTopLevelSecretName.Namespace,
+					},
+					Data: map[string][]byte{
+						"ServicePassword": []byte("12345678"),
+						"transport_url":   []byte("rabbit://api/fake"),
+						// notification_transport_url is missing
+					},
+				}
+				Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
+				DeferCleanup(k8sClient.Delete, ctx, secret)
+			})
+
+			It("is not Ready", func() {
+				th.ExpectCondition(
+					novaNames.APIName,
+					ConditionGetterFunc(NovaAPIConditionGetter),
+					condition.ReadyCondition,
+					corev1.ConditionFalse,
+				)
+			})
+
+			It("reports that the inputs are not ready", func() {
+				th.ExpectConditionWithDetails(
+					novaNames.APIName,
+					ConditionGetterFunc(NovaAPIConditionGetter),
+					condition.InputReadyCondition,
+					corev1.ConditionFalse,
+					condition.ErrorReason,
+					fmt.Sprintf("Input data error occurred field not found in Secret: 'notification_transport_url' not found in secret/%s", novaNames.InternalTopLevelSecretName.Name),
+				)
+			})
+		})
+
 		When("the Secret is created with all the expected fields", func() {
 			BeforeEach(func() {
 				DeferCleanup(
@@ -192,6 +230,8 @@ var _ = Describe("NovaAPI controller", func() {
 				Expect(configDataMap).ShouldNot(BeNil())
 				Expect(configDataMap.Data).Should(HaveKey("01-nova.conf"))
 				configData := string(configDataMap.Data["01-nova.conf"])
+				AssertHaveNotificationTransportURL("notifications", configData)
+
 				Expect(configData).Should(ContainSubstring("transport_url=rabbit://api/fake"))
 				// as of I3629b84d3255a8fe9d8a7cea8c6131d7c40899e8 nova now requires
 				// service_user configuration to work to address Bug: #2004555

--- a/test/functional/novacell_controller_test.go
+++ b/test/functional/novacell_controller_test.go
@@ -307,6 +307,8 @@ var _ = Describe("NovaCell controller", func() {
 			Expect(computeConfigData).ShouldNot(BeNil())
 			Expect(computeConfigData.Data).Should(HaveKey("01-nova.conf"))
 			configData := string(computeConfigData.Data["01-nova.conf"])
+
+			AssertHaveNotificationTransportURL("notifications", configData)
 			// ensure we maintain the tripleo default for backwards compatibility
 			Expect(configData).Should(ContainSubstring("dhcp_domain = ''"))
 			Expect(configData).To(ContainSubstring("transport_url=rabbit://cell1/fake"))


### PR DESCRIPTION
Initial commit - Adds tests for notification bus

how this should work is:

1 - human operator will update rabbitmq in openstackcontrolplane CR
     a) under rabbitmq: add new rabbitmq, ex: rabbitmq-broadcaster, something like
```
           rabbitmq-broadcaster:
               replicas: 1
```

2 - human operator will update Nova in  openstackcontrolplane CR
     a) under nova.template.spec:  register new rabbit 
                    (as we do for new cell but not inside celltemplate, as this one is top-level)
                    
```
     nova:
	  template:
               spec:
                  apiContainerImageURL: image_url
                  apiMessageBusInstance: rabbitmq
                  // new var
                  notificationsBusInstance: rabbitmq-broadcaster    
```

3 - now nova-operator will recognize notificationsBusInstance and retrieve transport_url of new rabbit (rabbitmq-broadcaster)

4 - nova-operator will set this transport_url in nova.conf

Jira: [OSPRH-15392](https://issues.redhat.com//browse/OSPRH-15392)