### PR TITLE
Removed duplicate code for NovaCreateSecret

### DIFF
--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -21,12 +21,13 @@ import (
 
 	. "github.com/onsi/gomega" //revive:disable:dot-imports
 
+	"maps"
+
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
-	"maps"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
@@ -277,16 +278,6 @@ func NovaCellConditionGetter(name types.NamespacedName) condition.Conditions {
 }
 
 func CreateNovaSecret(namespace string, name string) *corev1.Secret {
-	return th.CreateSecret(
-		types.NamespacedName{Namespace: namespace, Name: name},
-		map[string][]byte{
-			"NovaPassword":   []byte("service-password"),
-			"MetadataSecret": []byte("metadata-secret"),
-		},
-	)
-}
-
-func CreateNovaSecretFor3Cells(namespace string, name string) *corev1.Secret {
 	return th.CreateSecret(
 		types.NamespacedName{Namespace: namespace, Name: name},
 		map[string][]byte{

--- a/test/functional/nova_multicell_test.go
+++ b/test/functional/nova_multicell_test.go
@@ -59,7 +59,8 @@ var _ = Describe("Nova multi cell", func() {
 	When("Nova CR instance is created with 3 cells", func() {
 		BeforeEach(func() {
 			// TODO(bogdando): deduplicate this into CreateNovaWith3CellsAndEnsureReady()
-			DeferCleanup(k8sClient.Delete, ctx, CreateNovaSecretFor3Cells(novaNames.NovaName.Namespace, SecretName))
+			// DeferCleanup(k8sClient.Delete, ctx, CreateNovaSecretFor3Cells(novaNames.NovaName.Namespace, SecretName))
+			DeferCleanup(k8sClient.Delete, ctx, CreateNovaSecret(novaNames.NovaName.Namespace, SecretName))
 			DeferCleanup(k8sClient.Delete, ctx, CreateNovaMessageBusSecret(cell0))
 			DeferCleanup(k8sClient.Delete, ctx, CreateNovaMessageBusSecret(cell1))
 			DeferCleanup(k8sClient.Delete, ctx, CreateNovaMessageBusSecret(cell2))


### PR DESCRIPTION
both function are creating single NovaSecret, 
`CreateNovaSecret` is created/updated later but used in many places.

originally when `CreateNovaSecret` was created [1] it had more fields, later secret creation moved to lib-common test helper, as of today it same as `CreateNovaSecretFor3Cells`.
CreateNovaSecretFor3Cells  is used in one place.

[1] https://github.com/openstack-k8s-operators/nova-operator/commit/694374e44906db8adf8f1e8d4030291e643e8b8a