### PR TITLE
Use GetDefaultMemcachedSpec test helper from infra-operator

### DIFF
--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -27,10 +27,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
 	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	novav1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
@@ -708,14 +706,6 @@ func AssertMetadataDoesNotExist(name types.NamespacedName) {
 		err := k8sClient.Get(ctx, name, instance)
 		g.Expect(k8s_errors.IsNotFound(err)).To(BeTrue())
 	}, timeout, interval).Should(Succeed())
-}
-
-func GetDefaultMemcachedSpec() memcachedv1.MemcachedSpec {
-	return memcachedv1.MemcachedSpec{
-		MemcachedSpecCore: memcachedv1.MemcachedSpecCore{
-			Replicas: ptr.To(int32(3)),
-		},
-	}
 }
 
 func CreateNovaNoVNCProxy(name types.NamespacedName, spec map[string]interface{}) client.Object {

--- a/test/functional/nova_controller_test.go
+++ b/test/functional/nova_controller_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Nova controller", func() {
 					},
 				),
 			)
-			memcachedSpec := GetDefaultMemcachedSpec()
+			memcachedSpec := infra.GetDefaultMemcachedSpec()
 
 			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 			infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)
@@ -517,7 +517,7 @@ var _ = Describe("Nova controller", func() {
 				),
 			)
 
-			memcachedSpec := GetDefaultMemcachedSpec()
+			memcachedSpec := infra.GetDefaultMemcachedSpec()
 
 			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 			infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)
@@ -589,7 +589,7 @@ var _ = Describe("Nova controller", func() {
 					},
 				),
 			)
-			memcachedSpec := GetDefaultMemcachedSpec()
+			memcachedSpec := infra.GetDefaultMemcachedSpec()
 
 			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 			infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)
@@ -653,7 +653,7 @@ var _ = Describe("Nova controller", func() {
 					},
 				),
 			)
-			memcachedSpec := GetDefaultMemcachedSpec()
+			memcachedSpec := infra.GetDefaultMemcachedSpec()
 
 			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 			infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)
@@ -806,7 +806,7 @@ var _ = Describe("Nova controller", func() {
 					},
 				),
 			)
-			memcachedSpec := GetDefaultMemcachedSpec()
+			memcachedSpec := infra.GetDefaultMemcachedSpec()
 
 			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 			infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)
@@ -877,7 +877,7 @@ var _ = Describe("Nova controller", func() {
 					},
 				),
 			)
-			memcachedSpec := GetDefaultMemcachedSpec()
+			memcachedSpec := infra.GetDefaultMemcachedSpec()
 
 			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 			infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)
@@ -994,7 +994,7 @@ var _ = Describe("Nova controller", func() {
 				),
 			)
 
-			memcachedSpec := GetDefaultMemcachedSpec()
+			memcachedSpec := infra.GetDefaultMemcachedSpec()
 			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 			infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)
 
@@ -1065,7 +1065,7 @@ var _ = Describe("Nova controller", func() {
 				),
 			)
 
-			memcachedSpec := GetDefaultMemcachedSpec()
+			memcachedSpec := infra.GetDefaultMemcachedSpec()
 			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 			infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)
 
@@ -1212,7 +1212,7 @@ var _ = Describe("Nova controller", func() {
 			// except cell1 that has an override
 			spec["topologyRef"] = map[string]interface{}{"name": topologyRefTopLevel.Name}
 			DeferCleanup(th.DeleteInstance, CreateNova(novaNames.NovaName, spec))
-			memcachedSpec := GetDefaultMemcachedSpec()
+			memcachedSpec := infra.GetDefaultMemcachedSpec()
 			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 			infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)
 			keystoneAPIName := keystone.CreateKeystoneAPI(novaNames.NovaName.Namespace)
@@ -1342,7 +1342,7 @@ var _ = Describe("Nova controller", func() {
 					},
 				),
 			)
-			memcachedSpec := GetDefaultMemcachedSpec()
+			memcachedSpec := infra.GetDefaultMemcachedSpec()
 
 			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 			infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)
