### PR TITLE
Modernize Go code with latest style conventions

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -20,6 +20,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net/url"
 	"sort"
 	"strconv"
@@ -268,7 +269,7 @@ func allSubConditionIsTrue(conditionsGetter conditionsGetter) bool {
 
 type conditionUpdater interface {
 	Set(c *condition.Condition)
-	MarkTrue(t condition.Type, messageFormat string, messageArgs ...interface{})
+	MarkTrue(t condition.Type, messageFormat string, messageArgs ...any)
 }
 
 func ensureSecret(
@@ -482,7 +483,7 @@ func (r *Reconcilers) OverrideRequeueTimeout(timeout time.Duration) {
 func (r *ReconcilerBase) generateConfigsGeneric(
 	ctx context.Context, h *helper.Helper,
 	instance client.Object, configName string, envVars *map[string]env.Setter,
-	templateParameters map[string]interface{},
+	templateParameters map[string]any,
 	extraData map[string]string, cmLabels map[string]string,
 	additionalTemplates map[string]string,
 	withScripts bool,
@@ -493,9 +494,7 @@ func (r *ReconcilerBase) generateConfigsGeneric(
 		"nova-blank.conf": "/nova-blank.conf",
 	}
 
-	for k, v := range additionalTemplates {
-		extraTemplates[k] = v
-	}
+	maps.Copy(extraTemplates, additionalTemplates)
 	cms := []util.Template{
 		{
 			Name:               configName,
@@ -527,7 +526,7 @@ func (r *ReconcilerBase) generateConfigsGeneric(
 func (r *ReconcilerBase) GenerateConfigs(
 	ctx context.Context, h *helper.Helper,
 	instance client.Object, configName string, envVars *map[string]env.Setter,
-	templateParameters map[string]interface{},
+	templateParameters map[string]any,
 	extraData map[string]string, cmLabels map[string]string,
 	additionalTemplates map[string]string,
 ) error {
@@ -542,7 +541,7 @@ func (r *ReconcilerBase) GenerateConfigs(
 func (r *ReconcilerBase) GenerateConfigsWithScripts(
 	ctx context.Context, h *helper.Helper,
 	instance client.Object, envVars *map[string]env.Setter,
-	templateParameters map[string]interface{},
+	templateParameters map[string]any,
 	extraData map[string]string, cmLabels map[string]string,
 	additionalTemplates map[string]string,
 ) error {

--- a/controllers/nova_controller.go
+++ b/controllers/nova_controller.go
@@ -1056,7 +1056,7 @@ func (r *NovaReconciler) ensureNovaManageJobSecret(
 	// We configure the Job like it runs in the env of the conductor of the given cell
 	// but we ensure that the config always has [api_database] section configure
 	// even if the cell has no API access at all.
-	templateParameters := map[string]interface{}{
+	templateParameters := map[string]any{
 		"service_name":           "nova-conductor",
 		"keystone_internal_url":  cell.Spec.KeystoneAuthURL,
 		"nova_keystone_user":     cell.Spec.ServiceUser,

--- a/controllers/novacell_controller.go
+++ b/controllers/novacell_controller.go
@@ -769,7 +769,7 @@ func (r *NovaCellReconciler) generateComputeConfigs(
 	ctx context.Context, h *helper.Helper, instance *novav1.NovaCell,
 	secret corev1.Secret, vncProxyURL *string,
 ) error {
-	templateParameters := map[string]interface{}{
+	templateParameters := map[string]any{
 		"service_name":               "nova-compute",
 		"keystone_internal_url":      instance.Spec.KeystoneAuthURL,
 		"nova_keystone_user":         instance.Spec.ServiceUser,

--- a/controllers/novacompute_controller.go
+++ b/controllers/novacompute_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -357,7 +358,7 @@ func (r *NovaComputeReconciler) ensureConfigs(
 func (r *NovaComputeReconciler) generateConfigs(
 	ctx context.Context, h *helper.Helper, instance *novav1.NovaCompute, hashes *map[string]env.Setter, secret corev1.Secret,
 ) error {
-	templateParameters := map[string]interface{}{
+	templateParameters := map[string]any{
 		"service_name":               NovaComputeLabelPrefix,
 		"keystone_internal_url":      instance.Spec.KeystoneAuthURL,
 		"nova_keystone_user":         instance.Spec.ServiceUser,
@@ -377,9 +378,7 @@ func (r *NovaComputeReconciler) generateConfigs(
 	if instance.Spec.CustomServiceConfig != "" {
 		extraData["02-nova-override.conf"] = instance.Spec.CustomServiceConfig
 	}
-	for key, data := range instance.Spec.DefaultConfigOverwrite {
-		extraData[key] = data
-	}
+	maps.Copy(extraData, instance.Spec.DefaultConfigOverwrite)
 
 	cmLabels := labels.GetLabels(
 		instance, labels.GetGroupLabel(NovaComputeLabelPrefix), map[string]string{},

--- a/controllers/novaconductor_controller.go
+++ b/controllers/novaconductor_controller.go
@@ -450,7 +450,7 @@ func (r *NovaConductorReconciler) generateConfigs(
 	cellDatabaseAccount := cellDB.GetAccount()
 	cellDbSecret := cellDB.GetSecret()
 
-	templateParameters := map[string]interface{}{
+	templateParameters := map[string]any{
 		"service_name":               "nova-conductor",
 		"keystone_internal_url":      instance.Spec.KeystoneAuthURL,
 		"nova_keystone_user":         instance.Spec.ServiceUser,

--- a/controllers/novametadata_controller.go
+++ b/controllers/novametadata_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net/url"
 
 	v1 "k8s.io/api/apps/v1"
@@ -486,7 +487,7 @@ func (r *NovaMetadataReconciler) generateConfigs(
 
 	}
 
-	templateParameters := map[string]interface{}{
+	templateParameters := map[string]any{
 		"service_name":             novametadata.ServiceName,
 		"keystone_internal_url":    instance.Spec.KeystoneAuthURL,
 		"nova_keystone_user":       instance.Spec.ServiceUser,
@@ -560,9 +561,7 @@ func (r *NovaMetadataReconciler) generateConfigs(
 	if instance.Spec.CustomServiceConfig != "" {
 		extraData["02-nova-override.conf"] = instance.Spec.CustomServiceConfig
 	}
-	for key, data := range instance.Spec.DefaultConfigOverwrite {
-		extraData[key] = data
-	}
+	maps.Copy(extraData, instance.Spec.DefaultConfigOverwrite)
 
 	cmLabels := labels.GetLabels(
 		instance, labels.GetGroupLabel(NovaMetadataLabelPrefix), map[string]string{},
@@ -873,7 +872,7 @@ func (r *NovaMetadataReconciler) generateNeutronConfigs(
 	// 1. avoid the work needed to teach cells to neutron
 	// 2. avoid the need to synchronize the shared secret between nova- and
 	//    neutron-operator externally
-	templateParameters := map[string]interface{}{
+	templateParameters := map[string]any{
 		"nova_metadata_host":           endpointURL.Hostname(),
 		"nova_metadata_port":           endpointURL.Port(),
 		"nova_metadata_protocol":       endpointURL.Scheme,

--- a/controllers/novanovncproxy_controller.go
+++ b/controllers/novanovncproxy_controller.go
@@ -466,7 +466,7 @@ func (r *NovaNoVNCProxyReconciler) generateConfigs(
 	cellDatabaseAccount := cellDB.GetAccount()
 	cellDbSecret := cellDB.GetSecret()
 
-	templateParameters := map[string]interface{}{
+	templateParameters := map[string]any{
 		"service_name":             novncproxy.ServiceName,
 		"keystone_internal_url":    instance.Spec.KeystoneAuthURL,
 		"nova_keystone_user":       instance.Spec.ServiceUser,

--- a/controllers/novascheduler_controller.go
+++ b/controllers/novascheduler_controller.go
@@ -576,7 +576,7 @@ func (r *NovaSchedulerReconciler) generateConfigs(
 		return err
 	}
 
-	templateParameters := map[string]interface{}{
+	templateParameters := map[string]any{
 		"service_name":               "nova-scheduler",
 		"keystone_internal_url":      instance.Spec.KeystoneAuthURL,
 		"nova_keystone_user":         instance.Spec.ServiceUser,

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -54,8 +54,8 @@ const (
 	MemcachedInstance  = "memcached"
 )
 
-func GetDefaultNovaAPISpec(novaNames NovaNames) map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultNovaAPISpec(novaNames NovaNames) map[string]any {
+	return map[string]any{
 		"secret":                novaNames.InternalTopLevelSecretName.Name,
 		"apiDatabaseHostname":   "nova-api-db-hostname",
 		"cell0DatabaseHostname": "nova-cell0-db-hostname",
@@ -70,11 +70,11 @@ func GetDefaultNovaAPISpec(novaNames NovaNames) map[string]interface{} {
 	}
 }
 
-func CreateNovaAPI(name types.NamespacedName, spec map[string]interface{}) client.Object {
-	raw := map[string]interface{}{
+func CreateNovaAPI(name types.NamespacedName, spec map[string]any) client.Object {
+	raw := map[string]any{
 		"apiVersion": "nova.openstack.org/v1beta1",
 		"kind":       "NovaAPI",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -110,28 +110,28 @@ func NovaSchedulerConditionGetter(name types.NamespacedName) condition.Condition
 	return instance.Status.Conditions
 }
 
-func GetDefaultNovaSpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultNovaSpec() map[string]any {
+	return map[string]any{
 		"secret":                SecretName,
-		"cellTemplates":         map[string]interface{}{},
+		"cellTemplates":         map[string]any{},
 		"apiMessageBusInstance": cell0.TransportURLName.Name,
 		"apiDatabaseAccount":    novaNames.APIMariaDBDatabaseAccount.Name,
 	}
 }
 
-func GetDefaultNovaCellTemplate() map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultNovaCellTemplate() map[string]any {
+	return map[string]any{
 		"cellDatabaseAccount": cell0.MariaDBAccountName.Name,
 		"hasAPIAccess":        true,
 		"apiDatabaseAccount":  novaNames.APIMariaDBDatabaseAccount.Name,
 	}
 }
 
-func CreateNova(name types.NamespacedName, spec map[string]interface{}) client.Object {
-	raw := map[string]interface{}{
+func CreateNova(name types.NamespacedName, spec map[string]any) client.Object {
+	raw := map[string]any{
 		"apiVersion": "nova.openstack.org/v1beta1",
 		"kind":       "Nova",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -141,22 +141,22 @@ func CreateNova(name types.NamespacedName, spec map[string]interface{}) client.O
 }
 
 func CreateNovaWithCell0(name types.NamespacedName) client.Object {
-	rawNova := map[string]interface{}{
+	rawNova := map[string]any{
 		"apiVersion": "nova.openstack.org/v1beta1",
 		"kind":       "Nova",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
-		"spec": map[string]interface{}{
+		"spec": map[string]any{
 			"secret":             SecretName,
 			"apiDatabaseAccount": novaNames.APIMariaDBDatabaseAccount.Name,
-			"cellTemplates": map[string]interface{}{
-				"cell0": map[string]interface{}{
+			"cellTemplates": map[string]any{
+				"cell0": map[string]any{
 					"cellDatabaseAccount": cell0.MariaDBAccountName.Name,
 					"apiDatabaseAccount":  novaNames.APIMariaDBDatabaseAccount.Name,
 					"hasAPIAccess":        true,
-					"dbPurge": map[string]interface{}{
+					"dbPurge": map[string]any{
 						"schedule": "1 0 * * *",
 					},
 				},
@@ -181,8 +181,8 @@ func NovaConditionGetter(name types.NamespacedName) condition.Conditions {
 	return instance.Status.Conditions
 }
 
-func GetDefaultNovaConductorSpec(cell CellNames) map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultNovaConductorSpec(cell CellNames) map[string]any {
+	return map[string]any{
 		"cellName":            cell.CellName,
 		"secret":              cell.InternalCellSecretName.Name,
 		"apiDatabaseAccount":  novaNames.APIMariaDBDatabaseAccount.Name,
@@ -195,11 +195,11 @@ func GetDefaultNovaConductorSpec(cell CellNames) map[string]interface{} {
 	}
 }
 
-func CreateNovaConductor(name types.NamespacedName, spec map[string]interface{}) client.Object {
-	raw := map[string]interface{}{
+func CreateNovaConductor(name types.NamespacedName, spec map[string]any) client.Object {
+	raw := map[string]any{
 		"apiVersion": "nova.openstack.org/v1beta1",
 		"kind":       "NovaConductor",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -227,7 +227,7 @@ func CreateNovaMessageBusSecret(cell CellNames) *corev1.Secret {
 			Namespace: cell.CellCRName.Namespace,
 			Name:      fmt.Sprintf("%s-secret", cell.TransportURLName.Name)},
 		map[string][]byte{
-			"transport_url": []byte(fmt.Sprintf("rabbit://%s/fake", cell.CellName)),
+			"transport_url": fmt.Appendf(nil, "rabbit://%s/fake", cell.CellName),
 		},
 	)
 	logger.Info("Secret created", "name", s.Name)
@@ -240,15 +240,15 @@ func CreateNotificationTransportURLSecret(notificationsBus NotificationsBusNames
 			Namespace: novaNames.NovaName.Namespace,
 			Name:      fmt.Sprintf("%s-secret", notificationsBus.BusName)},
 		map[string][]byte{
-			"transport_url": []byte(fmt.Sprintf("rabbit://%s/fake", notificationsBus.TransportURLName.Name)),
+			"transport_url": fmt.Appendf(nil, "rabbit://%s/fake", notificationsBus.TransportURLName.Name),
 		},
 	)
 	logger.Info("Secret created", "name", s.Name)
 	return s
 }
 
-func GetDefaultNovaCellSpec(cell CellNames) map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultNovaCellSpec(cell CellNames) map[string]any {
+	return map[string]any{
 		"cellName":             cell.CellName,
 		"secret":               cell.InternalCellSecretName.Name,
 		"apiDatabaseAccount":   novaNames.APIMariaDBDatabaseAccount.Name,
@@ -260,12 +260,12 @@ func GetDefaultNovaCellSpec(cell CellNames) map[string]interface{} {
 	}
 }
 
-func CreateNovaCell(name types.NamespacedName, spec map[string]interface{}) client.Object {
+func CreateNovaCell(name types.NamespacedName, spec map[string]any) client.Object {
 
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "nova.openstack.org/v1beta1",
 		"kind":       "NovaCell",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -305,8 +305,8 @@ func CreateNovaSecret(namespace string, name string) *corev1.Secret {
 	)
 }
 
-func GetDefaultNovaSchedulerSpec(novaNames NovaNames) map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultNovaSchedulerSpec(novaNames NovaNames) map[string]any {
+	return map[string]any{
 		"secret":                novaNames.InternalTopLevelSecretName.Name,
 		"apiDatabaseAccount":    novaNames.APIMariaDBDatabaseAccount.Name,
 		"apiDatabaseHostname":   "nova-api-db-hostname",
@@ -320,11 +320,11 @@ func GetDefaultNovaSchedulerSpec(novaNames NovaNames) map[string]interface{} {
 	}
 }
 
-func CreateNovaScheduler(name types.NamespacedName, spec map[string]interface{}) client.Object {
-	raw := map[string]interface{}{
+func CreateNovaScheduler(name types.NamespacedName, spec map[string]any) client.Object {
+	raw := map[string]any{
 		"apiVersion": "nova.openstack.org/v1beta1",
 		"kind":       "NovaScheduler",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -688,11 +688,11 @@ func GetNovaNames(novaName types.NamespacedName, cellNames []string) NovaNames {
 	}
 }
 
-func CreateNovaMetadata(name types.NamespacedName, spec map[string]interface{}) client.Object {
-	raw := map[string]interface{}{
+func CreateNovaMetadata(name types.NamespacedName, spec map[string]any) client.Object {
+	raw := map[string]any{
 		"apiVersion": "nova.openstack.org/v1beta1",
 		"kind":       "NovaMetadata",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -726,8 +726,8 @@ func CreateInternalTopLevelSecret(novaNames NovaNames) *corev1.Secret {
 	)
 }
 
-func GetDefaultNovaMetadataSpec(secretName types.NamespacedName) map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultNovaMetadataSpec(secretName types.NamespacedName) map[string]any {
+	return map[string]any{
 		"secret":               secretName.Name,
 		"apiDatabaseAccount":   novaNames.APIMariaDBDatabaseAccount.Name,
 		"apiDatabaseHostname":  "nova-api-db-hostname",
@@ -748,11 +748,11 @@ func AssertMetadataDoesNotExist(name types.NamespacedName) {
 	}, timeout, interval).Should(Succeed())
 }
 
-func CreateNovaNoVNCProxy(name types.NamespacedName, spec map[string]interface{}) client.Object {
-	raw := map[string]interface{}{
+func CreateNovaNoVNCProxy(name types.NamespacedName, spec map[string]any) client.Object {
+	raw := map[string]any{
 		"apiVersion": "nova.openstack.org/v1beta1",
 		"kind":       "NovaNoVNCProxy",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -774,8 +774,8 @@ func GetNovaNoVNCProxy(name types.NamespacedName) *novav1.NovaNoVNCProxy {
 	return instance
 }
 
-func GetDefaultNovaNoVNCProxySpec(cell CellNames) map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultNovaNoVNCProxySpec(cell CellNames) map[string]any {
+	return map[string]any{
 		"secret":               cell.InternalCellSecretName.Name,
 		"apiDatabaseAccount":   novaNames.APIMariaDBDatabaseAccount.Name,
 		"cellDatabaseHostname": "nova-cell-db-hostname",
@@ -792,7 +792,7 @@ func CreateCellInternalSecret(cell CellNames, additionalValues map[string][]byte
 
 	secretMap := map[string][]byte{
 		"ServicePassword":            []byte("service-password"),
-		"transport_url":              []byte(fmt.Sprintf("rabbit://%s/fake", cell.CellName)),
+		"transport_url":              fmt.Appendf(nil, "rabbit://%s/fake", cell.CellName),
 		"notification_transport_url": []byte("rabbit://notifications/fake"),
 	}
 	// (ksambor) this can be replaced with maps.Copy directly from maps
@@ -823,11 +823,11 @@ func AssertNoVNCProxyDoesNotExist(name types.NamespacedName) {
 	}, timeout, interval).Should(Succeed())
 }
 
-func CreateNovaCompute(name types.NamespacedName, spec map[string]interface{}) client.Object {
-	raw := map[string]interface{}{
+func CreateNovaCompute(name types.NamespacedName, spec map[string]any) client.Object {
+	raw := map[string]any{
 		"apiVersion": "nova.openstack.org/v1beta1",
 		"kind":       "NovaCompute",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -849,15 +849,15 @@ func NovaComputeConditionGetter(name types.NamespacedName) condition.Conditions 
 	return instance.Status.Conditions
 }
 
-func GetDefaultNovaComputeTemplate() map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultNovaComputeTemplate() map[string]any {
+	return map[string]any{
 		"computeDriver": novav1.IronicDriver,
 		"name":          ironicComputeName,
 	}
 }
 
-func GetDefaultNovaComputeSpec(cell CellNames) map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultNovaComputeSpec(cell CellNames) map[string]any {
+	return map[string]any{
 		"secret":               cell.InternalCellSecretName.Name,
 		"apiDatabaseAccount":   novaNames.APIMariaDBDatabaseAccount.Name,
 		"computeName":          "compute1",
@@ -924,16 +924,16 @@ func SimulateReadyOfNovaTopServices() {
 // test Nova components. It returns both the user input representation
 // in the form of map[string]string, and the Golang expected representation
 // used in the test asserts.
-func GetSampleTopologySpec(label string) (map[string]interface{}, []corev1.TopologySpreadConstraint) {
+func GetSampleTopologySpec(label string) (map[string]any, []corev1.TopologySpreadConstraint) {
 	// Build the topology Spec yaml representation
-	topologySpec := map[string]interface{}{
-		"topologySpreadConstraints": []map[string]interface{}{
+	topologySpec := map[string]any{
+		"topologySpreadConstraints": []map[string]any{
 			{
 				"maxSkew":           1,
 				"topologyKey":       corev1.LabelHostname,
 				"whenUnsatisfiable": "ScheduleAnyway",
-				"labelSelector": map[string]interface{}{
-					"matchLabels": map[string]interface{}{
+				"labelSelector": map[string]any{
+					"matchLabels": map[string]any{
 						"service": label,
 					},
 				},
@@ -988,7 +988,7 @@ func CreateNovaWithNCellsAndEnsureReady(cellNumber int, novaNames *NovaNames) {
 	}
 
 	serviceSpec := corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 3306}}}
-	cellTemplates := make(map[string]interface{})
+	cellTemplates := make(map[string]any)
 
 	DeferCleanup(k8sClient.Delete, ctx, CreateNovaSecret(novaNames.NovaName.Namespace, SecretName))
 	DeferCleanup(
@@ -1000,7 +1000,7 @@ func CreateNovaWithNCellsAndEnsureReady(cellNumber int, novaNames *NovaNames) {
 	DeferCleanup(k8sClient.Delete, ctx, apiAccount)
 	DeferCleanup(k8sClient.Delete, ctx, apiSecret)
 
-	for i := 0; i < cellNumber; i++ {
+	for i := range cellNumber {
 		cellName := fmt.Sprintf("cell%d", i)
 		cell := novaNames.Cells[cellName]
 
@@ -1030,7 +1030,7 @@ func CreateNovaWithNCellsAndEnsureReady(cellNumber int, novaNames *NovaNames) {
 
 		if i == 1 {
 			// cell1
-			template["novaComputeTemplates"] = map[string]interface{}{
+			template["novaComputeTemplates"] = map[string]any{
 				ironicComputeName: GetDefaultNovaComputeTemplate(),
 			}
 		}
@@ -1063,7 +1063,7 @@ func CreateNovaWithNCellsAndEnsureReady(cellNumber int, novaNames *NovaNames) {
 	mariadb.SimulateMariaDBDatabaseCompleted(novaNames.APIMariaDBDatabaseName)
 	mariadb.SimulateMariaDBAccountCompleted(novaNames.APIMariaDBDatabaseAccount)
 
-	for i := 0; i < cellNumber; i++ {
+	for i := range cellNumber {
 		cell := novaNames.Cells[fmt.Sprintf("cell%d", i)]
 		mariadb.SimulateMariaDBDatabaseCompleted(cell.MariaDBDatabaseName)
 		mariadb.SimulateMariaDBAccountCompleted(cell.MariaDBAccountName)

--- a/test/functional/nova_compute_ironic_controller_test.go
+++ b/test/functional/nova_compute_ironic_controller_test.go
@@ -40,7 +40,7 @@ var _ = Describe("NovaCompute controller", func() {
 		BeforeEach(func() {
 			spec := GetDefaultNovaComputeSpec(cell1)
 			spec["customServiceConfig"] = "foo=bar"
-			spec["defaultConfigOverwrite"] = map[string]interface{}{
+			spec["defaultConfigOverwrite"] = map[string]any{
 				"provider1.yaml": `
 				providers:
 				    - identification:
@@ -643,7 +643,7 @@ var _ = Describe("NovaCompute with ironic diver controller", func() {
 	When("NovaCompute is created with TLS CA cert secret", func() {
 		BeforeEach(func() {
 			spec := GetDefaultNovaComputeSpec(cell1)
-			spec["tls"] = map[string]interface{}{
+			spec["tls"] = map[string]any{
 				"caBundleSecretName": novaNames.CaBundleSecretName.Name,
 			}
 			novaCompute := CreateNovaCompute(cell1.NovaComputeName, spec)

--- a/test/functional/nova_controller_test.go
+++ b/test/functional/nova_controller_test.go
@@ -940,7 +940,7 @@ var _ = Describe("Nova controller", func() {
 			spec := GetDefaultNovaSpec()
 			cell0template := GetDefaultNovaCellTemplate()
 			cell0template["cellDatabaseInstance"] = cell0.MariaDBDatabaseName.Name
-			spec["cellTemplates"] = map[string]interface{}{"cell0": cell0template}
+			spec["cellTemplates"] = map[string]any{"cell0": cell0template}
 			spec["apiDatabaseInstance"] = novaNames.APIMariaDBDatabaseName.Name
 
 			DeferCleanup(th.DeleteInstance, CreateNova(novaNames.NovaName, spec))
@@ -1164,36 +1164,36 @@ var _ = Describe("Nova controller", func() {
 			nad := th.CreateNetworkAttachmentDefinition(novaNames.InternalAPINetworkNADName)
 			DeferCleanup(th.DeleteInstance, nad)
 
-			var externalEndpoints []interface{}
+			var externalEndpoints []any
 			externalEndpoints = append(
-				externalEndpoints, map[string]interface{}{
+				externalEndpoints, map[string]any{
 					"endpoint":        "internal",
 					"ipAddressPool":   "osp-internalapi",
 					"loadBalancerIPs": []string{"10.1.0.1", "10.1.0.2"},
 				},
 			)
-			rawSpec := map[string]interface{}{
+			rawSpec := map[string]any{
 				"secret":                SecretName,
 				"apiDatabaseAccount":    novaNames.APIMariaDBDatabaseAccount.Name,
 				"apiMessageBusInstance": cell0.TransportURLName.Name,
-				"cellTemplates": map[string]interface{}{
-					"cell0": map[string]interface{}{
+				"cellTemplates": map[string]any{
+					"cell0": map[string]any{
 						"apiDatabaseAccount":  novaNames.APIMariaDBDatabaseAccount.Name,
 						"cellDatabaseAccount": cell0.MariaDBAccountName.Name,
 						"hasAPIAccess":        true,
-						"conductorServiceTemplate": map[string]interface{}{
+						"conductorServiceTemplate": map[string]any{
 							"networkAttachments": []string{"internalapi"},
 						},
 					},
 				},
-				"apiServiceTemplate": map[string]interface{}{
+				"apiServiceTemplate": map[string]any{
 					"networkAttachments": []string{"internalapi"},
 					"externalEndpoints":  externalEndpoints,
 				},
-				"schedulerServiceTemplate": map[string]interface{}{
+				"schedulerServiceTemplate": map[string]any{
 					"networkAttachments": []string{"internalapi"},
 				},
-				"metadataServiceTemplate": map[string]interface{}{
+				"metadataServiceTemplate": map[string]any{
 					"networkAttachments": []string{"internalapi"},
 				},
 			}
@@ -1281,10 +1281,10 @@ var _ = Describe("Nova controller", func() {
 			spec := GetDefaultNovaSpec()
 			cell0template := GetDefaultNovaCellTemplate()
 			cell0template["cellDatabaseInstance"] = cell0.MariaDBDatabaseName.Name
-			spec["cellTemplates"] = map[string]interface{}{"cell0": cell0template}
+			spec["cellTemplates"] = map[string]any{"cell0": cell0template}
 			spec["apiDatabaseInstance"] = novaNames.APIMariaDBDatabaseName.Name
 			spec["apiDatabaseAccount"] = novaNames.APIMariaDBDatabaseAccount.Name
-			spec["topologyRef"] = map[string]interface{}{"name": "foo"}
+			spec["topologyRef"] = map[string]any{"name": "foo"}
 
 			DeferCleanup(th.DeleteInstance, CreateNova(novaNames.NovaName, spec))
 
@@ -1357,12 +1357,12 @@ var _ = Describe("Nova controller", func() {
 			spec := GetDefaultNovaSpec()
 			cell0template := GetDefaultNovaCellTemplate()
 			cell0template["cellDatabaseInstance"] = cell0.MariaDBDatabaseName.Name
-			spec["cellTemplates"] = map[string]interface{}{"cell0": cell0template}
+			spec["cellTemplates"] = map[string]any{"cell0": cell0template}
 			spec["apiDatabaseInstance"] = novaNames.APIMariaDBDatabaseName.Name
 			spec["apiDatabaseAccount"] = novaNames.APIMariaDBDatabaseAccount.Name
 
 			// We reference the global topology and is inherited by the sub components
-			spec["topologyRef"] = map[string]interface{}{"name": topologyRef.Name}
+			spec["topologyRef"] = map[string]any{"name": topologyRef.Name}
 
 			DeferCleanup(th.DeleteInstance, CreateNova(novaNames.NovaName, spec))
 
@@ -1472,23 +1472,23 @@ var _ = Describe("Nova controller", func() {
 			cell1Template["cellMessageBusInstance"] = cell1.TransportURLName.Name
 			// We reference the cell1 topology that is inherited by the cell1 conductor,
 			// metadata, and novncproxy
-			cell1Template["topologyRef"] = map[string]interface{}{"name": topologyRefCell.Name}
-			cell1Template["metadataServiceTemplate"] = map[string]interface{}{
+			cell1Template["topologyRef"] = map[string]any{"name": topologyRefCell.Name}
+			cell1Template["metadataServiceTemplate"] = map[string]any{
 				"enabled": true,
 			}
-			spec["cellTemplates"] = map[string]interface{}{
+			spec["cellTemplates"] = map[string]any{
 				"cell0": cell0Template,
 				"cell1": cell1Template,
 			}
 			// disable top-level metadata as we enabled the instance in cell1
-			spec["metadataServiceTemplate"] = map[string]interface{}{
+			spec["metadataServiceTemplate"] = map[string]any{
 				"enabled": false,
 			}
 			spec["apiDatabaseInstance"] = novaNames.APIMariaDBDatabaseName.Name
 			spec["apiMessageBusInstance"] = cell0.TransportURLName.Name
 			// We reference the global topology and is inherited by the sub components
 			// except cell1 that has an override
-			spec["topologyRef"] = map[string]interface{}{"name": topologyRefTopLevel.Name}
+			spec["topologyRef"] = map[string]any{"name": topologyRefTopLevel.Name}
 			DeferCleanup(th.DeleteInstance, CreateNova(novaNames.NovaName, spec))
 			memcachedSpec := infra.GetDefaultMemcachedSpec()
 			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
@@ -1629,7 +1629,7 @@ var _ = Describe("Nova controller", func() {
 
 			spec := GetDefaultNovaSpec()
 			cell0 := GetDefaultNovaCellTemplate()
-			spec["cellTemplates"] = map[string]interface{}{"cell0": cell0}
+			spec["cellTemplates"] = map[string]any{"cell0": cell0}
 			// This nova is created without any container image is specified in
 			// the request
 			DeferCleanup(th.DeleteInstance, CreateNova(novaNames.NovaName, spec))
@@ -1714,7 +1714,7 @@ var _ = Describe("Nova controller", func() {
 			spec := GetDefaultNovaSpec()
 			cell0template := GetDefaultNovaCellTemplate()
 			cell0template["cellDatabaseInstance"] = cell0.MariaDBDatabaseName.Name
-			spec["cellTemplates"] = map[string]interface{}{"cell0": cell0template}
+			spec["cellTemplates"] = map[string]any{"cell0": cell0template}
 			spec["apiDatabaseInstance"] = novaNames.APIMariaDBDatabaseName.Name
 			spec["apiDatabaseAccount"] = accountName.Name
 
@@ -1828,7 +1828,7 @@ var _ = Describe("Nova controller", func() {
 			cell0template := GetDefaultNovaCellTemplate()
 			cell0template["cellDatabaseInstance"] = cell0.MariaDBDatabaseName.Name
 			cell0template["cellDatabaseAccount"] = accountName.Name
-			spec["cellTemplates"] = map[string]interface{}{"cell0": cell0template}
+			spec["cellTemplates"] = map[string]any{"cell0": cell0template}
 			spec["apiDatabaseInstance"] = novaNames.APIMariaDBDatabaseName.Name
 
 			DeferCleanup(th.DeleteInstance, CreateNova(novaNames.NovaName, spec))

--- a/test/functional/nova_metadata_controller_test.go
+++ b/test/functional/nova_metadata_controller_test.go
@@ -68,7 +68,7 @@ var _ = Describe("NovaMetadata controller", func() {
 		BeforeEach(func() {
 			spec := GetDefaultNovaMetadataSpec(novaNames.InternalTopLevelSecretName)
 			spec["customServiceConfig"] = "foo=bar"
-			spec["defaultConfigOverwrite"] = map[string]interface{}{
+			spec["defaultConfigOverwrite"] = map[string]any{
 				"api-paste.ini": "pipeline = cors metaapp",
 			}
 
@@ -614,7 +614,7 @@ var _ = Describe("NovaMetadata controller", func() {
 				k8sClient.Delete, ctx, CreateInternalTopLevelSecret(novaNames))
 
 			spec := GetDefaultNovaMetadataSpec(novaNames.InternalTopLevelSecretName)
-			serviceOverride := map[string]interface{}{
+			serviceOverride := map[string]any{
 				"metadata": map[string]map[string]string{
 					"annotations": {
 						"metallb.universe.tf/address-pool":    "osp-internalapi",
@@ -626,12 +626,12 @@ var _ = Describe("NovaMetadata controller", func() {
 						"service":  "nova",
 					},
 				},
-				"spec": map[string]interface{}{
+				"spec": map[string]any{
 					"type": "LoadBalancer",
 				},
 			}
 
-			spec["override"] = map[string]interface{}{
+			spec["override"] = map[string]any{
 				"service": serviceOverride,
 			}
 
@@ -925,7 +925,7 @@ var _ = Describe("NovaMetadata controller", func() {
 				k8sClient.Delete, ctx, CreateInternalTopLevelSecret(novaNames))
 
 			spec := GetDefaultNovaMetadataSpec(novaNames.InternalTopLevelSecretName)
-			spec["tls"] = map[string]interface{}{
+			spec["tls"] = map[string]any{
 				"secretName":         ptr.To(novaNames.InternalCertSecretName.Name),
 				"caBundleSecretName": novaNames.CaBundleSecretName.Name,
 			}
@@ -1082,7 +1082,7 @@ var _ = Describe("NovaMetadata controller", func() {
 		BeforeEach(func() {
 			spec := GetDefaultNovaMetadataSpec(novaNames.InternalTopLevelSecretName)
 			// We reference a topology that does not exist in the current namespace
-			spec["topologyRef"] = map[string]interface{}{"name": "foo"}
+			spec["topologyRef"] = map[string]any{"name": "foo"}
 
 			DeferCleanup(
 				k8sClient.Delete, ctx, CreateInternalTopLevelSecret(novaNames))
@@ -1109,14 +1109,14 @@ var _ = Describe("NovaMetadata controller", func() {
 		var expectedTopologySpec []corev1.TopologySpreadConstraint
 		BeforeEach(func() {
 			// Build the topology Spec
-			var topologySpec map[string]interface{}
+			var topologySpec map[string]any
 			topologySpec, expectedTopologySpec = GetSampleTopologySpec(novaNames.MetadataName.Name)
 			// Create Test Topologies
 			_, topologyRefAlt = infra.CreateTopology(novaNames.NovaTopologies[0], topologySpec)
 			_, topologyRefMeta = infra.CreateTopology(novaNames.NovaTopologies[3], topologySpec)
 
 			spec := GetDefaultNovaMetadataSpec(novaNames.InternalTopLevelSecretName)
-			spec["topologyRef"] = map[string]interface{}{"name": topologyRefMeta.Name}
+			spec["topologyRef"] = map[string]any{"name": topologyRefMeta.Name}
 
 			DeferCleanup(
 				k8sClient.Delete, ctx, CreateInternalTopLevelSecret(novaNames))
@@ -1301,7 +1301,7 @@ var _ = Describe("NovaMetadata controller", func() {
 				k8sClient.Delete, ctx, CreateInternalTopLevelSecret(novaNames))
 
 			spec := GetDefaultNovaMetadataSpec(novaNames.InternalTopLevelSecretName)
-			spec["tls"] = map[string]interface{}{
+			spec["tls"] = map[string]any{
 				"secretName":         ptr.To(novaNames.InternalCertSecretName.Name),
 				"caBundleSecretName": novaNames.CaBundleSecretName.Name,
 			}

--- a/test/functional/nova_multicell_test.go
+++ b/test/functional/nova_multicell_test.go
@@ -80,10 +80,10 @@ var _ = Describe("Nova multi cell", func() {
 			cell1Template["cellDatabaseInstance"] = cell1.MariaDBDatabaseName.Name
 			cell1Template["cellDatabaseAccount"] = cell1.MariaDBAccountName.Name
 			cell1Template["cellMessageBusInstance"] = cell1.TransportURLName.Name
-			cell1Template["passwordSelectors"] = map[string]interface{}{
+			cell1Template["passwordSelectors"] = map[string]any{
 				"database": "NovaCell1DatabasePassword",
 			}
-			cell1Template["novaComputeTemplates"] = map[string]interface{}{
+			cell1Template["novaComputeTemplates"] = map[string]any{
 				ironicComputeName: GetDefaultNovaComputeTemplate(),
 			}
 			cell1Memcached := "memcached1"
@@ -94,11 +94,11 @@ var _ = Describe("Nova multi cell", func() {
 			cell2Template["cellDatabaseAccount"] = cell2.MariaDBAccountName.Name
 			cell2Template["cellMessageBusInstance"] = cell2.TransportURLName.Name
 			cell2Template["hasAPIAccess"] = false
-			cell2Template["passwordSelectors"] = map[string]interface{}{
+			cell2Template["passwordSelectors"] = map[string]any{
 				"database": "NovaCell2DatabasePassword",
 			}
 
-			spec["cellTemplates"] = map[string]interface{}{
+			spec["cellTemplates"] = map[string]any{
 				"cell0": cell0Template,
 				"cell1": cell1Template,
 				"cell2": cell2Template,
@@ -665,7 +665,7 @@ var _ = Describe("Nova multi cell", func() {
 			cell0Template["cellDatabaseAccount"] = cell0.MariaDBAccountName.Name
 			cell0Template["hasAPIAccess"] = true
 			// disable cell0 conductor
-			cell0Template["conductorServiceTemplate"] = map[string]interface{}{
+			cell0Template["conductorServiceTemplate"] = map[string]any{
 				"replicas": 0,
 			}
 
@@ -678,7 +678,7 @@ var _ = Describe("Nova multi cell", func() {
 			cell1Template["cellMessageBusInstance"] = cell0.TransportURLName.Name
 			cell1Template["hasAPIAccess"] = true
 
-			spec["cellTemplates"] = map[string]interface{}{
+			spec["cellTemplates"] = map[string]any{
 				"cell0": cell0Template,
 				"cell1": cell1Template,
 			}
@@ -792,7 +792,7 @@ var _ = Describe("Nova multi cell", func() {
 			cell1Template["cellDatabaseAccount"] = cell1.MariaDBAccountName.Name
 			cell1Template["cellMessageBusInstance"] = cell1.TransportURLName.Name
 
-			spec["cellTemplates"] = map[string]interface{}{
+			spec["cellTemplates"] = map[string]any{
 				"cell0": cell0Template,
 				"cell1": cell1Template,
 			}
@@ -850,15 +850,15 @@ var _ = Describe("Nova multi cell", func() {
 			cell1Template["cellDatabaseInstance"] = cell1.MariaDBDatabaseName.Name
 			cell1Template["cellDatabaseAccount"] = cell1.MariaDBAccountName.Name
 			cell1Template["cellMessageBusInstance"] = cell1.TransportURLName.Name
-			cell1Template["metadataServiceTemplate"] = map[string]interface{}{
+			cell1Template["metadataServiceTemplate"] = map[string]any{
 				"enabled": true,
 			}
 
-			spec["cellTemplates"] = map[string]interface{}{
+			spec["cellTemplates"] = map[string]any{
 				"cell0": cell0Template,
 				"cell1": cell1Template,
 			}
-			spec["metadataServiceTemplate"] = map[string]interface{}{
+			spec["metadataServiceTemplate"] = map[string]any{
 				"enabled": false,
 			}
 			spec["apiDatabaseInstance"] = novaNames.APIMariaDBDatabaseName.Name

--- a/test/functional/nova_novncproxy_test.go
+++ b/test/functional/nova_novncproxy_test.go
@@ -490,7 +490,7 @@ var _ = Describe("NovaNoVNCProxy controller", func() {
 				k8sClient.Delete, ctx, CreateDefaultCellInternalSecret(cell1))
 
 			spec := GetDefaultNovaNoVNCProxySpec(cell1)
-			serviceOverride := map[string]interface{}{
+			serviceOverride := map[string]any{
 				"endpointURL": "http://nova-novncproxy-cell1-" + novaNames.Namespace + ".apps-crc.testing",
 				"metadata": map[string]map[string]string{
 					"labels": {
@@ -499,7 +499,7 @@ var _ = Describe("NovaNoVNCProxy controller", func() {
 				},
 			}
 
-			spec["override"] = map[string]interface{}{
+			spec["override"] = map[string]any{
 				"service": serviceOverride,
 			}
 
@@ -535,7 +535,7 @@ var _ = Describe("NovaNoVNCProxy controller", func() {
 				k8sClient.Delete, ctx, CreateDefaultCellInternalSecret(cell1))
 
 			spec := GetDefaultNovaNoVNCProxySpec(cell1)
-			serviceOverride := map[string]interface{}{
+			serviceOverride := map[string]any{
 				"metadata": map[string]map[string]string{
 					"annotations": {
 						"dnsmasq.network.openstack.org/hostname": "nova-novncproxy-cell1-public.openstack.svc",
@@ -547,12 +547,12 @@ var _ = Describe("NovaNoVNCProxy controller", func() {
 						"service": "nova-novncproxy",
 					},
 				},
-				"spec": map[string]interface{}{
+				"spec": map[string]any{
 					"type": "LoadBalancer",
 				},
 			}
 
-			spec["override"] = map[string]interface{}{
+			spec["override"] = map[string]any{
 				"service": serviceOverride,
 			}
 
@@ -807,8 +807,8 @@ var _ = Describe("NovaNoVNCProxy controller", func() {
 	When("NovaNoVNCProxy is created with service and CA bundle cert secret", func() {
 		BeforeEach(func() {
 			spec := GetDefaultNovaNoVNCProxySpec(cell1)
-			spec["tls"] = map[string]interface{}{
-				"service": map[string]interface{}{
+			spec["tls"] = map[string]any{
+				"service": map[string]any{
 					"secretName": ptr.To(novaNames.InternalCertSecretName.Name),
 				},
 				"caBundleSecretName": novaNames.CaBundleSecretName.Name,
@@ -969,8 +969,8 @@ var _ = Describe("NovaNoVNCProxy controller", func() {
 	When("NovaNoVNCProxy is created with vencrypt and CA bundle cert secret", func() {
 		BeforeEach(func() {
 			spec := GetDefaultNovaNoVNCProxySpec(cell1)
-			spec["tls"] = map[string]interface{}{
-				"vencrypt": map[string]interface{}{
+			spec["tls"] = map[string]any{
+				"vencrypt": map[string]any{
 					"secretName": ptr.To(novaNames.VNCProxyVencryptCertSecretName.Name),
 				},
 				"caBundleSecretName": novaNames.CaBundleSecretName.Name,
@@ -1131,11 +1131,11 @@ var _ = Describe("NovaNoVNCProxy controller", func() {
 	When("NovaNoVNCProxy is created with both service, vencrypt and CA bundle cert secret", func() {
 		BeforeEach(func() {
 			spec := GetDefaultNovaNoVNCProxySpec(cell1)
-			spec["tls"] = map[string]interface{}{
-				"service": map[string]interface{}{
+			spec["tls"] = map[string]any{
+				"service": map[string]any{
 					"secretName": ptr.To(novaNames.InternalCertSecretName.Name),
 				},
-				"vencrypt": map[string]interface{}{
+				"vencrypt": map[string]any{
 					"secretName": ptr.To(novaNames.VNCProxyVencryptCertSecretName.Name),
 				},
 				"caBundleSecretName": novaNames.CaBundleSecretName.Name,
@@ -1323,7 +1323,7 @@ var _ = Describe("NovaNoVNCProxy controller", func() {
 		BeforeEach(func() {
 			spec := GetDefaultNovaNoVNCProxySpec(cell1)
 			// We reference a topology that does not exist in the current namespace
-			spec["topologyRef"] = map[string]interface{}{"name": "foo"}
+			spec["topologyRef"] = map[string]any{"name": "foo"}
 
 			memcachedSpec := infra.GetDefaultMemcachedSpec()
 			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
@@ -1354,7 +1354,7 @@ var _ = Describe("NovaNoVNCProxy controller", func() {
 		var expectedTopologySpec []corev1.TopologySpreadConstraint
 		BeforeEach(func() {
 			// Build the topology Spec
-			var topologySpec map[string]interface{}
+			var topologySpec map[string]any
 			topologySpec, expectedTopologySpec = GetSampleTopologySpec(cell1.NoVNCProxyName.Name)
 
 			// Create Test Topologies
@@ -1362,7 +1362,7 @@ var _ = Describe("NovaNoVNCProxy controller", func() {
 			_, topologyRefNoVNC = infra.CreateTopology(novaNames.NovaTopologies[5], topologySpec)
 
 			spec := GetDefaultNovaNoVNCProxySpec(cell1)
-			spec["topologyRef"] = map[string]interface{}{"name": topologyRefNoVNC.Name}
+			spec["topologyRef"] = map[string]any{"name": topologyRefNoVNC.Name}
 
 			memcachedSpec := infra.GetDefaultMemcachedSpec()
 			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(novaNames.NovaName.Namespace, MemcachedInstance, memcachedSpec))
@@ -1549,11 +1549,11 @@ var _ = Describe("NovaNoVNCProxy controller", func() {
 	When("NovaNoVNCProxy is configured for MTLS memcached auth", func() {
 		BeforeEach(func() {
 			spec := GetDefaultNovaNoVNCProxySpec(cell1)
-			spec["tls"] = map[string]interface{}{
-				"service": map[string]interface{}{
+			spec["tls"] = map[string]any{
+				"service": map[string]any{
 					"secretName": ptr.To(novaNames.InternalCertSecretName.Name),
 				},
-				"vencrypt": map[string]interface{}{
+				"vencrypt": map[string]any{
 					"secretName": ptr.To(novaNames.VNCProxyVencryptCertSecretName.Name),
 				},
 				"caBundleSecretName": novaNames.CaBundleSecretName.Name,

--- a/test/functional/nova_reconfiguration_test.go
+++ b/test/functional/nova_reconfiguration_test.go
@@ -236,7 +236,7 @@ var _ = Describe("Nova reconfiguration", func() {
 	})
 
 	When("Nova CR instance is created with topology that is later removed", func() {
-		var topologySpec map[string]interface{}
+		var topologySpec map[string]any
 		var defaultTopologyRef topologyv1.TopoRef
 		BeforeEach(func() {
 			// Create Test Topologies

--- a/test/functional/nova_scheduler_test.go
+++ b/test/functional/nova_scheduler_test.go
@@ -772,7 +772,7 @@ var _ = Describe("NovaScheduler controller", func() {
 	When("NovaScheduler is created with TLS CA cert secret", func() {
 		BeforeEach(func() {
 			spec := GetDefaultNovaSchedulerSpec(novaNames)
-			spec["tls"] = map[string]interface{}{
+			spec["tls"] = map[string]any{
 				"caBundleSecretName": novaNames.CaBundleSecretName.Name,
 			}
 
@@ -887,7 +887,7 @@ var _ = Describe("NovaScheduler controller", func() {
 	When("NovaScheduler is created with a wrong topologyRef", func() {
 		BeforeEach(func() {
 			spec := GetDefaultNovaSchedulerSpec(novaNames)
-			spec["topologyRef"] = map[string]interface{}{"name": "foo"}
+			spec["topologyRef"] = map[string]any{"name": "foo"}
 
 			DeferCleanup(
 				k8sClient.Delete, ctx, CreateInternalTopLevelSecret(novaNames))
@@ -914,7 +914,7 @@ var _ = Describe("NovaScheduler controller", func() {
 		var expectedTopologySpec []corev1.TopologySpreadConstraint
 		BeforeEach(func() {
 			// Build the topology Spec
-			var topologySpec map[string]interface{}
+			var topologySpec map[string]any
 			topologySpec, expectedTopologySpec = GetSampleTopologySpec(novaNames.SchedulerName.Name)
 
 			// Create Test Topologies
@@ -922,7 +922,7 @@ var _ = Describe("NovaScheduler controller", func() {
 			_, topologyRefSch = infra.CreateTopology(novaNames.NovaTopologies[2], topologySpec)
 
 			spec := GetDefaultNovaSchedulerSpec(novaNames)
-			spec["topologyRef"] = map[string]interface{}{"name": topologyRefSch.Name}
+			spec["topologyRef"] = map[string]any{"name": topologyRefSch.Name}
 
 			DeferCleanup(
 				k8sClient.Delete, ctx, CreateInternalTopLevelSecret(novaNames))
@@ -1096,7 +1096,7 @@ var _ = Describe("NovaScheduler controller", func() {
 	When("NovaScheduler is configured for MTLS memcached auth", func() {
 		BeforeEach(func() {
 			spec := GetDefaultNovaSchedulerSpec(novaNames)
-			spec["tls"] = map[string]interface{}{
+			spec["tls"] = map[string]any{
 				"caBundleSecretName": novaNames.CaBundleSecretName.Name,
 			}
 

--- a/test/functional/novaapi_controller_test.go
+++ b/test/functional/novaapi_controller_test.go
@@ -60,7 +60,7 @@ var _ = Describe("NovaAPI controller", func() {
 		BeforeEach(func() {
 			spec := GetDefaultNovaAPISpec(novaNames)
 			spec["customServiceConfig"] = "foo=bar"
-			spec["defaultConfigOverwrite"] = map[string]interface{}{
+			spec["defaultConfigOverwrite"] = map[string]any{
 				"policy.yaml":   "\"os_compute_api:os-flavor-manage:create\": \"rule:project_member_or_admin\"",
 				"api-paste.ini": "pipeline = cors compute_req_id faultwrap request_log http_proxy_to_wsgi oscomputeversionapp_v2",
 			}
@@ -610,8 +610,8 @@ var _ = Describe("NovaAPI controller", func() {
 	When("NovaAPI is created with service override with endpointURL set", func() {
 		BeforeEach(func() {
 			spec := GetDefaultNovaAPISpec(novaNames)
-			serviceOverride := map[string]interface{}{}
-			serviceOverride["internal"] = map[string]interface{}{
+			serviceOverride := map[string]any{}
+			serviceOverride["internal"] = map[string]any{
 				"metadata": map[string]map[string]string{
 					"annotations": {
 						"dnsmasq.network.openstack.org/hostname": "nova-internal.openstack.svc",
@@ -624,11 +624,11 @@ var _ = Describe("NovaAPI controller", func() {
 						"service":  "nova",
 					},
 				},
-				"spec": map[string]interface{}{
+				"spec": map[string]any{
 					"type": "LoadBalancer",
 				},
 			}
-			serviceOverride["public"] = map[string]interface{}{
+			serviceOverride["public"] = map[string]any{
 				"endpointURL": "http://nova-api-" + novaNames.APIName.Namespace + ".apps-crc.testing",
 				"metadata": map[string]map[string]string{
 					"labels": {
@@ -637,7 +637,7 @@ var _ = Describe("NovaAPI controller", func() {
 				},
 			}
 
-			spec["override"] = map[string]interface{}{
+			spec["override"] = map[string]any{
 				"service": serviceOverride,
 			}
 
@@ -695,8 +695,8 @@ var _ = Describe("NovaAPI controller", func() {
 	When("NovaAPI is created with service override with no endpointURL set", func() {
 		BeforeEach(func() {
 			spec := GetDefaultNovaAPISpec(novaNames)
-			serviceOverride := map[string]interface{}{}
-			serviceOverride["internal"] = map[string]interface{}{
+			serviceOverride := map[string]any{}
+			serviceOverride["internal"] = map[string]any{
 				"metadata": map[string]map[string]string{
 					"annotations": {
 						"dnsmasq.network.openstack.org/hostname": "nova-internal.openstack.svc",
@@ -709,11 +709,11 @@ var _ = Describe("NovaAPI controller", func() {
 						"service":  "nova",
 					},
 				},
-				"spec": map[string]interface{}{
+				"spec": map[string]any{
 					"type": "LoadBalancer",
 				},
 			}
-			serviceOverride["public"] = map[string]interface{}{
+			serviceOverride["public"] = map[string]any{
 				"metadata": map[string]map[string]string{
 					"annotations": {
 						"dnsmasq.network.openstack.org/hostname": "nova-public.openstack.svc",
@@ -725,12 +725,12 @@ var _ = Describe("NovaAPI controller", func() {
 						"service": "nova-api",
 					},
 				},
-				"spec": map[string]interface{}{
+				"spec": map[string]any{
 					"type": "LoadBalancer",
 				},
 			}
 
-			spec["override"] = map[string]interface{}{
+			spec["override"] = map[string]any{
 				"service": serviceOverride,
 			}
 
@@ -995,12 +995,12 @@ var _ = Describe("NovaAPI controller", func() {
 	When("NovaAPI is created with TLS cert secrets", func() {
 		BeforeEach(func() {
 			spec := GetDefaultNovaAPISpec(novaNames)
-			spec["tls"] = map[string]interface{}{
-				"api": map[string]interface{}{
-					"internal": map[string]interface{}{
+			spec["tls"] = map[string]any{
+				"api": map[string]any{
+					"internal": map[string]any{
 						"secretName": novaNames.InternalCertSecretName.Name,
 					},
-					"public": map[string]interface{}{
+					"public": map[string]any{
 						"secretName": novaNames.PublicCertSecretName.Name,
 					},
 				},
@@ -1198,7 +1198,7 @@ var _ = Describe("NovaAPI controller", func() {
 		BeforeEach(func() {
 			spec := GetDefaultNovaAPISpec(novaNames)
 			// We reference a topology that does not exist in the current namespace
-			spec["topologyRef"] = map[string]interface{}{"name": "foo"}
+			spec["topologyRef"] = map[string]any{"name": "foo"}
 
 			DeferCleanup(
 				k8sClient.Delete, ctx, CreateInternalTopLevelSecret(novaNames))
@@ -1225,7 +1225,7 @@ var _ = Describe("NovaAPI controller", func() {
 		var expectedTopologySpec []corev1.TopologySpreadConstraint
 		BeforeEach(func() {
 			// Build the topology Spec
-			var topologySpec map[string]interface{}
+			var topologySpec map[string]any
 			topologySpec, expectedTopologySpec = GetSampleTopologySpec(novaNames.APIName.Name)
 
 			// Create Test Topologies
@@ -1233,7 +1233,7 @@ var _ = Describe("NovaAPI controller", func() {
 			_, topologyRefAPI = infra.CreateTopology(novaNames.NovaTopologies[1], topologySpec)
 
 			spec := GetDefaultNovaAPISpec(novaNames)
-			spec["topologyRef"] = map[string]interface{}{"name": topologyRefAPI.Name}
+			spec["topologyRef"] = map[string]any{"name": topologyRefAPI.Name}
 
 			DeferCleanup(
 				k8sClient.Delete, ctx, CreateInternalTopLevelSecret(novaNames))
@@ -1410,12 +1410,12 @@ var _ = Describe("NovaAPI controller", func() {
 	When("NovaAPI is configured for MTLS memcached auth", func() {
 		BeforeEach(func() {
 			spec := GetDefaultNovaAPISpec(novaNames)
-			spec["tls"] = map[string]interface{}{
-				"api": map[string]interface{}{
-					"internal": map[string]interface{}{
+			spec["tls"] = map[string]any{
+				"api": map[string]any{
+					"internal": map[string]any{
 						"secretName": novaNames.InternalCertSecretName.Name,
 					},
-					"public": map[string]interface{}{
+					"public": map[string]any{
 						"secretName": novaNames.PublicCertSecretName.Name,
 					},
 				},

--- a/test/functional/novacell_controller_test.go
+++ b/test/functional/novacell_controller_test.go
@@ -189,10 +189,10 @@ var _ = Describe("NovaCell controller", func() {
 			)
 
 			spec := GetDefaultNovaCellSpec(cell1)
-			spec["metadataServiceTemplate"] = map[string]interface{}{
+			spec["metadataServiceTemplate"] = map[string]any{
 				"enabled": true,
 			}
-			spec["novaComputeTemplates"] = map[string]interface{}{
+			spec["novaComputeTemplates"] = map[string]any{
 				ironicComputeName: GetDefaultNovaComputeTemplate(),
 			}
 			DeferCleanup(th.DeleteInstance, CreateNovaCell(cell1.CellCRName, spec))
@@ -573,7 +573,7 @@ var _ = Describe("NovaCell controller", func() {
 				CreateMetadataCellInternalSecret(cell2),
 			)
 			spec := GetDefaultNovaCellSpec(cell2)
-			spec["noVNCProxyServiceTemplate"] = map[string]interface{}{
+			spec["noVNCProxyServiceTemplate"] = map[string]any{
 				"enabled": false,
 			}
 			DeferCleanup(th.DeleteInstance, CreateNovaCell(cell2.CellCRName, spec))
@@ -1017,7 +1017,7 @@ var _ = Describe("NovaCell controller", func() {
 			DeferCleanup(k8sClient.Delete, ctx, CreateMetadataCellInternalSecret(cell1))
 
 			spec := GetDefaultNovaCellSpec(cell1)
-			spec["metadataServiceTemplate"] = map[string]interface{}{
+			spec["metadataServiceTemplate"] = map[string]any{
 				"enabled": true,
 			}
 			DeferCleanup(th.DeleteInstance, CreateNovaCell(cell1.CellCRName, spec))
@@ -1121,10 +1121,10 @@ var _ = Describe("NovaCell controller webhook", func() {
 		DeferCleanup(k8sClient.Delete, ctx, CreateDefaultCellInternalSecret(cell))
 
 		spec := GetDefaultNovaCellSpec(cell)
-		rawObj := map[string]interface{}{
+		rawObj := map[string]any{
 			"apiVersion": "nova.openstack.org/v1beta1",
 			"kind":       "NovaCell",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      cell.CellCRName.Name,
 				"namespace": cell.CellCRName.Namespace,
 			},

--- a/test/functional/novaconductor_controller_test.go
+++ b/test/functional/novaconductor_controller_test.go
@@ -819,7 +819,7 @@ var _ = Describe("NovaConductor controller", func() {
 	When("NovaConductor is created with a wrong topologyRef", func() {
 		BeforeEach(func() {
 			spec := GetDefaultNovaConductorSpec(cell0)
-			spec["topologyRef"] = map[string]interface{}{"name": "foo"}
+			spec["topologyRef"] = map[string]any{"name": "foo"}
 			conductor := CreateNovaConductor(cell0.ConductorName, spec)
 			DeferCleanup(th.DeleteInstance, conductor)
 		})
@@ -844,7 +844,7 @@ var _ = Describe("NovaConductor controller", func() {
 		var topologyRefAlt topologyv1.TopoRef
 		var expectedTopologySpec []corev1.TopologySpreadConstraint
 		BeforeEach(func() {
-			var topologySpec map[string]interface{}
+			var topologySpec map[string]any
 			// Build the topology Spec
 			topologySpec, expectedTopologySpec = GetSampleTopologySpec(cell0.ConductorName.Name)
 			// Create Test Topologies
@@ -855,7 +855,7 @@ var _ = Describe("NovaConductor controller", func() {
 				k8sClient.Delete, ctx, CreateDefaultCellInternalSecret(cell0))
 
 			spec := GetDefaultNovaConductorSpec(cell0)
-			spec["topologyRef"] = map[string]interface{}{"name": topologyRefCnd.Name}
+			spec["topologyRef"] = map[string]any{"name": topologyRefCnd.Name}
 
 			DeferCleanup(th.DeleteInstance, CreateNovaConductor(cell0.ConductorName, spec))
 		})
@@ -1114,7 +1114,7 @@ var _ = Describe("NovaConductor controller", func() {
 				k8sClient.Delete, ctx, CreateDefaultCellInternalSecret(cell0))
 
 			spec := GetDefaultNovaConductorSpec(cell0)
-			spec["tls"] = map[string]interface{}{
+			spec["tls"] = map[string]any{
 				"caBundleSecretName": novaNames.CaBundleSecretName.Name,
 			}
 			DeferCleanup(th.DeleteInstance, CreateNovaConductor(cell0.ConductorName, spec))
@@ -1244,7 +1244,7 @@ var _ = Describe("NovaConductor controller", func() {
 	When("NovaConductor is configured for MTLS memcached auth", func() {
 		BeforeEach(func() {
 			spec := GetDefaultNovaConductorSpec(cell0)
-			spec["tls"] = map[string]interface{}{
+			spec["tls"] = map[string]any{
 				"caBundleSecretName": novaNames.CaBundleSecretName.Name,
 			}
 

--- a/test/functional/sample_test.go
+++ b/test/functional/sample_test.go
@@ -27,8 +27,8 @@ import (
 
 const SamplesDir = "../../config/samples/"
 
-func ReadSample(sampleFileName string) map[string]interface{} {
-	rawSample := make(map[string]interface{})
+func ReadSample(sampleFileName string) map[string]any {
+	rawSample := make(map[string]any)
 
 	bytes, err := os.ReadFile(filepath.Join(SamplesDir, sampleFileName)) // #nosec G304 -- Reading test sample files from controlled directory
 	Expect(err).ShouldNot(HaveOccurred())
@@ -39,14 +39,14 @@ func ReadSample(sampleFileName string) map[string]interface{} {
 
 func CreateNovaFromSample(sampleFileName string, name types.NamespacedName) types.NamespacedName {
 	raw := ReadSample(sampleFileName)
-	instance := CreateNova(name, raw["spec"].(map[string]interface{}))
+	instance := CreateNova(name, raw["spec"].(map[string]any))
 	DeferCleanup(th.DeleteInstance, instance)
 	return types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
 }
 
 func CreateNovaAPIFromSample(sampleFileName string, name types.NamespacedName) types.NamespacedName {
 	raw := ReadSample(sampleFileName)
-	instance := CreateNovaAPI(name, raw["spec"].(map[string]interface{}))
+	instance := CreateNovaAPI(name, raw["spec"].(map[string]any))
 	DeferCleanup(th.DeleteInstance, instance)
 	return types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
 }
@@ -55,7 +55,7 @@ func CreateNovaCellFromSample(sampleFileName string, name types.NamespacedName) 
 	raw := ReadSample(sampleFileName)
 	instance := CreateNovaCell(
 		name,
-		raw["spec"].(map[string]interface{}),
+		raw["spec"].(map[string]any),
 	)
 	DeferCleanup(th.DeleteInstance, instance)
 	return types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
@@ -63,7 +63,7 @@ func CreateNovaCellFromSample(sampleFileName string, name types.NamespacedName) 
 
 func CreateNovaConductorFromSample(sampleFileName string, name types.NamespacedName) types.NamespacedName {
 	raw := ReadSample(sampleFileName)
-	instance := CreateNovaConductor(name, raw["spec"].(map[string]interface{}))
+	instance := CreateNovaConductor(name, raw["spec"].(map[string]any))
 	DeferCleanup(th.DeleteInstance, instance)
 	return types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
 }

--- a/test/functional/validation_webhook_test.go
+++ b/test/functional/validation_webhook_test.go
@@ -32,49 +32,49 @@ import (
 // Entries used to test topology validation webhook at different levels
 var (
 	topLevelEntry = Entry("top-level topologyRef", func() (
-		map[string]interface{}, string, string) {
+		map[string]any, string, string) {
 		spec := GetDefaultNovaSpec()
 		cell0 := GetDefaultNovaCellTemplate()
-		spec["cellTemplates"] = map[string]interface{}{"cell0": cell0}
+		spec["cellTemplates"] = map[string]any{"cell0": cell0}
 		return spec, "Nova", novaNames.NovaName.Name
 	})
 	apiEntry = Entry("api sub CR", func() (
-		map[string]interface{}, string, string) {
+		map[string]any, string, string) {
 		spec := GetDefaultNovaAPISpec(novaNames)
 		return spec, "NovaAPI", novaNames.APIName.Name
 	})
 	schedulerEntry = Entry("scheduler sub CR", func() (
-		map[string]interface{}, string, string) {
+		map[string]any, string, string) {
 		spec := GetDefaultNovaSchedulerSpec(novaNames)
 		return spec, "NovaScheduler", novaNames.SchedulerName.Name
 	})
 	metadataEntry = Entry("metadata sub CR", func() (
-		map[string]interface{}, string, string) {
+		map[string]any, string, string) {
 		spec := GetDefaultNovaMetadataSpec(novaNames.MetadataName)
 		return spec, "NovaMetadata", novaNames.MetadataName.Name
 	})
 	cellEntry = Entry("cell0 topologyRef", func() (
-		map[string]interface{}, string, string) {
+		map[string]any, string, string) {
 		spec := GetDefaultNovaCellTemplate()
 		return spec, "NovaCell", cell0.CellName
 	})
 	cell0MetadataEntry = Entry("cell0 metadata topologyRef", func() (
-		map[string]interface{}, string, string) {
+		map[string]any, string, string) {
 		spec := GetDefaultNovaMetadataSpec(cell0.MetadataName)
 		return spec, "NovaMetadata", cell0.ConductorName.Name
 	})
 	cell0ConductorEntry = Entry("cell0 conductor topologyRef", func() (
-		map[string]interface{}, string, string) {
+		map[string]any, string, string) {
 		spec := GetDefaultNovaConductorSpec(cell0)
 		return spec, "NovaConductor", cell0.ConductorName.Name
 	})
 	cell0NoVNCProxyEntry = Entry("cell0 NoVNCProxy topologyRef", func() (
-		map[string]interface{}, string, string) {
+		map[string]any, string, string) {
 		spec := GetDefaultNovaNoVNCProxySpec(cell0)
 		return spec, "NovaNoVNCProxy", cell0.NoVNCProxyName.Name
 	})
 	cell0ComputeEntry = Entry("cell0 compute topologyRef", func() (
-		map[string]interface{}, string, string) {
+		map[string]any, string, string) {
 		spec := GetDefaultNovaComputeSpec(cell0)
 		return spec, "NovaCompute", cell0.NovaComputeName.Name
 	})
@@ -83,24 +83,24 @@ var (
 var _ = Describe("Nova validation", func() {
 	It("rejects Nova with metadata in cell0", func() {
 		spec := GetDefaultNovaSpec()
-		spec["metadataServiceTemplate"] = map[string]interface{}{
+		spec["metadataServiceTemplate"] = map[string]any{
 			"enabled": false,
 		}
 		cell0Template := GetDefaultNovaCellTemplate()
-		cell0Template["metadataServiceTemplate"] = map[string]interface{}{
+		cell0Template["metadataServiceTemplate"] = map[string]any{
 			"enabled": true,
 		}
 
-		spec["cellTemplates"] = map[string]interface{}{
+		spec["cellTemplates"] = map[string]any{
 			"cell0": cell0Template,
 			// note that this is intentional to test that metadata 1 is allowed
 			// in cell1 but not in cell0
 			"cell1": cell0Template,
 		}
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "nova.openstack.org/v1beta1",
 			"kind":       "Nova",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      novaNames.NovaName.Name,
 				"namespace": novaNames.Namespace,
 			},
@@ -123,13 +123,13 @@ var _ = Describe("Nova validation", func() {
 	})
 	It("rejects NovaCell with metadata in cell0", func() {
 		spec := GetDefaultNovaCellSpec(cell0)
-		spec["metadataServiceTemplate"] = map[string]interface{}{
+		spec["metadataServiceTemplate"] = map[string]any{
 			"enabled": true,
 		}
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "nova.openstack.org/v1beta1",
 			"kind":       "NovaCell",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      cell0.CellCRName.Name,
 				"namespace": novaNames.Namespace,
 			},
@@ -153,20 +153,20 @@ var _ = Describe("Nova validation", func() {
 	It("rejects Nova with NoVNCProxy in cell0", func() {
 		spec := GetDefaultNovaSpec()
 		cell0Template := GetDefaultNovaCellTemplate()
-		cell0Template["noVNCProxyServiceTemplate"] = map[string]interface{}{
+		cell0Template["noVNCProxyServiceTemplate"] = map[string]any{
 			"enabled": true,
 		}
 
-		spec["cellTemplates"] = map[string]interface{}{
+		spec["cellTemplates"] = map[string]any{
 			"cell0": cell0Template,
 			// note that this is intentional to test that novncproxy is allowed
 			// in cell1 but not in cell0
 			"cell1": cell0Template,
 		}
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "nova.openstack.org/v1beta1",
 			"kind":       "Nova",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      novaNames.NovaName.Name,
 				"namespace": novaNames.Namespace,
 			},
@@ -189,13 +189,13 @@ var _ = Describe("Nova validation", func() {
 	})
 	It("rejects NovaCell with NoVNCProxy in cell0", func() {
 		spec := GetDefaultNovaCellSpec(cell0)
-		spec["noVNCProxyServiceTemplate"] = map[string]interface{}{
+		spec["noVNCProxyServiceTemplate"] = map[string]any{
 			"enabled": true,
 		}
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "nova.openstack.org/v1beta1",
 			"kind":       "NovaCell",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      cell0.CellCRName.Name,
 				"namespace": novaNames.Namespace,
 			},
@@ -219,15 +219,15 @@ var _ = Describe("Nova validation", func() {
 	It("rejects Nova with too long cell name", func() {
 		spec := GetDefaultNovaSpec()
 		cell0Template := GetDefaultNovaCellTemplate()
-		spec["cellTemplates"] = map[string]interface{}{
+		spec["cellTemplates"] = map[string]any{
 			"cell0": cell0Template,
 			// the limit is 35 chars, this is 5 + 31
 			"cell1" + strings.Repeat("x", 31): cell0Template,
 		}
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "nova.openstack.org/v1beta1",
 			"kind":       "Nova",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      novaNames.NovaName.Name,
 				"namespace": novaNames.Namespace,
 			},
@@ -252,15 +252,15 @@ var _ = Describe("Nova validation", func() {
 	DescribeTable("rejects Nova with wrong cell name format", func(cellName string) {
 		spec := GetDefaultNovaSpec()
 		cell0Template := GetDefaultNovaCellTemplate()
-		spec["cellTemplates"] = map[string]interface{}{
+		spec["cellTemplates"] = map[string]any{
 			"cell0": cell0Template,
 			// the limit is 35 chars, this is 5 + 31
 			cellName: cell0Template,
 		}
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "nova.openstack.org/v1beta1",
 			"kind":       "Nova",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      novaNames.NovaName.Name,
 				"namespace": novaNames.Namespace,
 			},
@@ -290,10 +290,10 @@ var _ = Describe("Nova validation", func() {
 	It("rejects NovaCell with too long cell name", func() {
 		cell := GetCellNames(novaNames.NovaName, "cell1"+strings.Repeat("x", 31))
 		spec := GetDefaultNovaCellSpec(cell)
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "nova.openstack.org/v1beta1",
 			"kind":       "NovaCell",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      cell0.CellCRName.Name,
 				"namespace": novaNames.Namespace,
 			},
@@ -316,24 +316,24 @@ var _ = Describe("Nova validation", func() {
 	})
 	It("rejects Nova with multiple errors", func() {
 		spec := GetDefaultNovaSpec()
-		spec["metadataServiceTemplate"] = map[string]interface{}{
+		spec["metadataServiceTemplate"] = map[string]any{
 			"enabled": false,
 		}
 		cell0Template := GetDefaultNovaCellTemplate()
-		cell0Template["metadataServiceTemplate"] = map[string]interface{}{
+		cell0Template["metadataServiceTemplate"] = map[string]any{
 			"enabled": true,
 		}
 
-		spec["cellTemplates"] = map[string]interface{}{
+		spec["cellTemplates"] = map[string]any{
 			// error: this is cell0 with metadata
 			"cell0": cell0Template,
 			// error: this is a too long cell name
 			"cell1" + strings.Repeat("x", 31): cell0Template,
 		}
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "nova.openstack.org/v1beta1",
 			"kind":       "Nova",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      novaNames.NovaName.Name,
 				"namespace": novaNames.Namespace,
 			},
@@ -369,15 +369,15 @@ var _ = Describe("Nova validation", func() {
 		spec := GetDefaultNovaSpec()
 		cell1Template := GetDefaultNovaCellTemplate()
 
-		spec["cellTemplates"] = map[string]interface{}{
+		spec["cellTemplates"] = map[string]any{
 			// We explicitly not define cell0 template to trigger the
 			// validation
 			"cell1": cell1Template,
 		}
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "nova.openstack.org/v1beta1",
 			"kind":       "Nova",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      novaNames.NovaName.Name,
 				"namespace": novaNames.Namespace,
 			},
@@ -401,14 +401,14 @@ var _ = Describe("Nova validation", func() {
 	It("rejects Nova if cell0 contains novacomputetemplates", func() {
 		spec := GetDefaultNovaSpec()
 		cell0 := GetDefaultNovaCellTemplate()
-		cell0["novaComputeTemplates"] = map[string]interface{}{
+		cell0["novaComputeTemplates"] = map[string]any{
 			ironicComputeName: GetDefaultNovaComputeTemplate(),
 		}
-		spec["cellTemplates"] = map[string]interface{}{"cell0": cell0}
-		raw := map[string]interface{}{
+		spec["cellTemplates"] = map[string]any{"cell0": cell0}
+		raw := map[string]any{
 			"apiVersion": "nova.openstack.org/v1beta1",
 			"kind":       "Nova",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      novaNames.NovaName.Name,
 				"namespace": novaNames.Namespace,
 			},
@@ -434,14 +434,14 @@ var _ = Describe("Nova validation", func() {
 		spec := GetDefaultNovaSpec()
 		cell0 := GetDefaultNovaCellTemplate()
 		cell1 := GetDefaultNovaCellTemplate()
-		cell1["novaComputeTemplates"] = map[string]interface{}{
+		cell1["novaComputeTemplates"] = map[string]any{
 			ironicComputeName + strings.Repeat("x", 31): GetDefaultNovaComputeTemplate(),
 		}
-		spec["cellTemplates"] = map[string]interface{}{"cell0": cell0, "cell1": cell1}
-		raw := map[string]interface{}{
+		spec["cellTemplates"] = map[string]any{"cell0": cell0, "cell1": cell1}
+		raw := map[string]any{
 			"apiVersion": "nova.openstack.org/v1beta1",
 			"kind":       "Nova",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      novaNames.NovaName.Name,
 				"namespace": novaNames.Namespace,
 			},
@@ -470,14 +470,14 @@ var _ = Describe("Nova validation", func() {
 		cell1 := GetDefaultNovaCellTemplate()
 		novaCompute := GetDefaultNovaComputeTemplate()
 		novaCompute["replicas"] = nil
-		cell1["novaComputeTemplates"] = map[string]interface{}{
+		cell1["novaComputeTemplates"] = map[string]any{
 			ironicComputeName: novaCompute,
 		}
-		spec["cellTemplates"] = map[string]interface{}{"cell0": cell0, "cell1": cell1}
-		raw := map[string]interface{}{
+		spec["cellTemplates"] = map[string]any{"cell0": cell0, "cell1": cell1}
+		raw := map[string]any{
 			"apiVersion": "nova.openstack.org/v1beta1",
 			"kind":       "Nova",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      novaNames.NovaName.Name,
 				"namespace": novaNames.Namespace,
 			},
@@ -495,14 +495,14 @@ var _ = Describe("Nova validation", func() {
 		cell1 := GetDefaultNovaCellTemplate()
 		novaCompute := GetDefaultNovaComputeTemplate()
 		novaCompute["replicas"] = 2
-		cell1["novaComputeTemplates"] = map[string]interface{}{
+		cell1["novaComputeTemplates"] = map[string]any{
 			ironicComputeName: novaCompute,
 		}
-		spec["cellTemplates"] = map[string]interface{}{"cell0": cell0, "cell1": cell1}
-		raw := map[string]interface{}{
+		spec["cellTemplates"] = map[string]any{"cell0": cell0, "cell1": cell1}
+		raw := map[string]any{
 			"apiVersion": "nova.openstack.org/v1beta1",
 			"kind":       "Nova",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      novaNames.NovaName.Name,
 				"namespace": novaNames.Namespace,
 			},
@@ -528,13 +528,13 @@ var _ = Describe("Nova validation", func() {
 	})
 	It("rejects NovaCell - cell0 contains novacomputetemplates", func() {
 		spec := GetDefaultNovaCellSpec(cell0)
-		spec["novaComputeTemplates"] = map[string]interface{}{
+		spec["novaComputeTemplates"] = map[string]any{
 			ironicComputeName: GetDefaultNovaComputeTemplate(),
 		}
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "nova.openstack.org/v1beta1",
 			"kind":       "NovaCell",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      cell0.CellCRName.Name,
 				"namespace": novaNames.Namespace,
 			},
@@ -557,13 +557,13 @@ var _ = Describe("Nova validation", func() {
 	})
 	It("rejects NovaCell with too long compute name", func() {
 		spec := GetDefaultNovaCellSpec(cell1)
-		spec["novaComputeTemplates"] = map[string]interface{}{
+		spec["novaComputeTemplates"] = map[string]any{
 			ironicComputeName + strings.Repeat("x", 31): GetDefaultNovaComputeTemplate(),
 		}
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "nova.openstack.org/v1beta1",
 			"kind":       "NovaCell",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      cell1.CellCRName.Name,
 				"namespace": novaNames.Namespace,
 			},
@@ -587,13 +587,13 @@ var _ = Describe("Nova validation", func() {
 	})
 	DescribeTable("rejects NovaCell with wrong compute name", func(computeName string) {
 		spec := GetDefaultNovaCellSpec(cell1)
-		spec["novaComputeTemplates"] = map[string]interface{}{
+		spec["novaComputeTemplates"] = map[string]any{
 			computeName: GetDefaultNovaComputeTemplate(),
 		}
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "nova.openstack.org/v1beta1",
 			"kind":       "NovaCell",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      cell1.CellCRName.Name,
 				"namespace": novaNames.Namespace,
 			},
@@ -621,23 +621,23 @@ var _ = Describe("Nova validation", func() {
 	)
 	It("rejects Nova with metadata both on top and in cells", func() {
 		spec := GetDefaultNovaSpec()
-		spec["metadataServiceTemplate"] = map[string]interface{}{
+		spec["metadataServiceTemplate"] = map[string]any{
 			"enabled": true,
 		}
 		cell0Template := GetDefaultNovaCellTemplate()
 		cell1Template := GetDefaultNovaCellTemplate()
-		cell1Template["metadataServiceTemplate"] = map[string]interface{}{
+		cell1Template["metadataServiceTemplate"] = map[string]any{
 			"enabled": true,
 		}
 
-		spec["cellTemplates"] = map[string]interface{}{
+		spec["cellTemplates"] = map[string]any{
 			"cell0": cell0Template,
 			"cell1": cell1Template,
 		}
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "nova.openstack.org/v1beta1",
 			"kind":       "Nova",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      novaNames.NovaName.Name,
 				"namespace": novaNames.Namespace,
 			},
@@ -669,11 +669,11 @@ var _ = Describe("Nova validation", func() {
 		cell2 := GetDefaultNovaCellTemplate()
 		cell1["cellMessageBusInstance"] = "rabbitmq-of-caerbannog"
 		cell2["cellMessageBusInstance"] = "rabbitmq-of-caerbannog"
-		spec["cellTemplates"] = map[string]interface{}{"cell0": cell0, "cell1": cell1, "cell2": cell2}
-		raw := map[string]interface{}{
+		spec["cellTemplates"] = map[string]any{"cell0": cell0, "cell1": cell1, "cell2": cell2}
+		raw := map[string]any{
 			"apiVersion": "nova.openstack.org/v1beta1",
 			"kind":       "Nova",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      novaNames.NovaName.Name,
 				"namespace": novaNames.Namespace,
 			},
@@ -695,15 +695,15 @@ var _ = Describe("Nova validation", func() {
 	})
 	It("rejects NovaAPI with wrong defaultConfigOverwrite", func() {
 		spec := GetDefaultNovaAPISpec(novaNames)
-		spec["defaultConfigOverwrite"] = map[string]interface{}{
+		spec["defaultConfigOverwrite"] = map[string]any{
 			"policy.yaml":   "custom policy",
 			"api-paste.ini": "custom paste config",
 			"foo.conf":      "wrong custom config",
 		}
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "nova.openstack.org/v1beta1",
 			"kind":       "NovaAPI",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      novaNames.APIName.Name,
 				"namespace": novaNames.Namespace,
 			},
@@ -728,20 +728,20 @@ var _ = Describe("Nova validation", func() {
 	})
 	It("rejects Nova with wrong defaultConfigOverwrite in NovaAPI", func() {
 		spec := GetDefaultNovaSpec()
-		spec["cellTemplates"] = map[string]interface{}{
+		spec["cellTemplates"] = map[string]any{
 			"cell0": GetDefaultNovaCellTemplate(),
 		}
-		spec["apiServiceTemplate"] = map[string]interface{}{
-			"defaultConfigOverwrite": map[string]interface{}{
+		spec["apiServiceTemplate"] = map[string]any{
+			"defaultConfigOverwrite": map[string]any{
 				"policy.yaml":   "custom policy",
 				"api-paste.ini": "custom paste config",
 				"provider.yaml": "provider.yaml not supported here",
 			},
 		}
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "nova.openstack.org/v1beta1",
 			"kind":       "Nova",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      novaNames.NovaName.Name,
 				"namespace": novaNames.Namespace,
 			},
@@ -766,14 +766,14 @@ var _ = Describe("Nova validation", func() {
 
 	It("rejects NovaMetadata with wrong defaultConfigOverwrite", func() {
 		spec := GetDefaultNovaMetadataSpec(novaNames.InternalTopLevelSecretName)
-		spec["defaultConfigOverwrite"] = map[string]interface{}{
+		spec["defaultConfigOverwrite"] = map[string]any{
 			"policy.yaml":   "custom policy not supported",
 			"api-paste.ini": "custom paste config",
 		}
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "nova.openstack.org/v1beta1",
 			"kind":       "NovaMetadata",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      novaNames.MetadataName.Name,
 				"namespace": novaNames.Namespace,
 			},
@@ -798,19 +798,19 @@ var _ = Describe("Nova validation", func() {
 	})
 	It("rejects Nova with wrong defaultConfigOverwrite in top level NovaMetadata", func() {
 		spec := GetDefaultNovaSpec()
-		spec["cellTemplates"] = map[string]interface{}{
+		spec["cellTemplates"] = map[string]any{
 			"cell0": GetDefaultNovaCellTemplate(),
 		}
-		spec["metadataServiceTemplate"] = map[string]interface{}{
-			"defaultConfigOverwrite": map[string]interface{}{
+		spec["metadataServiceTemplate"] = map[string]any{
+			"defaultConfigOverwrite": map[string]any{
 				"policy.yaml":   "custom policy not supported",
 				"api-paste.ini": "custom paste config",
 			},
 		}
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "nova.openstack.org/v1beta1",
 			"kind":       "Nova",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      novaNames.NovaName.Name,
 				"namespace": novaNames.Namespace,
 			},
@@ -835,20 +835,20 @@ var _ = Describe("Nova validation", func() {
 	It("rejects Nova with wrong defaultConfigOverwrite in cell level NovaMetadata", func() {
 		spec := GetDefaultNovaSpec()
 		cell1 := GetDefaultNovaCellTemplate()
-		cell1["metadataServiceTemplate"] = map[string]interface{}{
-			"defaultConfigOverwrite": map[string]interface{}{
+		cell1["metadataServiceTemplate"] = map[string]any{
+			"defaultConfigOverwrite": map[string]any{
 				"policy.yaml":   "custom policy not supported",
 				"api-paste.ini": "custom paste config",
 			},
 		}
-		spec["cellTemplates"] = map[string]interface{}{
+		spec["cellTemplates"] = map[string]any{
 			"cell0": GetDefaultNovaCellTemplate(),
 			"cell1": cell1,
 		}
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "nova.openstack.org/v1beta1",
 			"kind":       "Nova",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      novaNames.NovaName.Name,
 				"namespace": novaNames.Namespace,
 			},
@@ -872,14 +872,14 @@ var _ = Describe("Nova validation", func() {
 	})
 	It("rejects NovaCompute with wrong defaultConfigOverwrite", func() {
 		spec := GetDefaultNovaComputeSpec(cell1)
-		spec["defaultConfigOverwrite"] = map[string]interface{}{
+		spec["defaultConfigOverwrite"] = map[string]any{
 			"policy.yaml":      "custom policy not supported",
 			"provider123.yaml": "provider*.yaml is supported",
 		}
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "nova.openstack.org/v1beta1",
 			"kind":       "NovaCompute",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      cell1.NovaComputeName.Name,
 				"namespace": novaNames.Namespace,
 			},
@@ -905,18 +905,18 @@ var _ = Describe("Nova validation", func() {
 	It("rejects NovaCell with wrong defaultConfigOverwrite in computeTemplates", func() {
 		spec := GetDefaultNovaCellSpec(cell1)
 		novaCompute := GetDefaultNovaComputeTemplate()
-		novaCompute["defaultConfigOverwrite"] = map[string]interface{}{
+		novaCompute["defaultConfigOverwrite"] = map[string]any{
 			"policy.yaml":      "custom policy not supported",
 			"provider123.yaml": "provider*.yaml is supported",
 		}
-		spec["novaComputeTemplates"] = map[string]interface{}{
+		spec["novaComputeTemplates"] = map[string]any{
 			ironicComputeName: novaCompute,
 		}
 
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "nova.openstack.org/v1beta1",
 			"kind":       "NovaCell",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      cell1.CellCRName.Name,
 				"namespace": novaNames.Namespace,
 			},
@@ -944,18 +944,18 @@ var _ = Describe("Nova validation", func() {
 		cell0 := GetDefaultNovaCellTemplate()
 		cell1 := GetDefaultNovaCellTemplate()
 		novaCompute := GetDefaultNovaComputeTemplate()
-		novaCompute["defaultConfigOverwrite"] = map[string]interface{}{
+		novaCompute["defaultConfigOverwrite"] = map[string]any{
 			"policy.yaml":      "custom policy not supported",
 			"provider123.yaml": "provider*.yaml is supported",
 		}
-		cell1["novaComputeTemplates"] = map[string]interface{}{
+		cell1["novaComputeTemplates"] = map[string]any{
 			ironicComputeName: novaCompute,
 		}
-		spec["cellTemplates"] = map[string]interface{}{"cell0": cell0, "cell1": cell1}
-		raw := map[string]interface{}{
+		spec["cellTemplates"] = map[string]any{"cell0": cell0, "cell1": cell1}
+		raw := map[string]any{
 			"apiVersion": "nova.openstack.org/v1beta1",
 			"kind":       "Nova",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      novaNames.NovaName.Name,
 				"namespace": novaNames.Namespace,
 			},
@@ -980,13 +980,13 @@ var _ = Describe("Nova validation", func() {
 	})
 	It("rejects NovaConductor with wrong dbPurge.Schedule", func() {
 		spec := GetDefaultNovaConductorSpec(cell1)
-		spec["dbPurge"] = map[string]interface{}{
+		spec["dbPurge"] = map[string]any{
 			"schedule": "* * * *",
 		}
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "nova.openstack.org/v1beta1",
 			"kind":       "NovaConductor",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      cell1.ConductorName.Name,
 				"namespace": novaNames.Namespace,
 			},
@@ -1012,14 +1012,14 @@ var _ = Describe("Nova validation", func() {
 	It("rejects NovaCell with wrong dbPurge.Schedule", func() {
 		spec := GetDefaultNovaCellSpec(cell1)
 
-		spec["dbPurge"] = map[string]interface{}{
+		spec["dbPurge"] = map[string]any{
 			"schedule": "* * * * * 1",
 		}
 
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "nova.openstack.org/v1beta1",
 			"kind":       "NovaCell",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      cell1.CellCRName.Name,
 				"namespace": novaNames.Namespace,
 			},
@@ -1046,14 +1046,14 @@ var _ = Describe("Nova validation", func() {
 		spec := GetDefaultNovaSpec()
 		cell0 := GetDefaultNovaCellTemplate()
 		cell1 := GetDefaultNovaCellTemplate()
-		cell1["dbPurge"] = map[string]interface{}{
+		cell1["dbPurge"] = map[string]any{
 			"schedule": "@dailyX",
 		}
-		spec["cellTemplates"] = map[string]interface{}{"cell0": cell0, "cell1": cell1}
-		raw := map[string]interface{}{
+		spec["cellTemplates"] = map[string]any{"cell0": cell0, "cell1": cell1}
+		raw := map[string]any{
 			"apiVersion": "nova.openstack.org/v1beta1",
 			"kind":       "Nova",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      novaNames.NovaName.Name,
 				"namespace": novaNames.Namespace,
 			},
@@ -1079,16 +1079,16 @@ var _ = Describe("Nova validation", func() {
 
 	It("rejects NovaAPI wrong service override endpoint type", func() {
 		spec := GetDefaultNovaAPISpec(novaNames)
-		spec["override"] = map[string]interface{}{
-			"service": map[string]interface{}{
-				"internal": map[string]interface{}{},
-				"wrooong":  map[string]interface{}{},
+		spec["override"] = map[string]any{
+			"service": map[string]any{
+				"internal": map[string]any{},
+				"wrooong":  map[string]any{},
 			},
 		}
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "nova.openstack.org/v1beta1",
 			"kind":       "NovaAPI",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      novaNames.APIName.Name,
 				"namespace": novaNames.Namespace,
 			},
@@ -1111,21 +1111,21 @@ var _ = Describe("Nova validation", func() {
 	})
 	It("rejects Nova with wrong service override endpoint type in NovaAPI", func() {
 		spec := GetDefaultNovaSpec()
-		spec["cellTemplates"] = map[string]interface{}{
+		spec["cellTemplates"] = map[string]any{
 			"cell0": GetDefaultNovaCellTemplate(),
 		}
-		spec["apiServiceTemplate"] = map[string]interface{}{
-			"override": map[string]interface{}{
-				"service": map[string]interface{}{
-					"internal": map[string]interface{}{},
-					"wrooong":  map[string]interface{}{},
+		spec["apiServiceTemplate"] = map[string]any{
+			"override": map[string]any{
+				"service": map[string]any{
+					"internal": map[string]any{},
+					"wrooong":  map[string]any{},
 				},
 			},
 		}
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "nova.openstack.org/v1beta1",
 			"kind":       "Nova",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      novaNames.NovaName.Name,
 				"namespace": novaNames.Namespace,
 			},
@@ -1147,15 +1147,15 @@ var _ = Describe("Nova validation", func() {
 		)
 	})
 	DescribeTable("rejects wrong topology for",
-		func(serviceNameFunc func() (map[string]interface{}, string, string)) {
+		func(serviceNameFunc func() (map[string]any, string, string)) {
 			expectedErrorMessage := "spec.topologyRef.namespace: Invalid value: \"namespace\": Customizing namespace field is not supported"
 
 			spec, kind, name := serviceNameFunc()
-			spec["topologyRef"] = map[string]interface{}{"name": "foo", "namespace": "bar"}
-			raw := map[string]interface{}{
+			spec["topologyRef"] = map[string]any{"name": "foo", "namespace": "bar"}
+			raw := map[string]any{
 				"apiVersion": "nova.openstack.org/v1beta1",
 				"kind":       kind,
-				"metadata": map[string]interface{}{
+				"metadata": map[string]any{
 					"name":      name,
 					"namespace": novaNames.Namespace,
 				},


### PR DESCRIPTION
Modernize using `gopls modernize tool` to update:

- Replace interface{} with any type alias (Go 1.18+)
- Update range loops to use idiomatic range syntax
- Replace fmt.Sprintf with fmt.Appendf where appropriate

These changes improve code readability and align with current Go best practices.

Co-Authored-By: Claude <noreply@anthropic.com>