### PR TITLE
Cleanup placement-import residue

### DIFF
--- a/placement-import/config/manager/kustomization.yaml
+++ b/placement-import/config/manager/kustomization.yaml
@@ -1,8 +1,0 @@
-resources:
-- manager.yaml
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-images:
-- name: controller
-  newName: quay.io/openstack-k8s-operators/placement-operator
-  newTag: latest


### PR DESCRIPTION
placement-import/config/manager/kustomization.yaml was intentionally left during the merge of placement-operator code to nova-operator to ensure git history are preserved. Now that the change has been merged, it is safe to cleanup placement-import dir.

Along with that, we will see how the gate jobs are responding after merge.