### PR TITLE
 [OSPRH-20366] Improve consistency of condition severity usage

### DIFF
--- a/controllers/nova_controller.go
+++ b/controllers/nova_controller.go
@@ -354,8 +354,8 @@ func (r *NovaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 	} else if len(creatingDBs) > 0 {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			novav1.NovaAllCellsDBReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityError,
+			condition.RequestedReason,
+			condition.SeverityInfo,
 			novav1.NovaAllCellsDBReadyCreatingMessage,
 			strings.Join(creatingDBs, ",")))
 	} else { // we have no DB in failed or creating status so all DB is ready
@@ -380,8 +380,8 @@ func (r *NovaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 	case nova.MQCreating:
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			novav1.NovaAPIMQReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityError,
+			condition.RequestedReason,
+			condition.SeverityInfo,
 			novav1.NovaAPIMQReadyCreatingMessage,
 		))
 	case nova.MQCompleted:
@@ -418,8 +418,8 @@ func (r *NovaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 		case nova.MQCreating:
 			instance.Status.Conditions.Set(condition.FalseCondition(
 				novav1.NovaNotificationMQReadyCondition,
-				condition.ErrorReason,
-				condition.SeverityError,
+				condition.RequestedReason,
+				condition.SeverityInfo,
 				novav1.NovaNotificationMQReadyCreatingMessage,
 			))
 		case nova.MQCompleted:
@@ -492,8 +492,8 @@ func (r *NovaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 	} else if len(creatingMQs) > 0 {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			novav1.NovaAllCellsMQReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityError,
+			condition.RequestedReason,
+			condition.SeverityInfo,
 			novav1.NovaAllCellsMQReadyCreatingMessage,
 			strings.Join(creatingMQs, ",")))
 	} else { // we have no MQ in failed or creating status so all MQ is ready
@@ -581,7 +581,7 @@ func (r *NovaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			novav1.NovaAllCellsReadyCondition,
 			condition.RequestedReason,
-			condition.SeverityWarning,
+			condition.SeverityInfo,
 			novav1.NovaAllCellsReadyNotReadyMessage,
 			strings.Join(append(deployingCells, mappingCells...), ","),
 		))

--- a/controllers/novaapi_controller.go
+++ b/controllers/novaapi_controller.go
@@ -274,10 +274,12 @@ func (r *NovaAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since the CA cert secret should have been manually created by the user and provided in the spec,
+				// we treat this as a warning because it means that the service will not be able to start.
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					condition.TLSInputReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName))
 				return ctrl.Result{}, nil
 			}

--- a/controllers/novacompute_controller.go
+++ b/controllers/novacompute_controller.go
@@ -215,10 +215,12 @@ func (r *NovaComputeReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since the CA cert secret should have been manually created by the user and provided in the spec,
+				// we treat this as a warning because it means that the service will not be able to start.
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					condition.TLSInputReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName))
 				return ctrl.Result{}, nil
 			}

--- a/controllers/novaconductor_controller.go
+++ b/controllers/novaconductor_controller.go
@@ -236,10 +236,12 @@ func (r *NovaConductorReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since the CA cert secret should have been manually created by the user and provided in the spec,
+				// we treat this as a warning because it means that the service will not be able to start.
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					condition.TLSInputReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName))
 				return ctrl.Result{}, nil
 			}

--- a/controllers/novametadata_controller.go
+++ b/controllers/novametadata_controller.go
@@ -251,10 +251,12 @@ func (r *NovaMetadataReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since the CA cert secret should have been manually created by the user and provided in the spec,
+				// we treat this as a warning because it means that the service will not be able to start.
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					condition.TLSInputReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName))
 				return ctrl.Result{}, nil
 			}

--- a/controllers/novanovncproxy_controller.go
+++ b/controllers/novanovncproxy_controller.go
@@ -230,10 +230,12 @@ func (r *NovaNoVNCProxyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since the CA cert secret should have been manually created by the user and provided in the spec,
+				// we treat this as a warning because it means that the service will not be able to start.
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					condition.TLSInputReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName))
 				return ctrl.Result{}, nil
 			}
