### PR TITLE
kuttl: Delete nova-compute service before config update step

### DIFF
--- a/test/kuttl/test-suites/default/config-tests/02-enable-notifications.yaml
+++ b/test/kuttl/test-suites/default/config-tests/02-enable-notifications.yaml
@@ -1,3 +1,15 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      set -euxo pipefail
+      # Delete the nova-compute service record so that on restart
+      # nova-compute does not fail the _ensure_existing_node_identity
+      # check due to missing compute_id file (not written by FakeDriver).
+      oc exec -n $NAMESPACE openstackclient -- openstack compute service list \
+        --service nova-compute -f value -c ID | \
+        xargs -I{} oc exec -n $NAMESPACE openstackclient -- openstack compute service delete {}
+---
 apiVersion: nova.openstack.org/v1beta1
 kind: Nova
 metadata:


### PR DESCRIPTION
Config update in the config-tests kuttl test requires nova-compute pod restart. This restart does not work properly with the fake driver by design because the nova-compute service is registered in the DB, but the id is not stored in /var/lib/nova/compute_id file, so it fails to start with error:

  nova.exception.InvalidConfiguration: No local node identity found, but this\
  is not our first startup on this host. Refusing to start after potentially\
  having lost that state

This patch removes the nova-compute service from nova API before nova is reconfigured so that it's properly recreated when the pod is restarted b the config change.

Although I'm unclear why this behavior is happening more often now, I suspect recent changes in compute service probes affect how fast the compute pod is temporarily detected ready even before the actual compute service was properly working.

Assisted-By: Claude