### PR TITLE
Set service_type in [keystone_authtoken] for access rule validation

### DIFF
--- a/templates/nova/nova.conf
+++ b/templates/nova/nova.conf
@@ -283,6 +283,7 @@ username = {{ .nova_keystone_user }}
 password = {{ .nova_keystone_password }}
 {{ end }}
 region_name = {{ .openstack_region_name }}
+service_type = compute
 # This is part of hardening related to CVE-2023-2088
 # https://docs.openstack.org/nova/latest/configuration/config.html#keystone_authtoken.service_token_roles_required
 # when enabled the service token user must have the service role to be considered valid.

--- a/templates/placement/api/config/placement.conf
+++ b/templates/placement/api/config/placement.conf
@@ -33,6 +33,7 @@ project_name = service
 region_name = {{ .Region }}
 {{ end -}}
 interface = internal
+service_type = placement
 
 [oslo_policy]
 policy_file=/etc/placement/policy.yaml

--- a/test/functional/nova/novaapi_controller_test.go
+++ b/test/functional/nova/novaapi_controller_test.go
@@ -326,10 +326,11 @@ endpoint_service_type = compute`))
 				cfg, err := ini.Load([]byte(configData))
 				Expect(err).ShouldNot(HaveOccurred(), "Should be able to parse config as INI")
 
-				// Verify region_name in [keystone_authtoken]
+				// Verify region_name and service_type in [keystone_authtoken]
 				section := cfg.Section("keystone_authtoken")
 				Expect(section).ShouldNot(BeNil(), "Should find [keystone_authtoken] section")
 				Expect(section.Key("region_name").String()).Should(Equal(testRegion))
+				Expect(section.Key("service_type").String()).Should(Equal("compute"))
 
 				// Verify region_name in [placement]
 				section = cfg.Section("placement")

--- a/test/functional/placement/api_controller_test.go
+++ b/test/functional/placement/api_controller_test.go
@@ -372,13 +372,15 @@ var _ = Describe("PlacementAPI controller", func() {
 			cm := th.GetSecret(names.ConfigMapName)
 			conf := string(cm.Data["placement.conf"])
 
-			// Verify region_name is set in [keystone_authtoken] section
+			// Verify region_name and service_type are set in [keystone_authtoken] section
 			// GetRegion() returns Status.Region, so check that
 			Expect(keystoneAPI.Status.Region).ToNot(BeEmpty(), "KeystoneAPI should have a region set in status")
 			// The region_name should appear in the [keystone_authtoken] section (before [oslo_policy])
 			Expect(conf).Should(
 				MatchRegexp(fmt.Sprintf(
 					`\[keystone_authtoken\][\s\S]*region_name = %s[\s\S]*\[oslo_policy\]`, keystoneAPI.Status.Region)))
+			Expect(conf).Should(
+				MatchRegexp(`\[keystone_authtoken\][\s\S]*service_type = placement[\s\S]*\[oslo_policy\]`))
 		})
 
 		It("creates service account, role and rolebindig", func() {


### PR DESCRIPTION
Without service_type configured, keystonemiddleware cannot validate application credentials with custom access rules, causing HTTP 401 for end users.

Closes: [OSPRH-22365](https://redhat.atlassian.net/browse/OSPRH-22365)