@@ -256,6 +258,8 @@ func (r *NovaNoVNCProxyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		hash, err := instance.Spec.TLS.Service.ValidateCertSecret(ctx, h, instance.Namespace)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// We treat this as an info since the service cert secret is automatically generated
+				// by the encompassing OpenStackControlPlane CR
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					condition.TLSInputReadyCondition,
 					condition.RequestedReason,
@@ -279,6 +283,8 @@ func (r *NovaNoVNCProxyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		hash, err := instance.Spec.TLS.Vencrypt.ValidateCertSecret(ctx, h, instance.Namespace)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// We treat this as an info since the vencrypt cert secret is automatically generated
+				// by the encompassing OpenStackControlPlane CR
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					condition.TLSInputReadyCondition,
 					condition.RequestedReason,

--- a/controllers/novascheduler_controller.go
+++ b/controllers/novascheduler_controller.go
@@ -237,10 +237,12 @@ func (r *NovaSchedulerReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since the CA cert secret should have been manually created by the user and provided in the spec,
+				// we treat this as a warning because it means that the service will not be able to start.
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					condition.TLSInputReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName))
 				return ctrl.Result{}, nil
 			}

--- a/test/functional/nova_compute_ironic_controller_test.go
+++ b/test/functional/nova_compute_ironic_controller_test.go
@@ -347,7 +347,7 @@ var _ = Describe("NovaCompute with ironic diver controller", func() {
 				ConditionGetterFunc(NovaComputeConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				"NetworkAttachment resources missing: internalapi",
 			)
 			th.ExpectCondition(
@@ -506,7 +506,7 @@ var _ = Describe("NovaCompute with ironic diver controller", func() {
 				ConditionGetterFunc(NovaComputeConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				"NetworkAttachment resources missing: internalapi",
 			)
 			th.ExpectConditionWithDetails(
@@ -514,7 +514,7 @@ var _ = Describe("NovaCompute with ironic diver controller", func() {
 				ConditionGetterFunc(NovaComputeConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				"NetworkAttachment resources missing: internalapi",
 			)
 
@@ -661,7 +661,7 @@ var _ = Describe("NovaCompute with ironic diver controller", func() {
 				ConditionGetterFunc(NovaComputeConditionGetter),
 				condition.TLSInputReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				fmt.Sprintf("TLSInput is missing: %s", novaNames.CaBundleSecretName.Name),
 			)
 			th.ExpectCondition(

--- a/test/functional/nova_controller_test.go
+++ b/test/functional/nova_controller_test.go
@@ -1944,7 +1944,7 @@ var _ = Describe("Nova controller without memcached", func() {
 			ConditionGetterFunc(NovaConditionGetter),
 			condition.MemcachedReadyCondition,
 			corev1.ConditionFalse,
-			condition.RequestedReason,
+			condition.ErrorReason,
 			" Memcached instance has not been provisioned",
 		)
 	})

--- a/test/functional/nova_metadata_controller_test.go
+++ b/test/functional/nova_metadata_controller_test.go
@@ -497,7 +497,7 @@ var _ = Describe("NovaMetadata controller", func() {
 				ConditionGetterFunc(NovaMetadataConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				"NetworkAttachment resources missing: internalapi",
 			)
 			th.ExpectCondition(
@@ -712,7 +712,7 @@ var _ = Describe("NovaMetadata controller", func() {
 				ConditionGetterFunc(NovaMetadataConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				"NetworkAttachment resources missing: internalapi",
 			)
 			th.ExpectConditionWithDetails(
@@ -720,7 +720,7 @@ var _ = Describe("NovaMetadata controller", func() {
 				ConditionGetterFunc(NovaMetadataConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				"NetworkAttachment resources missing: internalapi",
 			)
 
@@ -939,7 +939,7 @@ var _ = Describe("NovaMetadata controller", func() {
 				ConditionGetterFunc(NovaMetadataConditionGetter),
 				condition.TLSInputReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				fmt.Sprintf("TLSInput is missing: %s", novaNames.CaBundleSecretName.Name),
 			)
 			th.ExpectCondition(

--- a/test/functional/nova_novncproxy_test.go
+++ b/test/functional/nova_novncproxy_test.go
@@ -88,7 +88,7 @@ var _ = Describe("NovaNoVNCProxy controller", func() {
 					ConditionGetterFunc(NoVNCProxyConditionGetter),
 					condition.InputReadyCondition,
 					corev1.ConditionFalse,
-					condition.RequestedReason,
+					condition.ErrorReason,
 					fmt.Sprintf("Input data resources missing: secret/%s", cell1.CellCRName.Name),
 				)
 			})
@@ -371,7 +371,7 @@ var _ = Describe("NovaNoVNCProxy controller", func() {
 				ConditionGetterFunc(NoVNCProxyConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				"NetworkAttachment resources missing: internalapi",
 			)
 			th.ExpectCondition(
@@ -637,7 +637,7 @@ var _ = Describe("NovaNoVNCProxy controller", func() {
 				ConditionGetterFunc(NoVNCProxyConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				"NetworkAttachment resources missing: internalapi",
 			)
 			th.ExpectConditionWithDetails(
@@ -645,7 +645,7 @@ var _ = Describe("NovaNoVNCProxy controller", func() {
 				ConditionGetterFunc(NoVNCProxyConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				"NetworkAttachment resources missing: internalapi",
 			)
 
@@ -828,7 +828,7 @@ var _ = Describe("NovaNoVNCProxy controller", func() {
 				ConditionGetterFunc(NoVNCProxyConditionGetter),
 				condition.TLSInputReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				fmt.Sprintf("TLSInput is missing: %s", novaNames.CaBundleSecretName.Name),
 			)
 			th.ExpectCondition(
@@ -990,7 +990,7 @@ var _ = Describe("NovaNoVNCProxy controller", func() {
 				ConditionGetterFunc(NoVNCProxyConditionGetter),
 				condition.TLSInputReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				fmt.Sprintf("TLSInput is missing: %s", novaNames.CaBundleSecretName.Name),
 			)
 			th.ExpectCondition(
@@ -1155,7 +1155,7 @@ var _ = Describe("NovaNoVNCProxy controller", func() {
 				ConditionGetterFunc(NoVNCProxyConditionGetter),
 				condition.TLSInputReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				fmt.Sprintf("TLSInput is missing: %s", novaNames.CaBundleSecretName.Name),
 			)
 			th.ExpectCondition(

--- a/test/functional/nova_reconfiguration_test.go
+++ b/test/functional/nova_reconfiguration_test.go
@@ -165,7 +165,7 @@ var _ = Describe("Nova reconfiguration", func() {
 				ConditionGetterFunc(NovaConductorConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				"NetworkAttachment resources missing: internalapi",
 			)
 			th.ExpectConditionWithDetails(
@@ -173,7 +173,7 @@ var _ = Describe("Nova reconfiguration", func() {
 				ConditionGetterFunc(NovaConductorConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				"NetworkAttachment resources missing: internalapi",
 			)
 
@@ -182,7 +182,7 @@ var _ = Describe("Nova reconfiguration", func() {
 				ConditionGetterFunc(NovaCellConditionGetter),
 				novav1.NovaConductorReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				"NetworkAttachment resources missing: internalapi",
 			)
 			th.ExpectConditionWithDetails(
@@ -190,7 +190,7 @@ var _ = Describe("Nova reconfiguration", func() {
 				ConditionGetterFunc(NovaCellConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				"NetworkAttachment resources missing: internalapi",
 			)
 

--- a/test/functional/nova_scheduler_test.go
+++ b/test/functional/nova_scheduler_test.go
@@ -386,7 +386,7 @@ var _ = Describe("NovaScheduler controller", func() {
 				ConditionGetterFunc(NovaSchedulerConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				"NetworkAttachment resources missing: internalapi",
 			)
 			th.ExpectCondition(
@@ -539,7 +539,7 @@ var _ = Describe("NovaScheduler controller", func() {
 				ConditionGetterFunc(NovaSchedulerConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				"NetworkAttachment resources missing: internalapi",
 			)
 
@@ -548,7 +548,7 @@ var _ = Describe("NovaScheduler controller", func() {
 				ConditionGetterFunc(NovaSchedulerConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				"NetworkAttachment resources missing: internalapi",
 			)
 
@@ -787,7 +787,7 @@ var _ = Describe("NovaScheduler controller", func() {
 				ConditionGetterFunc(NovaSchedulerConditionGetter),
 				condition.TLSInputReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				fmt.Sprintf("TLSInput is missing: %s", novaNames.CaBundleSecretName.Name),
 			)
 			th.ExpectCondition(

--- a/test/functional/novaapi_controller_test.go
+++ b/test/functional/novaapi_controller_test.go
@@ -91,7 +91,7 @@ var _ = Describe("NovaAPI controller", func() {
 				ConditionGetterFunc(NovaAPIConditionGetter),
 				condition.InputReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				fmt.Sprintf("Input data resources missing: secret/%s", novaNames.InternalTopLevelSecretName.Name),
 			)
 		})
@@ -123,7 +123,7 @@ var _ = Describe("NovaAPI controller", func() {
 					ConditionGetterFunc(NovaAPIConditionGetter),
 					condition.InputReadyCondition,
 					corev1.ConditionFalse,
-					condition.RequestedReason,
+					condition.ErrorReason,
 					fmt.Sprintf("Input data resources missing: secret/%s", novaNames.InternalTopLevelSecretName.Name),
 				)
 			})
@@ -496,7 +496,7 @@ var _ = Describe("NovaAPI controller", func() {
 				ConditionGetterFunc(NovaAPIConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				"NetworkAttachment resources missing: internalapi",
 			)
 			th.ExpectCondition(
@@ -835,7 +835,7 @@ var _ = Describe("NovaAPI controller", func() {
 				ConditionGetterFunc(NovaAPIConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				"NetworkAttachment resources missing: internalapi",
 			)
 			th.ExpectConditionWithDetails(
@@ -843,7 +843,7 @@ var _ = Describe("NovaAPI controller", func() {
 				ConditionGetterFunc(NovaAPIConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				"NetworkAttachment resources missing: internalapi",
 			)
 
@@ -1018,7 +1018,7 @@ var _ = Describe("NovaAPI controller", func() {
 				ConditionGetterFunc(NovaAPIConditionGetter),
 				condition.TLSInputReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				fmt.Sprintf("TLSInput is missing: %s", novaNames.CaBundleSecretName.Name),
 			)
 			th.ExpectCondition(

--- a/test/functional/novacell_controller_test.go
+++ b/test/functional/novacell_controller_test.go
@@ -73,7 +73,7 @@ var _ = Describe("NovaCell controller", func() {
 				ConditionGetterFunc(NovaCellConditionGetter),
 				condition.InputReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				fmt.Sprintf("Input data resources missing: secret/%s", cell0.InternalCellSecretName.Name),
 			)
 		})
@@ -953,7 +953,7 @@ var _ = Describe("NovaCell controller", func() {
 				ConditionGetterFunc(NovaConductorConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				"NetworkAttachment resources missing: internalapi",
 			)
 
@@ -962,7 +962,7 @@ var _ = Describe("NovaCell controller", func() {
 				ConditionGetterFunc(NovaCellConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				"NetworkAttachment resources missing: internalapi",
 			)
 

--- a/test/functional/novaconductor_controller_test.go
+++ b/test/functional/novaconductor_controller_test.go
@@ -550,7 +550,7 @@ var _ = Describe("NovaConductor controller", func() {
 				ConditionGetterFunc(NovaConductorConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				"NetworkAttachment resources missing: internalapi",
 			)
 			th.ExpectCondition(
@@ -706,7 +706,7 @@ var _ = Describe("NovaConductor controller", func() {
 				ConditionGetterFunc(NovaConductorConditionGetter),
 				condition.NetworkAttachmentsReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				"NetworkAttachment resources missing: internalapi",
 			)
 
@@ -715,7 +715,7 @@ var _ = Describe("NovaConductor controller", func() {
 				ConditionGetterFunc(NovaConductorConditionGetter),
 				condition.ReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				"NetworkAttachment resources missing: internalapi",
 			)
 
@@ -1126,7 +1126,7 @@ var _ = Describe("NovaConductor controller", func() {
 				ConditionGetterFunc(NovaConductorConditionGetter),
 				condition.TLSInputReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				fmt.Sprintf("TLSInput is missing: %s", novaNames.CaBundleSecretName.Name),
 			)
 			th.ExpectCondition(


### PR DESCRIPTION
Use consistent condition severity across repeated patterns found in our operators, and otherwise use an appropriate severity for conditions unique to each operator.

Jira: https://issues.redhat.com/browse/OSPRH-20366

Co-authored-by: Claude (Anthropic) [claude@anthropic.com](mailto:claude@anthropic.com)