### PR TITLE
Add max_retries and retry_interval to [(api_)database] conf

### DIFF
--- a/templates/nova/nova.conf
+++ b/templates/nova/nova.conf
@@ -241,12 +241,24 @@ cpu_power_management=false
 
 {{if (index . "cell_db_address")}}
 [database]
+{{ if eq .service_name "nova-conductor"}}
+max_retries = 30
+{{ else }}
+max_retries = 3
+{{ end }}
+retry_interval = 1
 connection = mysql+pymysql://{{ .cell_db_user }}:{{ .cell_db_password}}@{{ .cell_db_address }}/{{ .cell_db_name }}?read_default_file=/etc/my.cnf
 {{end}}
 
 
 {{if (index . "api_db_address")}}
 [api_database]
+{{ if eq .service_name "nova-conductor"}}
+max_retries = 30
+{{ else }}
+max_retries = 3
+{{ end }}
+retry_interval = 1
 connection = mysql+pymysql://{{ .api_db_user }}:{{ .api_db_password }}@{{ .api_db_address }}/{{ .api_db_name }}?read_default_file=/etc/my.cnf
 {{end}}
 

--- a/test/functional/nova/multicell_test.go
+++ b/test/functional/nova/multicell_test.go
@@ -156,7 +156,7 @@ var _ = Describe("Nova multi cell", func() {
 			Expect(configData).To(
 				ContainSubstring(
 					fmt.Sprintf(
-						"[database]\nconnection = mysql+pymysql://%s:%s@hostname-for-%s.%s.svc/nova_cell0?read_default_file=/etc/my.cnf",
+						"[database]\nmax_retries = 30\nretry_interval = 1\nconnection = mysql+pymysql://%s:%s@hostname-for-%s.%s.svc/nova_cell0?read_default_file=/etc/my.cnf",
 						cell0Account.Spec.UserName, cell0Secret.Data[mariadbv1.DatabasePasswordSelector],
 						cell0.MariaDBDatabaseName.Name, novaNames.Namespace)),
 			)
@@ -167,7 +167,7 @@ var _ = Describe("Nova multi cell", func() {
 			Expect(configData).To(
 				ContainSubstring(
 					fmt.Sprintf(
-						"[api_database]\nconnection = mysql+pymysql://%s:%s@hostname-for-%s.%s.svc/nova_api?read_default_file=/etc/my.cnf",
+						"[api_database]\nmax_retries = 30\nretry_interval = 1\nconnection = mysql+pymysql://%s:%s@hostname-for-%s.%s.svc/nova_api?read_default_file=/etc/my.cnf",
 						apiAccount.Spec.UserName, apiSecret.Data[mariadbv1.DatabasePasswordSelector],
 						novaNames.APIMariaDBDatabaseName.Name, novaNames.Namespace)),
 			)
@@ -229,7 +229,7 @@ var _ = Describe("Nova multi cell", func() {
 			Expect(configData).To(
 				ContainSubstring(
 					fmt.Sprintf(
-						"[database]\nconnection = mysql+pymysql://%s:%s@hostname-for-%s.%s.svc/nova_cell0?read_default_file=/etc/my.cnf",
+						"[database]\nmax_retries = 3\nretry_interval = 1\nconnection = mysql+pymysql://%s:%s@hostname-for-%s.%s.svc/nova_cell0?read_default_file=/etc/my.cnf",
 						cell0Account.Spec.UserName, cell0Secret.Data[mariadbv1.DatabasePasswordSelector],
 						cell0.MariaDBDatabaseName.Name, novaNames.Namespace)),
 			)
@@ -240,7 +240,7 @@ var _ = Describe("Nova multi cell", func() {
 			Expect(configData).To(
 				ContainSubstring(
 					fmt.Sprintf(
-						"[api_database]\nconnection = mysql+pymysql://%s:%s@hostname-for-%s.%s.svc/nova_api?read_default_file=/etc/my.cnf",
+						"[api_database]\nmax_retries = 3\nretry_interval = 1\nconnection = mysql+pymysql://%s:%s@hostname-for-%s.%s.svc/nova_api?read_default_file=/etc/my.cnf",
 						apiAccount.Spec.UserName, apiSecret.Data[mariadbv1.DatabasePasswordSelector],
 						novaNames.APIMariaDBDatabaseName.Name, novaNames.Namespace)),
 			)
@@ -354,7 +354,7 @@ var _ = Describe("Nova multi cell", func() {
 			Expect(configData).To(
 				ContainSubstring(
 					fmt.Sprintf(
-						"[database]\nconnection = mysql+pymysql://%s:%s@hostname-for-%s.%s.svc/nova_cell1?read_default_file=/etc/my.cnf",
+						"[database]\nmax_retries = 30\nretry_interval = 1\nconnection = mysql+pymysql://%s:%s@hostname-for-%s.%s.svc/nova_cell1?read_default_file=/etc/my.cnf",
 						cell1Account.Spec.UserName, cell1Secret.Data[mariadbv1.DatabasePasswordSelector],
 						cell1.MariaDBDatabaseName.Name, novaNames.Namespace)),
 			)
@@ -365,7 +365,7 @@ var _ = Describe("Nova multi cell", func() {
 			Expect(configData).To(
 				ContainSubstring(
 					fmt.Sprintf(
-						"[api_database]\nconnection = mysql+pymysql://%s:%s@hostname-for-%s.%s.svc/nova_api?read_default_file=/etc/my.cnf",
+						"[api_database]\nmax_retries = 30\nretry_interval = 1\nconnection = mysql+pymysql://%s:%s@hostname-for-%s.%s.svc/nova_api?read_default_file=/etc/my.cnf",
 						apiAccount.Spec.UserName, apiSecret.Data[mariadbv1.DatabasePasswordSelector],
 						novaNames.APIMariaDBDatabaseName.Name, novaNames.Namespace)),
 			)
@@ -477,7 +477,7 @@ var _ = Describe("Nova multi cell", func() {
 			Expect(configData).To(
 				ContainSubstring(
 					fmt.Sprintf(
-						"[database]\nconnection = mysql+pymysql://%s:%s@hostname-for-%s.%s.svc/nova_cell2?read_default_file=/etc/my.cnf",
+						"[database]\nmax_retries = 30\nretry_interval = 1\nconnection = mysql+pymysql://%s:%s@hostname-for-%s.%s.svc/nova_cell2?read_default_file=/etc/my.cnf",
 						cell2Account.Spec.UserName, cell2Secret.Data[mariadbv1.DatabasePasswordSelector],
 						cell2.MariaDBDatabaseName.Name, novaNames.Namespace)),
 			)
@@ -512,7 +512,7 @@ var _ = Describe("Nova multi cell", func() {
 			Expect(configData).To(
 				ContainSubstring(
 					fmt.Sprintf(
-						"[database]\nconnection = mysql+pymysql://%s:%s@hostname-for-%s.%s.svc/nova_cell2?read_default_file=/etc/my.cnf",
+						"[database]\nmax_retries = 30\nretry_interval = 1\nconnection = mysql+pymysql://%s:%s@hostname-for-%s.%s.svc/nova_cell2?read_default_file=/etc/my.cnf",
 						cell2Account.Spec.UserName, cell2Secret.Data[mariadbv1.DatabasePasswordSelector],
 						cell2.MariaDBDatabaseName.Name, novaNames.Namespace)),
 			)
@@ -523,7 +523,7 @@ var _ = Describe("Nova multi cell", func() {
 			Expect(configData).To(
 				ContainSubstring(
 					fmt.Sprintf(
-						"[api_database]\nconnection = mysql+pymysql://%s:%s@hostname-for-%s.%s.svc/nova_api?read_default_file=/etc/my.cnf",
+						"[api_database]\nmax_retries = 30\nretry_interval = 1\nconnection = mysql+pymysql://%s:%s@hostname-for-%s.%s.svc/nova_api?read_default_file=/etc/my.cnf",
 						apiAccount.Spec.UserName, apiSecret.Data[mariadbv1.DatabasePasswordSelector],
 						novaNames.APIMariaDBDatabaseName.Name, novaNames.Namespace)),
 			)

--- a/test/functional/nova/nova_controller_test.go
+++ b/test/functional/nova/nova_controller_test.go
@@ -660,7 +660,7 @@ var _ = Describe("Nova controller", func() {
 			cell0Secret := th.GetSecret(types.NamespacedName{Name: cell0Account.Spec.Secret, Namespace: cell0.MariaDBAccountName.Namespace})
 
 			Expect(configData).To(
-				ContainSubstring(fmt.Sprintf("[database]\nconnection = mysql+pymysql://%s:%s@hostname-for-openstack.%s.svc/nova_cell0?read_default_file=/etc/my.cnf",
+				ContainSubstring(fmt.Sprintf("[database]\nmax_retries = 30\nretry_interval = 1\nconnection = mysql+pymysql://%s:%s@hostname-for-openstack.%s.svc/nova_cell0?read_default_file=/etc/my.cnf",
 					cell0Account.Spec.UserName, cell0Secret.Data[mariadbv1.DatabasePasswordSelector],
 					novaNames.Namespace)),
 			)
@@ -669,7 +669,7 @@ var _ = Describe("Nova controller", func() {
 			apiSecret := th.GetSecret(types.NamespacedName{Name: apiAccount.Spec.Secret, Namespace: novaNames.APIMariaDBDatabaseAccount.Namespace})
 
 			Expect(configData).To(
-				ContainSubstring(fmt.Sprintf("[api_database]\nconnection = mysql+pymysql://%s:%s@hostname-for-openstack.%s.svc/nova_api?read_default_file=/etc/my.cnf",
+				ContainSubstring(fmt.Sprintf("[api_database]\nmax_retries = 30\nretry_interval = 1\nconnection = mysql+pymysql://%s:%s@hostname-for-openstack.%s.svc/nova_api?read_default_file=/etc/my.cnf",
 					apiAccount.Spec.UserName, apiSecret.Data[mariadbv1.DatabasePasswordSelector], novaNames.Namespace)),
 			)
 			// NOTE(gibi): cell mapping for cell0 should not have transport_url
@@ -1044,7 +1044,7 @@ var _ = Describe("Nova controller", func() {
 			Expect(configData).To(
 				ContainSubstring(
 					fmt.Sprintf(
-						"[database]\nconnection = mysql+pymysql://%s:%s@hostname-for-%s.%s.svc/nova_cell0?read_default_file=/etc/my.cnf",
+						"[database]\nmax_retries = 30\nretry_interval = 1\nconnection = mysql+pymysql://%s:%s@hostname-for-%s.%s.svc/nova_cell0?read_default_file=/etc/my.cnf",
 						cell0Account.Spec.UserName, cell0Secret.Data[mariadbv1.DatabasePasswordSelector],
 						cell0.MariaDBDatabaseName.Name, novaNames.Namespace)),
 			)
@@ -1055,7 +1055,7 @@ var _ = Describe("Nova controller", func() {
 			Expect(configData).To(
 				ContainSubstring(
 					fmt.Sprintf(
-						"[api_database]\nconnection = mysql+pymysql://%s:%s@hostname-for-%s.%s.svc/nova_api?read_default_file=/etc/my.cnf",
+						"[api_database]\nmax_retries = 30\nretry_interval = 1\nconnection = mysql+pymysql://%s:%s@hostname-for-%s.%s.svc/nova_api?read_default_file=/etc/my.cnf",
 						apiAccount.Spec.UserName, apiSecret.Data[mariadbv1.DatabasePasswordSelector],
 						novaNames.APIMariaDBDatabaseName.Name, novaNames.Namespace)),
 			)
@@ -1072,14 +1072,14 @@ var _ = Describe("Nova controller", func() {
 			Expect(configData).To(
 				ContainSubstring(
 					fmt.Sprintf(
-						"[database]\nconnection = mysql+pymysql://%s:%s@hostname-for-%s.%s.svc/nova_cell0?read_default_file=/etc/my.cnf",
+						"[database]\nmax_retries = 3\nretry_interval = 1\nconnection = mysql+pymysql://%s:%s@hostname-for-%s.%s.svc/nova_cell0?read_default_file=/etc/my.cnf",
 						cell0Account.Spec.UserName, cell0Secret.Data[mariadbv1.DatabasePasswordSelector],
 						cell0.MariaDBDatabaseName.Name, novaNames.Namespace)),
 			)
 			Expect(configData).To(
 				ContainSubstring(
 					fmt.Sprintf(
-						"[api_database]\nconnection = mysql+pymysql://%s:%s@hostname-for-%s.%s.svc/nova_api?read_default_file=/etc/my.cnf",
+						"[api_database]\nmax_retries = 3\nretry_interval = 1\nconnection = mysql+pymysql://%s:%s@hostname-for-%s.%s.svc/nova_api?read_default_file=/etc/my.cnf",
 						apiAccount.Spec.UserName, apiSecret.Data[mariadbv1.DatabasePasswordSelector],
 						novaNames.APIMariaDBDatabaseName.Name, novaNames.Namespace)),
 			)
@@ -1091,14 +1091,14 @@ var _ = Describe("Nova controller", func() {
 			Expect(configData).To(
 				ContainSubstring(
 					fmt.Sprintf(
-						"[database]\nconnection = mysql+pymysql://%s:%s@hostname-for-%s.%s.svc/nova_cell0?read_default_file=/etc/my.cnf",
+						"[database]\nmax_retries = 3\nretry_interval = 1\nconnection = mysql+pymysql://%s:%s@hostname-for-%s.%s.svc/nova_cell0?read_default_file=/etc/my.cnf",
 						cell0Account.Spec.UserName, cell0Secret.Data[mariadbv1.DatabasePasswordSelector],
 						cell0.MariaDBDatabaseName.Name, novaNames.Namespace)),
 			)
 			Expect(configData).To(
 				ContainSubstring(
 					fmt.Sprintf(
-						"[api_database]\nconnection = mysql+pymysql://%s:%s@hostname-for-%s.%s.svc/nova_api?read_default_file=/etc/my.cnf",
+						"[api_database]\nmax_retries = 3\nretry_interval = 1\nconnection = mysql+pymysql://%s:%s@hostname-for-%s.%s.svc/nova_api?read_default_file=/etc/my.cnf",
 						apiAccount.Spec.UserName, apiSecret.Data[mariadbv1.DatabasePasswordSelector],
 						novaNames.APIMariaDBDatabaseName.Name, novaNames.Namespace)),
 			)


### PR DESCRIPTION
Nova's default database connection retry settings (max_retries=10, retry_interval=10) mean nova-api, for example, can spend up to 100 seconds retrying a connection to an unavailable database. This exceeds the Kubernetes startup probe window (60 seconds), so the pod gets killed before Nova finishes retrying, leading to a CrashLoopBackOff when a cell database is down.

In RHOSO, Kubernetes provides its own higher-level retry mechanism by killing and recreating pods that fail to start. This is preferable to Nova retrying internally because it reports the situation clearly via CR status fields and events, and allows Kubernetes to reschedule the pod to another worker if needed.

Set max_retries to 3 seconds and retry_interval to 1 second for both [database] and [api_database] so that Nova gives up on an unreachable database quickly and lets Kubernetes handle the recovery.

For nova-conductor services, set max_retries to 30 seconds and retry_interval to 1 second to enable them to be more tolerant of temporary database connection disruptions.

Resolves: [OSPRH-30130](https://redhat.atlassian.net/browse/OSPRH-30130)