### PR TITLE
refactor: use GetKeystoneAPIByName instead of label-based lookup

### DIFF
--- a/controllers/nova_controller.go
+++ b/controllers/nova_controller.go
@@ -1649,10 +1649,7 @@ func (r *NovaReconciler) getKeystoneAuthURL(
 	h *helper.Helper,
 	instance *novav1.Nova,
 ) (string, string, error) {
-	// TODO(gibi): change lib-common to take the name of the KeystoneAPI as
-	// parameter instead of labels. Then use instance.Spec.KeystoneInstance as
-	// the name.
-	keystoneAPI, err := keystonev1.GetKeystoneAPI(ctx, h, instance.Namespace, map[string]string{})
+	keystoneAPI, err := keystonev1.GetKeystoneAPIByName(ctx, h, instance.Spec.KeystoneInstance, instance.Namespace)
 	if err != nil {
 		return "", "", err
 	}

--- a/go.mod
+++ b/go.mod
@@ -87,6 +87,8 @@ require (
 
 replace github.com/openstack-k8s-operators/nova-operator/api => ./api
 
+replace github.com/openstack-k8s-operators/keystone-operator/api => github.com/openstack-k8s-operators/keystone-operator/api v0.6.1-0.20250818061624-cbdfd1f68df8 //allow-merging
+
 // mschuppert: map to latest commit from release-4.16 tag
 // must consistent within modules and service operators
 replace github.com/openshift/api => github.com/openshift/api v0.0.0-20240830023148-b7d0481c9094 //allow-merging

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/openshift/api v0.0.0-20240830023148-b7d0481c9094 h1:J1wuGhVxpsHykZBa6
 github.com/openshift/api v0.0.0-20240830023148-b7d0481c9094/go.mod h1:CxgbWAlvu2iQB0UmKTtRu1YfepRg1/vJ64n2DlIEVz4=
 github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20250813063935-fdc20530dcf1 h1:77TRnwfSxNI5cn/RxMS9I+kqefMm7XRQsNknIhEE4tg=
 github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20250813063935-fdc20530dcf1/go.mod h1:Dv8qpmBIQy3Jv/EyQnOyc0w61X8vyfxpjcIQONP5CwY=
-github.com/openstack-k8s-operators/keystone-operator/api v0.6.1-0.20250811083324-e790d63f389f h1:Ivo4YKaH26B1lQlwKcolELCRGtEbmvbfJShBTVrCdQI=
-github.com/openstack-k8s-operators/keystone-operator/api v0.6.1-0.20250811083324-e790d63f389f/go.mod h1:H5iZOohoVOmZvIZPR5ep6z+jmfrpz25axOM6IXlXzNU=
+github.com/openstack-k8s-operators/keystone-operator/api v0.6.1-0.20250818061624-cbdfd1f68df8 h1:1r3wSalcW2TY8K3X6j5cL0M9MgJDCI1nZ7tHne/Izlg=
+github.com/openstack-k8s-operators/keystone-operator/api v0.6.1-0.20250818061624-cbdfd1f68df8/go.mod h1:H5iZOohoVOmZvIZPR5ep6z+jmfrpz25axOM6IXlXzNU=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20250730071847-837b07f8d72f h1:DW8aNjEtDFrWiZ6vWuOXwdRB4eBD0n+bA9foQkOEx6U=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20250730071847-837b07f8d72f/go.mod h1:P+7F1wiwZUxOy4myYXFyc/uBtGATDFpk3yAllXe1Vzk=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.6.1-0.20250730071847-837b07f8d72f h1:nGYLHcpM7EjiSzN4bmiLZbxty9u0k0Qzvkqn+1s1TF0=

--- a/test/functional/nova_multicell_test.go
+++ b/test/functional/nova_multicell_test.go
@@ -98,6 +98,10 @@ var _ = Describe("Nova multi cell", func() {
 				"database": "NovaCell2DatabasePassword",
 			}
 
+			// Create KeystoneAPI first to get the correct name
+			keystoneAPIName := keystone.CreateKeystoneAPI(novaNames.NovaName.Namespace)
+			DeferCleanup(keystone.DeleteKeystoneAPI, keystoneAPIName)
+
 			spec["cellTemplates"] = map[string]interface{}{
 				"cell0": cell0Template,
 				"cell1": cell1Template,
@@ -105,9 +109,9 @@ var _ = Describe("Nova multi cell", func() {
 			}
 			spec["apiDatabaseInstance"] = novaNames.APIMariaDBDatabaseName.Name
 			spec["apiMessageBusInstance"] = cell0.TransportURLName.Name
+			spec["keystoneInstance"] = keystoneAPIName.Name
 
 			DeferCleanup(th.DeleteInstance, CreateNova(novaNames.NovaName, spec))
-			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(novaNames.NovaName.Namespace))
 			memcachedSpecCell1 := infra.GetDefaultMemcachedSpec()
 			memcachedNamespace := types.NamespacedName{
 				Name:      cell1Memcached,
@@ -678,19 +682,23 @@ var _ = Describe("Nova multi cell", func() {
 			cell1Template["cellMessageBusInstance"] = cell0.TransportURLName.Name
 			cell1Template["hasAPIAccess"] = true
 
+			// Create KeystoneAPI first to get the correct name
+			keystoneAPIName := keystone.CreateKeystoneAPI(novaNames.NovaName.Namespace)
+			DeferCleanup(keystone.DeleteKeystoneAPI, keystoneAPIName)
+
 			spec["cellTemplates"] = map[string]interface{}{
 				"cell0": cell0Template,
 				"cell1": cell1Template,
 			}
 			spec["apiDatabaseInstance"] = novaNames.APIMariaDBDatabaseName.Name
 			spec["apiMessageBusInstance"] = cell0.TransportURLName.Name
+			spec["keystoneInstance"] = keystoneAPIName.Name
 
 			DeferCleanup(th.DeleteInstance, CreateNova(novaNames.NovaName, spec))
 			memcachedSpec := infra.GetDefaultMemcachedSpec()
 
 			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 			infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)
-			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(novaNames.NovaName.Namespace))
 			keystone.SimulateKeystoneServiceReady(novaNames.KeystoneServiceName)
 
 		})
@@ -792,19 +800,23 @@ var _ = Describe("Nova multi cell", func() {
 			cell1Template["cellDatabaseAccount"] = cell1.MariaDBAccountName.Name
 			cell1Template["cellMessageBusInstance"] = cell1.TransportURLName.Name
 
+			// Create KeystoneAPI first to get the correct name
+			keystoneAPIName := keystone.CreateKeystoneAPI(novaNames.Namespace)
+			DeferCleanup(keystone.DeleteKeystoneAPI, keystoneAPIName)
+
 			spec["cellTemplates"] = map[string]interface{}{
 				"cell0": cell0Template,
 				"cell1": cell1Template,
 			}
 			spec["apiDatabaseInstance"] = novaNames.APIMariaDBDatabaseName.Name
 			spec["apiMessageBusInstance"] = cell0.TransportURLName.Name
+			spec["keystoneInstance"] = keystoneAPIName.Name
 
 			DeferCleanup(th.DeleteInstance, CreateNova(novaNames.NovaName, spec))
 			memcachedSpec := infra.GetDefaultMemcachedSpec()
 
 			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 			infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)
-			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(novaNames.Namespace))
 			keystone.SimulateKeystoneServiceReady(novaNames.KeystoneServiceName)
 		})
 
@@ -858,19 +870,22 @@ var _ = Describe("Nova multi cell", func() {
 				"cell0": cell0Template,
 				"cell1": cell1Template,
 			}
+			// Create KeystoneAPI first to get the correct name
+			keystoneAPIName := keystone.CreateKeystoneAPI(novaNames.NovaName.Namespace)
+			DeferCleanup(keystone.DeleteKeystoneAPI, keystoneAPIName)
+
 			spec["metadataServiceTemplate"] = map[string]interface{}{
 				"enabled": false,
 			}
 			spec["apiDatabaseInstance"] = novaNames.APIMariaDBDatabaseName.Name
 			spec["apiMessageBusInstance"] = cell0.TransportURLName.Name
+			spec["keystoneInstance"] = keystoneAPIName.Name
 
 			DeferCleanup(th.DeleteInstance, CreateNova(novaNames.NovaName, spec))
 			memcachedSpec := infra.GetDefaultMemcachedSpec()
 
 			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
 			infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)
-			keystoneAPIName := keystone.CreateKeystoneAPI(novaNames.NovaName.Namespace)
-			DeferCleanup(keystone.DeleteKeystoneAPI, keystoneAPIName)
 			keystoneAPI := keystone.GetKeystoneAPI(keystoneAPIName)
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Status().Update(ctx, keystoneAPI.DeepCopy())).Should(Succeed())

