### PR TITLE
Run Cyborg containers as cyborg user in the controlplane

### DIFF
--- a/internal/cyborg/api/statefulset.go
+++ b/internal/cyborg/api/statefulset.go
@@ -51,7 +51,6 @@ func StatefulSet(
 	topology *topologyv1.Topology,
 ) (*appsv1.StatefulSet, error) {
 	var config0644AccessMode int32 = 0644
-	runAsUser := int64(0)
 
 	envVars := make(map[string]env.Setter)
 	envVars["KOLLA_CONFIG_STRATEGY"] = env.SetValue("COPY_ALWAYS")
@@ -176,7 +175,7 @@ func StatefulSet(
 							},
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
-								RunAsUser: ptr.To(runAsUser),
+								RunAsUser: ptr.To(cyborg.CyborgUserID),
 							},
 							Env:          env.MergeEnvs([]corev1.EnvVar{}, envVars),
 							VolumeMounts: []corev1.VolumeMount{logVolumeMount},
@@ -190,7 +189,7 @@ func StatefulSet(
 							Args:  args,
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
-								RunAsUser: ptr.To(runAsUser),
+								RunAsUser: ptr.To(cyborg.CyborgUserID),
 							},
 							Env:            env.MergeEnvs([]corev1.EnvVar{}, envVars),
 							VolumeMounts:   volumeMounts,

--- a/internal/cyborg/conductor/statefulset.go
+++ b/internal/cyborg/conductor/statefulset.go
@@ -58,7 +58,6 @@ func StatefulSet(
 	}
 
 	var config0644AccessMode int32 = 0644
-	runAsUser := int64(0)
 
 	envVars := make(map[string]env.Setter)
 	envVars["KOLLA_CONFIG_STRATEGY"] = env.SetValue("COPY_ALWAYS")
@@ -129,7 +128,7 @@ func StatefulSet(
 							Args:  args,
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
-								RunAsUser: ptr.To(runAsUser),
+								RunAsUser: ptr.To(cyborg.CyborgUserID),
 							},
 							Env:           env.MergeEnvs([]corev1.EnvVar{}, envVars),
 							VolumeMounts:  volumeMounts,

--- a/internal/cyborg/constants.go
+++ b/internal/cyborg/constants.go
@@ -45,12 +45,13 @@ const (
 	// DefaultsConfigFileName is the file name with default configuration
 	DefaultsConfigFileName = "00-default.conf"
 
-	// DBSyncCommand is the kolla command to run the dbsync job
-	DBSyncCommand = "/usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start"
-
 	// CyborgLogPath is the default path for the cyborg service logs
 	CyborgLogPath = "/var/log/cyborg/"
 
 	// LogVolume is the name of the EmptyDir volume used for log streaming
 	LogVolume = "logs"
+
+	// CyborgUserID is the linux user ID used by Kolla for the cyborg user
+	// in the service containers
+	CyborgUserID int64 = 42483
 )

--- a/internal/cyborg/dbsync.go
+++ b/internal/cyborg/dbsync.go
@@ -17,7 +17,10 @@ limitations under the License.
 package cyborg
 
 import (
+	"k8s.io/utils/ptr"
+
 	cyborgv1beta1 "github.com/openstack-k8s-operators/nova-operator/api/cyborg/v1beta1"
+	internalcommon "github.com/openstack-k8s-operators/nova-operator/internal/common"
 
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
 	batchv1 "k8s.io/api/batch/v1"
@@ -31,7 +34,6 @@ func DbSyncJob(
 	labels map[string]string,
 	annotations map[string]string,
 ) *batchv1.Job {
-	runAsUser := int64(0)
 	completions := int32(1)
 	parallelism := int32(1)
 	var config0644AccessMode int32 = 0644
@@ -101,7 +103,7 @@ func DbSyncJob(
 		volumeMounts = append(volumeMounts, instance.Spec.APIServiceTemplate.TLS.CreateVolumeMounts(nil)...)
 	}
 
-	args := []string{"-c", DBSyncCommand}
+	args := []string{"-c", internalcommon.ServiceCommand}
 
 	envVars := make(map[string]env.Setter)
 	envVars["KOLLA_CONFIG_STRATEGY"] = env.SetValue("COPY_ALWAYS")
@@ -134,7 +136,7 @@ func DbSyncJob(
 							Args:  args,
 							Image: instance.Spec.ConductorContainerImageURL,
 							SecurityContext: &corev1.SecurityContext{
-								RunAsUser: &runAsUser,
+								RunAsUser: ptr.To(CyborgUserID),
 							},
 							Env:          env.MergeEnvs([]corev1.EnvVar{}, envVars),
 							VolumeMounts: volumeMounts,


### PR DESCRIPTION
Currently, it's running as root (uid = 0) needlessly instead of as cyborg user.

This patch sets both the dbsync, conductor and api to run as cyborg user.