### PR TITLE
Allow defaultConfigOverwrite to replace httpd.conf

### DIFF
--- a/api/v1beta1/novaapi_webhook.go
+++ b/api/v1beta1/novaapi_webhook.go
@@ -34,8 +34,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	"github.com/openstack-k8s-operators/lib-common/modules/common/service"
 	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/service"
 )
 
 // NovaAPIDefaults -
@@ -148,7 +148,7 @@ func ValidateAPIDefaultConfigOverwrite(
 	return ValidateDefaultConfigOverwrite(
 		basePath,
 		defaultConfigOverwrite,
-		[]string{"policy.yaml", "api-paste.ini"})
+		[]string{"policy.yaml", "api-paste.ini", "httpd.conf"})
 }
 
 // ValidateTopology validates the referenced TopoRef.Namespace.

--- a/api/v1beta1/novametadata_webhook.go
+++ b/api/v1beta1/novametadata_webhook.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 
 	"github.com/google/go-cmp/cmp"
+	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -33,7 +34,6 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 )
 
 // NovaMetadataDefaults -
@@ -156,7 +156,7 @@ func ValidateMetadataDefaultConfigOverwrite(
 	defaultConfigOverwrite map[string]string,
 ) field.ErrorList {
 	return ValidateDefaultConfigOverwrite(
-		basePath, defaultConfigOverwrite, []string{"api-paste.ini"})
+		basePath, defaultConfigOverwrite, []string{"api-paste.ini", "httpd.conf"})
 }
 
 // ValidateTopology validates the referenced TopoRef.Namespace.


### PR DESCRIPTION
For nova-api and nova-metadata we now allow to replace the whole
apache httpd.conf file. The replacement can be a template the same
way as the default file in templates/novaapi/config/httpd.conf is a
template.

**This is expected to be only used for advanced troubleshooting and not
for customization for production use.** Any permanent customization needs
to go through the CR interface (and potentially need an RFE to extend
such interface)