### PR TITLE
Add cyborg validation job

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -122,6 +122,26 @@
         cpu_mode = custom
         cpu_models = Nehalem
 - job:
+    name: nova-operator-cyborg-tempest-multinode
+    parent: nova-operator-tempest-multinode
+    vars:
+      cifmw_extras:
+        - "@scenarios/centos-9/multinode-ci.yml"
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/nova-operator'].src_dir }}/ci/nova-operator-cyborg-tempest-multinode/ci_fw_vars.yaml"
+      cifmw_update_containers_registry: quay.rdoproject.org
+      cifmw_update_containers_org: podified-master-centos10
+      cifmw_update_containers_tag: current-tested
+      cifmw_test_operator_tempest_registry: "{{ cifmw_update_containers_registry }}"
+      cifmw_test_operator_tempest_namespace: "{{ cifmw_update_containers_org }}"
+      cifmw_test_operator_tempest_image_tag: "{{ cifmw_update_containers_tag }}"
+      # Pin cyborg tempest plugin as newer commits require roles that are not created in RHOSO18
+      cifmw_test_operator_tempest_external_plugin:
+        - repository: https://opendev.org/openstack/cyborg-tempest-plugin.git
+          changeRepository: "https://review.opendev.org/openstack/cyborg-tempest-plugin"
+          changeRefspec: "e98dfff4bacdaeffe1fa79d3cfd5f2e28002cd98"
+      cifmw_test_operator_tempest_include_list: |
+          cyborg_tempest_plugin
+- job:
     name: nova-operator-tempest-multinode-ceph
     parent: podified-multinode-hci-deployment-crc-3comp
     dependencies: ["openstack-meta-content-provider"]
@@ -207,6 +227,25 @@
             nodeset: centos-9-medium-3x-centos-9-crc-cloud-ocp-4-18-1-3xl
         - nova-operator-tempest-multinode-ceph:
             nodeset: centos-9-medium-3x-centos-9-crc-cloud-ocp-4-18-1-3xl
+        - nova-operator-cyborg-tempest-multinode:
+            nodeset: centos-9-medium-3x-centos-9-crc-cloud-ocp-4-18-1-3xl
+            voting: false
+            files:
+              - ^api/cyborg/
+              - ^internal/cyborg/
+              - ^internal/controller/cyborg/
+              - ^internal/webhook/cyborg/
+              - ^templates/cyborg/
+              - ^config/samples/cyborg.*
+              - ^api/bases/cyborg\.openstack\.org.*
+              - ^test/functional/cyborg/
+              - ^test/kuttl/test-suites/default/cyborg-tests/
+              - ^ci/nova-operator-cyborg-tempest-multinode/
+              - ^go\.mod$
+              - ^go\.sum$
+              - ^go\.work.*
+              - ^api/go\.mod$
+              - ^api/go\.sum$
 
 - pragma:
     implied-branch-matchers: True

--- a/api/cyborg/v1beta1/common_types.go
+++ b/api/cyborg/v1beta1/common_types.go
@@ -21,11 +21,10 @@ import (
 )
 
 // Container image fall-back defaults
-// TODO(amoralej): replace by proper s2i images when exist in o-k-o namespace.
 const (
-	CyborgAPIContainerImage       = "quay.io/amoralej/openstack-cyborg:master-latest"
-	CyborgConductorContainerImage = "quay.io/amoralej/openstack-cyborg:master-latest"
-	CyborgAgentContainerImage     = "quay.io/amoralej/openstack-cyborg-agent:master-latest"
+	CyborgAPIContainerImage       = "quay.io/openstack-k8s-operators/openstack-cyborg:master-latest"
+	CyborgConductorContainerImage = "quay.io/openstack-k8s-operators/openstack-cyborg:master-latest"
+	CyborgAgentContainerImage     = "quay.io/openstack-k8s-operators/openstack-cyborg-agent:master-latest"
 )
 
 // PasswordSelector to identify the DB and AdminUser password from the Secret

