### PR TITLE
Replace deprecated 'cifmw_test_operator_concurrency'

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -65,7 +65,7 @@
         - "@scenarios/centos-9/multinode-ci.yml"
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/nova-operator'].src_dir }}/ci/nova-operator-tempest-multinode/ci_fw_vars.yaml"
       cifmw_run_test_role: test_operator
-      cifmw_test_operator_concurrency: 4
+      cifmw_test_operator_tempest_concurrency: 4
       cifmw_test_operator_timeout: 7200
       cifmw_test_operator_tempest_network_attachments:
         - ctlplane
@@ -125,7 +125,7 @@
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/nova-operator'].src_dir }}/ci/nova-operator-tempest-multinode-ceph/ci_fw_vars.yaml"
       # dedupe this later
       cifmw_run_test_role: test_operator
-      cifmw_test_operator_concurrency: 4
+      cifmw_test_operator_tempest_concurrency: 4
       cifmw_test_operator_timeout: 7200
       cifmw_test_operator_tempest_network_attachments:
         - ctlplane


### PR DESCRIPTION
Replace deprecated 'cifmw_test_operator_concurrency' with 'cifmw_test_operator_tempest_concurrency'
This aligns with the DoD described in https://issues.redhat.com/browse/OSPRH-16755