### PR TITLE
Remove deprecated webhook.Defaulter/Validator interface assertions

### DIFF
--- a/api/nova/v1beta1/nova_webhook.go
+++ b/api/nova/v1beta1/nova_webhook.go
@@ -36,7 +36,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -59,7 +58,6 @@ func SetupNovaDefaults(defaults NovaDefaults) {
 	novalog.Info("Nova defaults initialized", "defaults", defaults)
 }
 
-var _ webhook.Defaulter = &Nova{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *Nova) Default() {
@@ -130,7 +128,6 @@ func (spec *NovaSpecCore) Default() {
 	}
 }
 
-var _ webhook.Validator = &Nova{}
 
 // ValidateCellTemplates validates cell templates configuration
 func (spec *NovaSpecCore) ValidateCellTemplates(basePath *field.Path, namespace string) field.ErrorList {

--- a/api/nova/v1beta1/novaapi_webhook.go
+++ b/api/nova/v1beta1/novaapi_webhook.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/openstack-k8s-operators/lib-common/modules/common/service"
@@ -54,7 +53,6 @@ func SetupNovaAPIDefaults(defaults NovaAPIDefaults) {
 	novaapilog.Info("NovaAPI defaults initialized", "defaults", defaults)
 }
 
-var _ webhook.Defaulter = &NovaAPI{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *NovaAPI) Default() {
@@ -70,7 +68,6 @@ func (spec *NovaAPISpec) Default() {
 	}
 }
 
-var _ webhook.Validator = &NovaAPI{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *NovaAPI) ValidateCreate() (admission.Warnings, error) {

--- a/api/nova/v1beta1/novacell_webhook.go
+++ b/api/nova/v1beta1/novacell_webhook.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 )
@@ -60,7 +59,6 @@ func SetupNovaCellDefaults(defaults NovaCellDefaults) {
 	novacelllog.Info("NovaCell defaults initialized", "defaults", defaults)
 }
 
-var _ webhook.Defaulter = &NovaCell{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *NovaCell) Default() {
@@ -90,7 +88,6 @@ func (spec *NovaCellSpec) Default() {
 	}
 }
 
-var _ webhook.Validator = &NovaCell{}
 
 func (spec *NovaCellSpec) validate(basePath *field.Path, namespace string) field.ErrorList {
 	var errors field.ErrorList

--- a/api/nova/v1beta1/novacompute_webhook.go
+++ b/api/nova/v1beta1/novacompute_webhook.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 )
@@ -53,7 +52,6 @@ func SetupNovaComputeDefaults(defaults NovaComputeDefaults) {
 	novacomputelog.Info("NovaCompute defaults initialized", "defaults", defaults)
 }
 
-var _ webhook.Defaulter = &NovaCompute{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *NovaCompute) Default() {
@@ -69,7 +67,6 @@ func (spec *NovaComputeSpec) Default() {
 	}
 }
 
-var _ webhook.Validator = &NovaCompute{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *NovaCompute) ValidateCreate() (admission.Warnings, error) {

--- a/api/nova/v1beta1/novaconductor_webhook.go
+++ b/api/nova/v1beta1/novaconductor_webhook.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 )
@@ -52,7 +51,6 @@ func SetupNovaConductorDefaults(defaults NovaConductorDefaults) {
 	novaconductorlog.Info("NovaConductor defaults initialized", "defaults", defaults)
 }
 
-var _ webhook.Defaulter = &NovaConductor{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *NovaConductor) Default() {
@@ -68,7 +66,6 @@ func (spec *NovaConductorSpec) Default() {
 	}
 }
 
-var _ webhook.Validator = &NovaConductor{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *NovaConductor) ValidateCreate() (admission.Warnings, error) {

--- a/api/nova/v1beta1/novametadata_webhook.go
+++ b/api/nova/v1beta1/novametadata_webhook.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 )
@@ -52,7 +51,6 @@ func SetupNovaMetadataDefaults(defaults NovaMetadataDefaults) {
 	novametadatalog.Info("NovaMetadata defaults initialized", "defaults", defaults)
 }
 
-var _ webhook.Defaulter = &NovaMetadata{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *NovaMetadata) Default() {
@@ -68,7 +66,6 @@ func (spec *NovaMetadataSpec) Default() {
 	}
 }
 
-var _ webhook.Validator = &NovaMetadata{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *NovaMetadata) ValidateCreate() (admission.Warnings, error) {

--- a/api/nova/v1beta1/novanovncproxy_webhook.go
+++ b/api/nova/v1beta1/novanovncproxy_webhook.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
@@ -52,7 +51,6 @@ func SetupNovaNoVNCProxyDefaults(defaults NovaNoVNCProxyDefaults) {
 	novanovncproxylog.Info("NovaNoVNCProxy defaults initialized", "defaults", defaults)
 }
 
-var _ webhook.Defaulter = &NovaNoVNCProxy{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *NovaNoVNCProxy) Default() {
@@ -68,7 +66,6 @@ func (spec *NovaNoVNCProxySpec) Default() {
 	}
 }
 
-var _ webhook.Validator = &NovaNoVNCProxy{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *NovaNoVNCProxy) ValidateCreate() (admission.Warnings, error) {

--- a/api/nova/v1beta1/novascheduler_webhook.go
+++ b/api/nova/v1beta1/novascheduler_webhook.go
@@ -29,7 +29,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
@@ -52,7 +51,6 @@ func SetupNovaSchedulerDefaults(defaults NovaSchedulerDefaults) {
 	novaschedulerlog.Info("NovaScheduler defaults initialized", "defaults", defaults)
 }
 
-var _ webhook.Defaulter = &NovaScheduler{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *NovaScheduler) Default() {
@@ -68,7 +66,6 @@ func (spec *NovaSchedulerSpec) Default() {
 	}
 }
 
-var _ webhook.Validator = &NovaScheduler{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *NovaScheduler) ValidateCreate() (admission.Warnings, error) {

--- a/api/placement/v1beta1/api_webhook.go
+++ b/api/placement/v1beta1/api_webhook.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -50,8 +49,6 @@ func SetupPlacementAPIDefaults(defaults PlacementAPIDefaults) {
 	placementAPIDefaults = defaults
 	placementapilog.Info("PlacementAPI defaults initialized", "defaults", defaults)
 }
-
-var _ webhook.Defaulter = &PlacementAPI{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *PlacementAPI) Default() {
@@ -74,8 +71,6 @@ func (spec *PlacementAPISpec) Default() {
 func (spec *PlacementAPISpecCore) Default() {
 	// nothing here yet
 }
-
-var _ webhook.Validator = &PlacementAPI{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *PlacementAPI) ValidateCreate() (admission.Warnings, error) {


### PR DESCRIPTION
These compile-time assertions reference webhook.Defaulter and webhook.Validator interfaces that are removed in controller-runtime v0.21 (OCP 4.20). The assertions are dead code — webhook registration already uses CustomDefaulter/CustomValidator in internal/webhook/.

Removing them makes the API module forward-compatible with CR v0.21 so that consumers (like openstack-operator) can bump controller-runtime without needing replace directives for this operator.

Jira: [OSPRH-32989](https://redhat.atlassian.net/browse/OSPRH-32989)