### PR TITLE
[vncproxy]Disable traffic logging

### DIFF
--- a/templates/nova/nova.conf
+++ b/templates/nova/nova.conf
@@ -14,7 +14,14 @@ log_rotation_type=size
 {{if (index . "log_file") }}
 log_file = {{ .log_file }}
 {{end}}
+{{if eq .service_name "nova-novncproxy"}}
+# vncproxy does expensive traffic logging
+# when debug is enabled so keep it disabled
+# by default.
+debug=false
+{{else}}
 debug=true
+{{end}}
 {{if eq .service_name "nova-compute"}}
 compute_driver = {{ .compute_driver }}
 {{if eq .compute_driver "ironic.IronicDriver"}}

--- a/test/functional/nova/novncproxy_test.go
+++ b/test/functional/nova/novncproxy_test.go
@@ -207,6 +207,7 @@ var _ = Describe("NovaNoVNCProxy controller", func() {
 				Expect(configData).Should(ContainSubstring("transport_url=rabbit://cell1/fake"))
 				Expect(configData).Should(
 					ContainSubstring("[upgrade_levels]\ncompute = auto"))
+				Expect(configData).Should(ContainSubstring("debug=false"))
 				Expect(configDataMap.Data).Should(HaveKey("02-nova-override.conf"))
 				myCnf := configDataMap.Data["my.cnf"]
 				Expect(myCnf).To(


### PR DESCRIPTION
By default we set [DEFAULT]debug=true in all service config to increase our troubleshooting chances. But vncproxy with that setting emits a lot of traffic logging. By setting debug=false (and with the nova fix in depends-on) we disable traffic logging by default.

Depends-On: https://gitlab.cee.redhat.com/eng/openstack/nova/-/merge_requests/95
Related: [OSPRH-29916](https://redhat.atlassian.net/browse/OSPRH-29916)