@@ -1427,7 +1427,7 @@ var _ = Describe("Nova controller", func() {
 				),
 			)
 
-			memcachedSpec := GetDefaultMemcachedSpec()
+			memcachedSpec := infra.GetDefaultMemcachedSpec()
 			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 			infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)
 
@@ -1531,7 +1531,7 @@ var _ = Describe("Nova controller", func() {
 				),
 			)
 
-			memcachedSpec := GetDefaultMemcachedSpec()
+			memcachedSpec := infra.GetDefaultMemcachedSpec()
 			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 			infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)
 

--- a/test/functional/nova_metadata_controller_test.go
+++ b/test/functional/nova_metadata_controller_test.go
@@ -56,7 +56,7 @@ var _ = Describe("NovaMetadata controller", func() {
 		DeferCleanup(k8sClient.Delete, ctx, cell1Secret)
 
 		mariadb.CreateMariaDBDatabase(novaNames.APIMariaDBDatabaseName.Namespace, novaNames.APIMariaDBDatabaseName.Name, mariadbv1.MariaDBDatabaseSpec{})
-		memcachedSpec := GetDefaultMemcachedSpec()
+		memcachedSpec := infra.GetDefaultMemcachedSpec()
 		DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 		infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)
 		DeferCleanup(k8sClient.Delete, ctx, mariadb.GetMariaDBDatabase(novaNames.APIMariaDBDatabaseName))
@@ -395,7 +395,7 @@ var _ = Describe("NovaMetadata controller", func() {
 		DeferCleanup(k8sClient.Delete, ctx, cell1Account)
 		DeferCleanup(k8sClient.Delete, ctx, cell1Secret)
 
-		memcachedSpec := GetDefaultMemcachedSpec()
+		memcachedSpec := infra.GetDefaultMemcachedSpec()
 		DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 		infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)
 
@@ -868,7 +868,7 @@ var _ = Describe("NovaMetadata controller", func() {
 
 		mariadb.SimulateMariaDBTLSDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
 		mariadb.SimulateMariaDBAccountCompleted(novaNames.APIMariaDBDatabaseAccount)
-		memcachedSpec := GetDefaultMemcachedSpec()
+		memcachedSpec := infra.GetDefaultMemcachedSpec()
 		DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 		infra.SimulateTLSMemcachedReady(novaNames.MemcachedNamespace)
 

--- a/test/functional/nova_multicell_test.go
+++ b/test/functional/nova_multicell_test.go
@@ -108,7 +108,7 @@ var _ = Describe("Nova multi cell", func() {
 
 			DeferCleanup(th.DeleteInstance, CreateNova(novaNames.NovaName, spec))
 			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(novaNames.NovaName.Namespace))
-			memcachedSpecCell1 := GetDefaultMemcachedSpec()
+			memcachedSpecCell1 := infra.GetDefaultMemcachedSpec()
 			memcachedNamespace := types.NamespacedName{
 				Name:      cell1Memcached,
 				Namespace: novaNames.NovaName.Namespace,
@@ -116,7 +116,7 @@ var _ = Describe("Nova multi cell", func() {
 			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, cell1Memcached, memcachedSpecCell1))
 			infra.SimulateMemcachedReady(memcachedNamespace)
 
-			memcachedSpec := GetDefaultMemcachedSpec()
+			memcachedSpec := infra.GetDefaultMemcachedSpec()
 
 			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 			infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)
@@ -686,7 +686,7 @@ var _ = Describe("Nova multi cell", func() {
 			spec["apiMessageBusInstance"] = cell0.TransportURLName.Name
 
 			DeferCleanup(th.DeleteInstance, CreateNova(novaNames.NovaName, spec))
-			memcachedSpec := GetDefaultMemcachedSpec()
+			memcachedSpec := infra.GetDefaultMemcachedSpec()
 
 			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 			infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)
@@ -800,7 +800,7 @@ var _ = Describe("Nova multi cell", func() {
 			spec["apiMessageBusInstance"] = cell0.TransportURLName.Name
 
 			DeferCleanup(th.DeleteInstance, CreateNova(novaNames.NovaName, spec))
-			memcachedSpec := GetDefaultMemcachedSpec()
+			memcachedSpec := infra.GetDefaultMemcachedSpec()
 
 			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 			infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)
@@ -865,7 +865,7 @@ var _ = Describe("Nova multi cell", func() {
 			spec["apiMessageBusInstance"] = cell0.TransportURLName.Name
 
 			DeferCleanup(th.DeleteInstance, CreateNova(novaNames.NovaName, spec))
-			memcachedSpec := GetDefaultMemcachedSpec()
+			memcachedSpec := infra.GetDefaultMemcachedSpec()
 
 			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 			infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)
@@ -1027,7 +1027,7 @@ func CreateNovaWith4CellsAndEnsureReady(novaNames NovaNames) {
 
 	DeferCleanup(th.DeleteInstance, CreateNova(novaNames.NovaName, spec))
 	DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(novaNames.NovaName.Namespace))
-	memcachedSpec := GetDefaultMemcachedSpec()
+	memcachedSpec := infra.GetDefaultMemcachedSpec()
 
 	DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 	infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)

--- a/test/functional/nova_novncproxy_test.go
+++ b/test/functional/nova_novncproxy_test.go
@@ -52,7 +52,7 @@ var _ = Describe("NovaNoVNCProxy controller", func() {
 			cell1.MariaDBAccountName, mariadbv1.MariaDBAccountSpec{})
 		DeferCleanup(k8sClient.Delete, ctx, cell1Account)
 		DeferCleanup(k8sClient.Delete, ctx, cell1Secret)
-		memcachedSpec := GetDefaultMemcachedSpec()
+		memcachedSpec := infra.GetDefaultMemcachedSpec()
 		DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 		infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)
 
@@ -349,7 +349,7 @@ var _ = Describe("NovaNoVNCProxy controller", func() {
 		DeferCleanup(k8sClient.Delete, ctx, cell1Account)
 		DeferCleanup(k8sClient.Delete, ctx, cell1Secret)
 
-		memcachedSpec := GetDefaultMemcachedSpec()
+		memcachedSpec := infra.GetDefaultMemcachedSpec()
 		DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 		infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)
 
@@ -768,7 +768,7 @@ var _ = Describe("NovaNoVNCProxy controller", func() {
 				},
 				"caBundleSecretName": novaNames.CaBundleSecretName.Name,
 			}
-			memcachedSpec := GetDefaultMemcachedSpec()
+			memcachedSpec := infra.GetDefaultMemcachedSpec()
 
 			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 			infra.SimulateTLSMemcachedReady(novaNames.MemcachedNamespace)
@@ -930,7 +930,7 @@ var _ = Describe("NovaNoVNCProxy controller", func() {
 				},
 				"caBundleSecretName": novaNames.CaBundleSecretName.Name,
 			}
-			memcachedSpec := GetDefaultMemcachedSpec()
+			memcachedSpec := infra.GetDefaultMemcachedSpec()
 
 			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 			infra.SimulateTLSMemcachedReady(novaNames.MemcachedNamespace)
@@ -1095,7 +1095,7 @@ var _ = Describe("NovaNoVNCProxy controller", func() {
 				},
 				"caBundleSecretName": novaNames.CaBundleSecretName.Name,
 			}
-			memcachedSpec := GetDefaultMemcachedSpec()
+			memcachedSpec := infra.GetDefaultMemcachedSpec()
 
 			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 			infra.SimulateTLSMemcachedReady(novaNames.MemcachedNamespace)
@@ -1280,7 +1280,7 @@ var _ = Describe("NovaNoVNCProxy controller", func() {
 			// We reference a topology that does not exist in the current namespace
 			spec["topologyRef"] = map[string]interface{}{"name": "foo"}
 
-			memcachedSpec := GetDefaultMemcachedSpec()
+			memcachedSpec := infra.GetDefaultMemcachedSpec()
 			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 			DeferCleanup(th.DeleteInstance, CreateNovaNoVNCProxy(cell1.NoVNCProxyName, spec))
 			DeferCleanup(
@@ -1319,7 +1319,7 @@ var _ = Describe("NovaNoVNCProxy controller", func() {
 			spec := GetDefaultNovaNoVNCProxySpec(cell1)
 			spec["topologyRef"] = map[string]interface{}{"name": topologyRefNoVNC.Name}
 
-			memcachedSpec := GetDefaultMemcachedSpec()
+			memcachedSpec := infra.GetDefaultMemcachedSpec()
 			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 			DeferCleanup(th.DeleteInstance, CreateNovaNoVNCProxy(cell1.NoVNCProxyName, spec))
 			DeferCleanup(

--- a/test/functional/nova_reconfiguration_test.go
+++ b/test/functional/nova_reconfiguration_test.go
@@ -108,7 +108,7 @@ func CreateNovaWith3CellsAndEnsureReady(novaNames NovaNames) {
 
 	DeferCleanup(th.DeleteInstance, CreateNova(novaNames.NovaName, spec))
 	DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(novaNames.NovaName.Namespace))
-	memcachedSpec := GetDefaultMemcachedSpec()
+	memcachedSpec := infra.GetDefaultMemcachedSpec()
 
 	DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 	infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)

--- a/test/functional/nova_scheduler_test.go
+++ b/test/functional/nova_scheduler_test.go
@@ -52,7 +52,7 @@ var _ = Describe("NovaScheduler controller", func() {
 		// Uncomment this if you need the full output in the logs from gomega
 		// matchers
 		// format.MaxLength = 0
-		memcachedSpec := GetDefaultMemcachedSpec()
+		memcachedSpec := infra.GetDefaultMemcachedSpec()
 		DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 		infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)
 		DeferCleanup(
@@ -323,7 +323,7 @@ var _ = Describe("NovaScheduler controller", func() {
 			cell0.MariaDBAccountName, mariadbv1.MariaDBAccountSpec{})
 		DeferCleanup(k8sClient.Delete, ctx, cell0Account)
 		DeferCleanup(k8sClient.Delete, ctx, cell0Secret)
-		memcachedSpec := GetDefaultMemcachedSpec()
+		memcachedSpec := infra.GetDefaultMemcachedSpec()
 		DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 		infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)
 
@@ -601,7 +601,7 @@ var _ = Describe("NovaScheduler controller cleaning", func() {
 
 	var novaAPIFixture *NovaAPIFixture
 	BeforeEach(func() {
-		memcachedSpec := GetDefaultMemcachedSpec()
+		memcachedSpec := infra.GetDefaultMemcachedSpec()
 		DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 		infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)
 		DeferCleanup(
@@ -653,7 +653,7 @@ var _ = Describe("NovaScheduler controller", func() {
 		DeferCleanup(k8sClient.Delete, ctx, cell0Account)
 		DeferCleanup(k8sClient.Delete, ctx, cell0Secret)
 
-		memcachedSpec := GetDefaultMemcachedSpec()
+		memcachedSpec := infra.GetDefaultMemcachedSpec()
 		DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 		infra.SimulateTLSMemcachedReady(novaNames.MemcachedNamespace)
 	})

--- a/test/functional/novaapi_controller_test.go
+++ b/test/functional/novaapi_controller_test.go
@@ -50,7 +50,7 @@ var _ = Describe("NovaAPI controller", func() {
 			cell0.MariaDBAccountName, mariadbv1.MariaDBAccountSpec{})
 		DeferCleanup(k8sClient.Delete, ctx, cell0Account)
 		DeferCleanup(k8sClient.Delete, ctx, cell0Secret)
-		memcachedSpec := GetDefaultMemcachedSpec()
+		memcachedSpec := infra.GetDefaultMemcachedSpec()
 		DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 		infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)
 	})
@@ -432,7 +432,7 @@ var _ = Describe("NovaAPI controller", func() {
 			cell0.MariaDBAccountName, mariadbv1.MariaDBAccountSpec{})
 		DeferCleanup(k8sClient.Delete, ctx, cell0Account)
 		DeferCleanup(k8sClient.Delete, ctx, cell0Secret)
-		memcachedSpec := GetDefaultMemcachedSpec()
+		memcachedSpec := infra.GetDefaultMemcachedSpec()
 		DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 		infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)
 
@@ -902,7 +902,7 @@ var _ = Describe("NovaAPI controller", func() {
 		DeferCleanup(k8sClient.Delete, ctx, cell0Account)
 		DeferCleanup(k8sClient.Delete, ctx, cell0Secret)
 
-		memcachedSpec := GetDefaultMemcachedSpec()
+		memcachedSpec := infra.GetDefaultMemcachedSpec()
 		DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 		infra.SimulateTLSMemcachedReady(novaNames.MemcachedNamespace)
 	})

--- a/test/functional/novacell_controller_test.go
+++ b/test/functional/novacell_controller_test.go
@@ -57,7 +57,7 @@ var _ = Describe("NovaCell controller", func() {
 		DeferCleanup(k8sClient.Delete, ctx, cell2Account)
 		DeferCleanup(k8sClient.Delete, ctx, cell2Secret)
 
-		memcachedSpec := GetDefaultMemcachedSpec()
+		memcachedSpec := infra.GetDefaultMemcachedSpec()
 		DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 		infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)
 	})
@@ -1063,7 +1063,7 @@ var _ = Describe("NovaCell controller", func() {
 
 var _ = Describe("NovaCell controller webhook", func() {
 	BeforeEach(func() {
-		memcachedSpec := GetDefaultMemcachedSpec()
+		memcachedSpec := infra.GetDefaultMemcachedSpec()
 		DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 		infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)
 

--- a/test/functional/novaconductor_controller_test.go
+++ b/test/functional/novaconductor_controller_test.go
@@ -50,7 +50,7 @@ var _ = Describe("NovaConductor controller", func() {
 		DeferCleanup(k8sClient.Delete, ctx, cell0Account)
 		DeferCleanup(k8sClient.Delete, ctx, cell0Secret)
 
-		memcachedSpec := GetDefaultMemcachedSpec()
+		memcachedSpec := infra.GetDefaultMemcachedSpec()
 		DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 		infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)
 
@@ -488,7 +488,7 @@ var _ = Describe("NovaConductor controller", func() {
 		DeferCleanup(k8sClient.Delete, ctx, cell0Account)
 		DeferCleanup(k8sClient.Delete, ctx, cell0Secret)
 
-		memcachedSpec := GetDefaultMemcachedSpec()
+		memcachedSpec := infra.GetDefaultMemcachedSpec()
 		DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 		infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)
 	})
@@ -939,7 +939,7 @@ var _ = Describe("NovaConductor controller cleaning", func() {
 		mariadb.CreateMariaDBDatabase(cell0.MariaDBDatabaseName.Namespace, cell0.MariaDBDatabaseName.Name, mariadbv1.MariaDBDatabaseSpec{})
 		DeferCleanup(k8sClient.Delete, ctx, mariadb.GetMariaDBDatabase(cell0.MariaDBDatabaseName))
 
-		memcachedSpec := GetDefaultMemcachedSpec()
+		memcachedSpec := infra.GetDefaultMemcachedSpec()
 		DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 		infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)
 
@@ -990,7 +990,7 @@ var _ = Describe("NovaConductor controller", func() {
 
 		mariadb.CreateMariaDBDatabase(cell0.MariaDBDatabaseName.Namespace, cell0.MariaDBDatabaseName.Name, mariadbv1.MariaDBDatabaseSpec{})
 		mariadb.SimulateMariaDBTLSDatabaseCompleted(cell0.MariaDBDatabaseName)
-		memcachedSpec := GetDefaultMemcachedSpec()
+		memcachedSpec := infra.GetDefaultMemcachedSpec()
 		DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 		infra.SimulateTLSMemcachedReady(novaNames.MemcachedNamespace)
 	})


### PR DESCRIPTION
This change uses GetDefaultMemcachedSpec test helper from infra-operator to reduce code duplication.