--- a/ci/nova-operator-cyborg-tempest-multinode/ci_fw_vars.yaml
+++ b/ci/nova-operator-cyborg-tempest-multinode/ci_fw_vars.yaml
@@ -1,0 +1,38 @@
+---
+cifmw_install_yamls_vars:
+  BMO_SETUP: false
+  INSTALL_CERT_MANAGER: false
+
+cifmw_edpm_prepare_skip_crc_storage_creation: true
+# as we scale the openstack services to 3 replicas we need more PVs
+cifmw_cls_pv_count: 20
+
+cifmw_services_swift_enabled: false
+
+
+# note by default the source for the playbook specified
+# in the hooks is relative to
+# https://github.com/openstack-k8s-operators/ci-framework/tree/main/hooks/playbooks
+# if you want to use a different source you can use the full path on the ansible controller
+post_ctlplane_deploy:
+  - name: 71 Kustomize control plane to scale openstack services
+    type: playbook
+    source: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/nova-operator'].src_dir }}/ci/nova-operator-tempest-multinode/control_plane_hook.yaml"
+  - name: 82 Kustomize and update Control Plane
+    type: playbook
+    source: control_plane_kustomize_deploy.yml
+  - name: 85 Create neutron-metadata-custom
+    type: playbook
+    source: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/nova-operator'].src_dir }}/ci/nova-operator-cyborg-tempest-multinode/pre_deploy_hook.yml"
+  - name: 90 Deploy Cyborg service
+    type: playbook
+    source: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/nova-operator'].src_dir }}/ci/nova-operator-cyborg-tempest-multinode/deploy_cyborg_service.yaml"
+
+
+
+cifmw_run_tests: true
+cifmw_tempest_container: openstack-tempest-extras
+# we do not want the ci framework trying to enable any
+# tempest groups by default we will manage all tempest execution
+# via the job definition.
+cifmw_tempest_default_groups: []

