### PR TITLE
Set mkisofs_cmd to mkisofs in default config

### DIFF
--- a/templates/nova.conf
+++ b/templates/nova.conf
@@ -30,6 +30,7 @@ initial_ram_allocation_ratio=1.0
 initial_disk_allocation_ratio=0.9
 {{/*using a config drive will void issues with ovn and metadata*/}}
 force_config_drive=True
+mkisofs_cmd=/usr/bin/mkisofs
 {{end}}
 {{ if (index . "transport_url") }}
 transport_url={{.transport_url}}


### PR DESCRIPTION
CS10 EDPM job watcher tempest tests fails while creating server with `No such file or directory: 'genisoimage'`.
    
mkisofs_cmd config option sets the genisoimage, is default in the nova config.
    
In RHEL-10, we use xorriso package not genisoimage. mkisofs is used in Nova conf[1]. We need to set the same in nova config so that instances gets created.
    
This pr sets the proper mkisofs_cmd to fix the issue.

Testresults: https://github.com/openstack-k8s-operators/watcher-operator/pull/159#issuecomment-2886479601
    
Jira: [OSPRH-16715](https://issues.redhat.com//browse/OSPRH-16715)
    
Links:
[1]. https://github.com/rdo-packages/nova-distgit/commit/702f2fbf0ef344b594d89448e4d06ae3edb42dd6
