### PR TITLE
[OSPRH-19301] Remove deprecated Kustomize fields in config dir

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -12,27 +12,27 @@ resources:
 - bases/nova.openstack.org_novacomputes.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
+patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-#- patches/webhook_in_novaapis.yaml
-#- patches/webhook_in_novaschedulers.yaml
-#- patches/webhook_in_novaconductors.yaml
-#- patches/webhook_in_novametadata.yaml
-#- patches/webhook_in_novanovncproxies.yaml
-#- patches/webhook_in_novacells.yaml
-#- patches/webhook_in_nova.yaml
+#- path: patches/webhook_in_novaapis.yaml
+#- path: patches/webhook_in_novaschedulers.yaml
+#- path: patches/webhook_in_novaconductors.yaml
+#- path: patches/webhook_in_novametadata.yaml
+#- path: patches/webhook_in_novanovncproxies.yaml
+#- path: patches/webhook_in_novacells.yaml
+#- path: patches/webhook_in_nova.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-#- patches/cainjection_in_novaapis.yaml
-#- patches/cainjection_in_novaschedulers.yaml
-#- patches/cainjection_in_novaconductors.yaml
-#- patches/cainjection_in_novametadata.yaml
-#- patches/cainjection_in_novanovncproxies.yaml
-#- patches/cainjection_in_novacells.yaml
-#- patches/cainjection_in_nova.yaml
+#- path: patches/cainjection_in_novaapis.yaml
+#- path: patches/cainjection_in_novaschedulers.yaml
+#- path: patches/cainjection_in_novaconductors.yaml
+#- path: patches/cainjection_in_novametadata.yaml
+#- path: patches/cainjection_in_novanovncproxies.yaml
+#- path: patches/cainjection_in_novacells.yaml
+#- path: patches/cainjection_in_nova.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -12,7 +12,7 @@ namePrefix: nova-operator-
 #commonLabels:
 #  someName: someValue
 
-bases:
+resources:
 - ../crd
 - ../rbac
 - ../manager
@@ -24,27 +24,27 @@ bases:
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
-patchesStrategicMerge:
+patches:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
-- manager_auth_proxy_patch.yaml
+- path: manager_auth_proxy_patch.yaml
 
 # Mount the controller config file for loading manager configurations
 # through a ComponentConfig type
-#- manager_config_patch.yaml
+#- path: manager_config_patch.yaml
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-- manager_webhook_patch.yaml
+- path: manager_webhook_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
-#- webhookcainjection_patch.yaml
+#- path: webhookcainjection_patch.yaml
 
 # Injects our custom images (ENV variable settings)
-- manager_default_images.yaml
+- path: manager_default_images.yaml
 
 # the following config is for teaching kustomize how to do var substitution
 vars:

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
 # [WEBHOOK] To enable webhooks, uncomment all the sections with [WEBHOOK] prefix.
 # Do NOT uncomment sections with prefix [CERTMANAGER], as OLM does not support cert-manager.
 # These patches remove the unnecessary "cert" volume and its manager container volumeMount.
-#patchesJson6902:
+#patches:
 #- target:
 #    group: apps
 #    version: v1

--- a/config/scorecard/kustomization.yaml
+++ b/config/scorecard/kustomization.yaml
@@ -1,6 +1,6 @@
 resources:
 - bases/config.yaml
-patchesJson6902:
+patches:
 - path: patches/basic.config.yaml
   target:
     group: scorecard.operatorframework.io
@@ -13,4 +13,4 @@ patchesJson6902:
     version: v1alpha3
     kind: Configuration
     name: config
-#+kubebuilder:scaffold:patchesJson6902
+#+kubebuilder:scaffold:patches


### PR DESCRIPTION
Update all deprecated Kustomize fields to their modern equivalents across the config directory to ensure compatibility with Kustomize v5.3+ and future versions.

Changes made:

config/default/kustomization.yaml:
- Replace 'bases:' with 'resources:'
- Replace 'patchesStrategicMerge:' with 'patches:'
- Convert patch entries to use 'path:' format

config/crd/kustomization.yaml:
- Replace 'patchesStrategicMerge:' with 'patches:'
- Update commented patch entries to use 'path:' format for both webhook and cainjection patches

config/manifests/kustomization.yaml:
- Replace commented '#patchesJson6902:' with '#patches:'

config/scorecard/kustomization.yaml:
- Replace 'patchesJson6902:' with 'patches:'
- Update kubebuilder scaffold comment from 'patchesJson6902' to 'patches'

These changes eliminate deprecation warnings and align with the modern Kustomize field syntax while maintaining full backward compatibility. The modernization follows patterns established by other OpenStack K8s operators and industry best practices.

Jira: https://issues.redhat.com/browse/OSPRH-19301

Co-authored-by: Claude [claude@anthropic.com](mailto:claude@anthropic.com)