--- a/ci/nova-operator-cyborg-tempest-multinode/deploy_cyborg_service.yaml
+++ b/ci/nova-operator-cyborg-tempest-multinode/deploy_cyborg_service.yaml
@@ -1,0 +1,175 @@
+---
+- name: Deploy Cyborg service
+  hosts: "{{ cifmw_target_hook_host | default('localhost') }}"
+  gather_facts: false
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  tasks:
+    # NOTE(amoralej): Cyborg controllers and webhooks in the nova-operator
+    # are gated behind the ENABLE_CYBORG=true env var (cmd/main.go).
+    # The nova-operator deployment is owned and reconciled by the
+    # openstack-operator, which rebuilds its env vars from scratch on
+    # every reconcile loop (it Owns the Deployment). The OpenStack CRD
+    # does not expose a way to inject custom env vars into sub-operator
+    # deployments, so we must:
+    #   1. Scale down the openstack-operator via its CSV to stop it
+    #      from reconciling (OLM manages the deployment, so we patch
+    #      the CSV replicas rather than scaling the deployment directly).
+    #   2. Patch the nova-operator deployment directly to add ENABLE_CYBORG.
+    #   3. Wait for the nova-operator to roll out with Cyborg enabled.
+    - name: Get the openstack-operator CSV name
+      ansible.builtin.command:
+        cmd: >-
+          oc get csv -n openstack-operators
+          -l operators.coreos.com/openstack-operator.openstack-operators
+          -o name
+      register: csv_name
+
+    - name: Patch CSV to scale down openstack-operator
+      ansible.builtin.shell: |
+        oc patch -n openstack-operators {{ csv_name.stdout }} --type json -p='[
+          {"op": "replace",
+           "path": "/spec/install/spec/deployments/0/spec/replicas",
+           "value": 0}
+        ]'
+
+    - name: Wait for openstack-operator to scale down
+      ansible.builtin.command:
+        cmd: >-
+          oc rollout status deployment/openstack-operator-controller-init
+          -n openstack-operators --timeout=120s
+
+    - name: Patch nova-operator deployment to enable Cyborg
+      ansible.builtin.command:
+        cmd: >-
+          oc set env deployment/nova-operator-controller-manager
+          -n openstack-operators ENABLE_CYBORG=true
+
+    - name: Wait for nova-operator rollout
+      ansible.builtin.command:
+        cmd: >-
+          oc rollout status deployment/nova-operator-controller-manager
+          -n openstack-operators --timeout=300s
+
+    - name: Add CyborgPassword to osp-secret
+      ansible.builtin.shell: |
+        oc patch secret osp-secret \
+          --namespace={{ cifmw_install_yamls_defaults['NAMESPACE'] }} \
+          --type merge -p '{"data":{"CyborgPassword":"'"$(oc get secret osp-secret --namespace={{ cifmw_install_yamls_defaults['NAMESPACE'] }} -o jsonpath='{.data.AdminPassword}')"'"}}'
+
+    - name: Create Cyborg TLS certificates
+      ansible.builtin.shell: |
+        oc apply -f - <<EOF
+        apiVersion: cert-manager.io/v1
+        kind: Certificate
+        metadata:
+          name: cyborg-internal-svc
+          namespace: {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
+        spec:
+          dnsNames:
+          - cyborg-internal.{{ cifmw_install_yamls_defaults['NAMESPACE'] }}.svc
+          - cyborg-internal.{{ cifmw_install_yamls_defaults['NAMESPACE'] }}.svc.cluster.local
+          duration: 43800h0m0s
+          issuerRef:
+            group: cert-manager.io
+            kind: Issuer
+            name: rootca-internal
+          secretName: cert-cyborg-internal-svc
+          usages:
+          - key encipherment
+          - digital signature
+          - server auth
+        ---
+        apiVersion: cert-manager.io/v1
+        kind: Certificate
+        metadata:
+          name: cyborg-public-svc
+          namespace: {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
+        spec:
+          dnsNames:
+          - cyborg-public.{{ cifmw_install_yamls_defaults['NAMESPACE'] }}.svc
+          - cyborg-public.{{ cifmw_install_yamls_defaults['NAMESPACE'] }}.svc.cluster.local
+          duration: 43800h0m0s
+          issuerRef:
+            group: cert-manager.io
+            kind: Issuer
+            name: rootca-public
+          secretName: cert-cyborg-public-svc
+          usages:
+          - key encipherment
+          - digital signature
+          - server auth
+        EOF
+
+    - name: Wait for Cyborg certificate secrets to be created
+      ansible.builtin.command:
+        cmd: >-
+          oc wait certificate {{ item }}
+          --namespace={{ cifmw_install_yamls_defaults['NAMESPACE'] }}
+          --for=condition=Ready --timeout=300s
+      loop:
+        - cyborg-internal-svc
+        - cyborg-public-svc
+
+    - name: Create Cyborg CR
+      ansible.builtin.shell: |
+        oc apply -f - <<EOF
+        apiVersion: cyborg.openstack.org/v1beta1
+        kind: Cyborg
+        metadata:
+          name: cyborg
+          namespace: {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
+        spec:
+          agentContainerImageURL: quay.io/openstack-k8s-operators/openstack-cyborg-agent:master-latest
+          apiContainerImageURL: quay.io/openstack-k8s-operators/openstack-cyborg:master-latest
+          conductorContainerImageURL: quay.io/openstack-k8s-operators/openstack-cyborg:master-latest
+          secret: osp-secret
+          messagingBus:
+            cluster: rabbitmq
+          apiServiceTemplate:
+            override:
+              service:
+                internal:
+                  metadata:
+                    annotations:
+                      metallb.universe.tf/address-pool: internalapi
+                      metallb.universe.tf/allow-shared-ip: internalapi
+                      metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+                  spec:
+                    type: LoadBalancer
+            tls:
+              caBundleSecretName: combined-ca-bundle
+              api:
+                internal:
+                  secretName: cert-cyborg-internal-svc
+                public:
+                  secretName: cert-cyborg-public-svc
+        EOF
+
+    - name: Wait for Cyborg CR to be ready
+      ansible.builtin.command:
+        cmd: >-
+          oc wait cyborg cyborg
+          --namespace={{ cifmw_install_yamls_defaults['NAMESPACE'] }}
+          --for=condition=Ready --timeout=600s
+
+    - name: Create OpenStackDataPlaneService for cyborg
+      ansible.builtin.shell: |
+        oc apply -f - <<EOF
+        apiVersion: dataplane.openstack.org/v1beta1
+        kind: OpenStackDataPlaneService
+        metadata:
+          name: cyborg
+          namespace: {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
+        spec:
+          dataSources:
+            - secretRef:
+                name: cyborg-agent-config
+            - configMapRef:
+                name: cyborg-extra-config
+                optional: true
+          playbook: osp.edpm.cyborg
+          caCerts: combined-ca-bundle
+          edpmServiceType: cyborg
+        EOF

--- a/ci/nova-operator-cyborg-tempest-multinode/pre_deploy_hook.yml
+++ b/ci/nova-operator-cyborg-tempest-multinode/pre_deploy_hook.yml
@@ -1,0 +1,72 @@
+- name: Create custom service
+  hosts: "{{ cifmw_target_hook_host | default('localhost') }}"
+  gather_facts: false
+  tasks:
+    - name: Create kustomization
+      ansible.builtin.copy:
+        dest: "{{ cifmw_basedir }}/artifacts/manifests/kustomizations/dataplane/98-kustomization.yaml"
+        content: |-
+          apiVersion: kustomize.config.k8s.io/v1beta1
+          kind: Kustomization
+          resources:
+            namespace: {{ cifmw_install_yamls_defaults.NAMESPACE }}
+          patches:
+          - target:
+              kind: OpenStackDataPlaneNodeSet
+            patch: |-
+              - op: replace
+                path: /spec/services
+                value:
+                  - repo-setup
+                  - bootstrap
+                  - download-cache
+                  - configure-network
+                  - validate-network
+                  - install-os
+                  - configure-os
+                  - ssh-known-hosts
+                  - run-os
+                  - reboot-os
+                  - install-certs
+                  - ovn
+                  - neutron-metadata-custom
+                  - libvirt
+                  - nova
+                  - cyborg
+                  - telemetry
+    - name: Create neutron-metadata-custom service
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+        PATH: "{{ cifmw_path }}"
+      ansible.builtin.shell: |
+        oc apply -f - <<EOF
+        apiVersion: dataplane.openstack.org/v1beta1
+        kind: OpenStackDataPlaneService
+        metadata:
+          name: neutron-metadata-custom
+          namespace: {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
+        spec:
+          addCertMounts: false
+          caCerts: combined-ca-bundle
+          containerImageFields:
+          - EdpmNeutronMetadataAgentImage
+          dataSources:
+          - secretRef:
+              name: neutron-ovn-metadata-agent-neutron-config
+          - secretRef:
+              name: nova-cell1-metadata-neutron-config
+          edpmServiceType: neutron-metadata
+          playbook: osp.edpm.neutron_metadata
+          tlsCerts:
+            default:
+              contents:
+              - dnsnames
+              - ips
+              issuer: osp-rootca-issuer-ovn
+              keyUsages:
+              - digital signature
+              - key encipherment
+              - client auth
+              networks:
+              - ctlplane
+        EOF

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -24,8 +24,8 @@ spec:
         - name: RELATED_IMAGE_PLACEMENT_API_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-placement-api:current-podified
         - name: RELATED_IMAGE_CYBORG_API_IMAGE_URL_DEFAULT
-          value: quay.io/amoralej/openstack-cyborg:master-latest
+          value: quay.io/openstack-k8s-operators/openstack-cyborg:master-latest
         - name: RELATED_IMAGE_CYBORG_CONDUCTOR_IMAGE_URL_DEFAULT
-          value: quay.io/amoralej/openstack-cyborg:master-latest
+          value: quay.io/openstack-k8s-operators/openstack-cyborg:master-latest
         - name: RELATED_IMAGE_CYBORG_AGENT_IMAGE_URL_DEFAULT
-          value: quay.io/amoralej/openstack-cyborg-agent:master-latest
+          value: quay.io/openstack-k8s-operators/openstack-cyborg-agent:master-latest


### PR DESCRIPTION
- Adds new non-voting cyborg job (nv as we are not pre-validating cyborg container images and may break.
- Sets default container images to new s2i ones created in quay.io/openstack-k8s-operators.

Depends-On: https://github.com/openstack-k8s-operators/edpm-ansible/pull/1180