### PR TITLE
Add missing hook step in vars

### DIFF
--- a/ci/nova-operator-tempest-multinode-ceph/ci_fw_vars.yaml
+++ b/ci/nova-operator-tempest-multinode-ceph/ci_fw_vars.yaml
@@ -28,6 +28,13 @@ post_deploy:
     type: playbook
     source: control_plane_kustomize_deploy.yml
 
+post_ceph:
+  - name: 80 Run Ceph hook playbook
+    type: playbook
+    source: ceph.yml
+
+cifmw_cephadm_log_path: /home/zuul/ci-framework-data/logs
+
 # we can use this hook to create flavors, images, etc
 # before we execute tempest simiilar to how we would use
 # local.sh in devstack based jobs


### PR DESCRIPTION
The Ceph playbook is not executed in hook. When the playbook uses hook role, it should contain a post_ceph variable, otherwise the Ceph playbook would not be executed and it would fail with error:

    - 'error: the path "/tmp/k8s_ceph_secret.yml" does not exist'