### PR TITLE
Remove no longer relevant comment

### DIFF
--- a/controllers/novametadata_controller.go
+++ b/controllers/novametadata_controller.go
@@ -345,8 +345,6 @@ func (r *NovaMetadataReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, nil
 	}
 
-	// TODO(gibi): fix lib-common endpoint.ExposeEndpoints return value to
-	// avoid the need for the cast
 	err = r.ensureNeutronConfig(ctx, h, instance, apiEndpoint, secret)
 	if err != nil {
 		return result, err


### PR DESCRIPTION
This change removes comment, as it is no longer relevant after fixing it by pull request
https://github.com/openstack-k8s-operators/nova-operator/pull/522/