### PR TITLE
[golang] bump to golang 1.22

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: tools
   namespace: openstack-k8s-operators
-  tag: ci-build-root-golang-1.21-sdk-1.31
+  tag: ci-build-root-golang-1.22-sdk-1.31

--- a/.github/workflows/build-nova-operator.yaml
+++ b/.github/workflows/build-nova-operator.yaml
@@ -15,7 +15,7 @@ jobs:
     uses: openstack-k8s-operators/openstack-k8s-operators-ci/.github/workflows/reusable-build-operator.yaml@main
     with:
       operator_name: nova
-      go_version: 1.21.x
+      go_version: 1.22.x
       operator_sdk_version: 1.31.0
     secrets:
       IMAGENAMESPACE: ${{ secrets.IMAGENAMESPACE }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,7 +77,7 @@ repos:
       # E012: here doc didn't end before EOF
 
 - repo: https://github.com/golangci/golangci-lint
-  rev: v1.59.1
+  rev: v1.63.4
   hooks:
     - id: golangci-lint-full
       args: ["-v"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GOLANG_BUILDER=registry.access.redhat.com/ubi9/go-toolset:1.21
+ARG GOLANG_BUILDER=registry.access.redhat.com/ubi9/go-toolset:1.22
 ARG OPERATOR_BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 # Build the manager binary

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ endif
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
-GOTOOLCHAIN_VERSION ?= go1.21.0
+GOTOOLCHAIN_VERSION ?= go1.22.0
 
 .PHONY: all
 all: build
@@ -134,10 +134,11 @@ tidy: ## Run go mod tidy on every mod file in the repo
 	go mod tidy
 	cd ./api && go mod tidy
 
+GOLANGCI_LINT_VERSION ?= v1.63.4
 .PHONY: golangci-lint
 golangci-lint:
 	# NOTE this will install golangci-lint in to local bin dir
-	test -s $(LOCALBIN)/golangci-lint || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.59.1
+	test -s $(LOCALBIN)/golangci-lint || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s $(GOLANGCI_LINT_VERSION)
 	$(LOCALBIN)/golangci-lint run --fix
 
 PROCS?=$(shell expr $(shell nproc --ignore 2) / 2)

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/openstack-k8s-operators/nova-operator/api
 
-go 1.21
+go 1.22
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -257,7 +257,7 @@ func ensureSecret(
 				condition.InputReadyCondition,
 				condition.RequestedReason,
 				condition.SeverityInfo,
-				fmt.Sprintf(novav1.InputReadyWaitingMessage, "secret/"+secretName.Name)))
+				novav1.InputReadyWaitingMessage, "secret/"+secretName.Name))
 			return "",
 				ctrl.Result{RequeueAfter: requeueTimeout},
 				*secret,

