### PR TITLE
test: Fix race condition in NovaNoVNCProxy topology test

### DIFF
--- a/test/functional/nova_novncproxy_test.go
+++ b/test/functional/nova_novncproxy_test.go
@@ -1366,10 +1366,10 @@ var _ = Describe("NovaNoVNCProxy controller", func() {
 
 			memcachedSpec := infra.GetDefaultMemcachedSpec()
 			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
+			infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)
 			DeferCleanup(th.DeleteInstance, CreateNovaNoVNCProxy(cell1.NoVNCProxyName, spec))
 			DeferCleanup(
 				k8sClient.Delete, ctx, CreateDefaultCellInternalSecret(cell1))
-			infra.SimulateMemcachedReady(novaNames.MemcachedNamespace)
 		})
 		It("sets lastAppliedTopology field in NovaNoVNCProxy topology .Status", func() {
 			th.SimulateStatefulSetReplicaReady(cell1.NoVNCProxyStatefulSetName)


### PR DESCRIPTION
The "updates lastAppliedTopology in NovaNoVNCProxy .Status" test was failing intermittently due to a race condition in test setup.

**Problem**: SimulateMemcachedReady() was called after CreateNovaNoVNCProxy(), causing the controller's ensureMemcached() call to fail intermittently when reconciliation triggered before the Memcached instance was simulated as ready.

**Solution**: Move SimulateMemcachedReady() call before CreateNovaNoVNCProxy() to ensure Memcached is ready before controller reconciliation begins.

Commit-message-assisted-by: claude-4-sonnet
Closes: OSPRH-19625