--- a/test/functional/nova_reconfiguration_test.go
+++ b/test/functional/nova_reconfiguration_test.go
@@ -1060,7 +1060,11 @@ var _ = Describe("Nova reconfiguration", func() {
 	It("updates the KeystoneAuthURL of the sub components if keystone internal endpoint changes", func() {
 		newInternalEndpoint := "https://keystone-internal"
 
-		keystone.UpdateKeystoneAPIEndpoint(novaNames.KeystoneAPIName, "internal", newInternalEndpoint)
+		// Create keystoneAPI first to get the correct name
+		keystoneAPIName := keystone.CreateKeystoneAPI(novaNames.NovaName.Namespace)
+
+		keystone.UpdateKeystoneAPIEndpoint(keystoneAPIName, "internal", newInternalEndpoint)
+		DeferCleanup(keystone.DeleteKeystoneAPI, keystoneAPIName)
 		logger.Info("Reconfigured")
 
 		SimulateReadyOfNovaTopServices()


### PR DESCRIPTION
- Replace GetKeystoneAPI with GetKeystoneAPIByName in nova_controller.go
- use instance.Spec.KeystoneInstance directly instead of empty label map
- Remove TODO comment about changing the API usage.
- Update keystone-operator/api dependency to support new functionality

This provides a more direct and efficient way to get the KeystoneAPI resource by name rather then searching by labels.

Commit message assisted by: claude-4-sonnet