--- a/controllers/novaapi_controller.go
+++ b/controllers/novaapi_controller.go
@@ -254,7 +254,7 @@ func (r *NovaAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 					condition.TLSInputReadyCondition,
 					condition.RequestedReason,
 					condition.SeverityInfo,
-					fmt.Sprintf(condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName)))
+					condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName))
 				return ctrl.Result{}, nil
 			}
 			instance.Status.Conditions.Set(condition.FalseCondition(
@@ -279,7 +279,7 @@ func (r *NovaAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 				condition.TLSInputReadyCondition,
 				condition.RequestedReason,
 				condition.SeverityInfo,
-				fmt.Sprintf(condition.TLSInputReadyWaitingMessage, err.Error())))
+				condition.TLSInputReadyWaitingMessage, err.Error()))
 			return ctrl.Result{}, nil
 		}
 		instance.Status.Conditions.Set(condition.FalseCondition(

--- a/controllers/novacompute_controller.go
+++ b/controllers/novacompute_controller.go
@@ -192,7 +192,7 @@ func (r *NovaComputeReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 					condition.TLSInputReadyCondition,
 					condition.RequestedReason,
 					condition.SeverityInfo,
-					fmt.Sprintf(condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName)))
+					condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName))
 				return ctrl.Result{}, nil
 			}
 			instance.Status.Conditions.Set(condition.FalseCondition(

--- a/controllers/novaconductor_controller.go
+++ b/controllers/novaconductor_controller.go
@@ -216,7 +216,7 @@ func (r *NovaConductorReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 					condition.TLSInputReadyCondition,
 					condition.RequestedReason,
 					condition.SeverityInfo,
-					fmt.Sprintf(condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName)))
+					condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName))
 				return ctrl.Result{}, nil
 			}
 			instance.Status.Conditions.Set(condition.FalseCondition(

--- a/controllers/novametadata_controller.go
+++ b/controllers/novametadata_controller.go
@@ -232,7 +232,7 @@ func (r *NovaMetadataReconciler) Reconcile(ctx context.Context, req ctrl.Request
 					condition.TLSInputReadyCondition,
 					condition.RequestedReason,
 					condition.SeverityInfo,
-					fmt.Sprintf(condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName)))
+					condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName))
 				return ctrl.Result{}, nil
 			}
 			instance.Status.Conditions.Set(condition.FalseCondition(
@@ -258,7 +258,7 @@ func (r *NovaMetadataReconciler) Reconcile(ctx context.Context, req ctrl.Request
 					condition.TLSInputReadyCondition,
 					condition.RequestedReason,
 					condition.SeverityInfo,
-					fmt.Sprintf(condition.TLSInputReadyWaitingMessage, err.Error())))
+					condition.TLSInputReadyWaitingMessage, err.Error()))
 				return ctrl.Result{}, nil
 			}
 			instance.Status.Conditions.Set(condition.FalseCondition(

--- a/controllers/novanovncproxy_controller.go
+++ b/controllers/novanovncproxy_controller.go
@@ -210,7 +210,7 @@ func (r *NovaNoVNCProxyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 					condition.TLSInputReadyCondition,
 					condition.RequestedReason,
 					condition.SeverityInfo,
-					fmt.Sprintf(condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName)))
+					condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName))
 				return ctrl.Result{}, nil
 			}
 			instance.Status.Conditions.Set(condition.FalseCondition(
@@ -236,7 +236,7 @@ func (r *NovaNoVNCProxyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 					condition.TLSInputReadyCondition,
 					condition.RequestedReason,
 					condition.SeverityInfo,
-					fmt.Sprintf(condition.TLSInputReadyWaitingMessage, err.Error())))
+					condition.TLSInputReadyWaitingMessage, err.Error()))
 				return ctrl.Result{}, nil
 			}
 			instance.Status.Conditions.Set(condition.FalseCondition(
@@ -259,7 +259,7 @@ func (r *NovaNoVNCProxyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 					condition.TLSInputReadyCondition,
 					condition.RequestedReason,
 					condition.SeverityInfo,
-					fmt.Sprintf(condition.TLSInputReadyWaitingMessage, err.Error())))
+					condition.TLSInputReadyWaitingMessage, err.Error()))
 				return ctrl.Result{}, nil
 			}
 			instance.Status.Conditions.Set(condition.FalseCondition(

--- a/controllers/novascheduler_controller.go
+++ b/controllers/novascheduler_controller.go
@@ -214,7 +214,7 @@ func (r *NovaSchedulerReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 					condition.TLSInputReadyCondition,
 					condition.RequestedReason,
 					condition.SeverityInfo,
-					fmt.Sprintf(condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName)))
+					condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName))
 				return ctrl.Result{}, nil
 			}
 			instance.Status.Conditions.Set(condition.FalseCondition(

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openstack-k8s-operators/nova-operator
 
-go 1.21
+go 1.22
 
 require (
 	github.com/go-logr/logr v1.4.2

--- a/test/functional/novacell_controller_test.go
+++ b/test/functional/novacell_controller_test.go
@@ -99,7 +99,7 @@ var _ = Describe("NovaCell controller", func() {
 			Expect(instance.Status.ConductorServiceReadyCount).To(Equal(int32(0)))
 			Expect(instance.Status.MetadataServiceReadyCount).To(Equal(int32(0)))
 			Expect(instance.Status.NoVNCPRoxyServiceReadyCount).To(Equal(int32(0)))
-			Expect(instance.Status.NovaComputesStatus).To(HaveLen(int(0)))
+			Expect(instance.Status.NovaComputesStatus).To(BeEmpty())
 		})
 	})
 


### PR DESCRIPTION
* bump in go.mod (base and api)
* bump go-toolset in Dockerfile
* bump in github jobs ('.github/workflows')
* Bump the golangci-lint version in the .pre-commit-config.yaml to v1.63.4
* Bump build_root_image in .ci-operator.yaml to ci-build-root-golang-1.22-sdk-1.31 (if set)

To test on existing env:
* update golang to 1.22
* delete current `go.work*` files
* init go work files `go work init`

Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/1051
Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/1411

Jira: [OSPRH-12935](https://issues.redhat.com//browse/OSPRH-12935)