### PR TITLE
switch anyuid SCC to nonroot-v2 for Nova, Placement, and Cyborg

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -268,7 +268,7 @@ rules:
 - apiGroups:
   - security.openshift.io
   resourceNames:
-  - anyuid
+  - nonroot-v2
   resources:
   - securitycontextconstraints
   verbs:

--- a/internal/controller/cyborg/cyborg_controller.go
+++ b/internal/controller/cyborg/cyborg_controller.go
@@ -89,7 +89,7 @@ func (r *CyborgReconciler) GetLogger(ctx context.Context) logr.Logger {
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update;patch
-// +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid,resources=securitycontextconstraints,verbs=use
+// +kubebuilder:rbac:groups="security.openshift.io",resourceNames=nonroot-v2,resources=securitycontextconstraints,verbs=use
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -515,7 +515,7 @@ func (r *CyborgReconciler) ensureRbac(
 	rbacRules := []rbacv1.PolicyRule{
 		{
 			APIGroups:     []string{"security.openshift.io"},
-			ResourceNames: []string{"anyuid"},
+			ResourceNames: []string{"nonroot-v2"},
 			Resources:     []string{"securitycontextconstraints"},
 			Verbs:         []string{"use"},
 		},

--- a/internal/controller/nova/nova_controller.go
+++ b/internal/controller/nova/nova_controller.go
@@ -93,7 +93,7 @@ func (r *NovaReconciler) GetLogger(ctx context.Context) logr.Logger {
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update;patch
 // service account permissions that are needed to grant permission to the above
-// +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid,resources=securitycontextconstraints,verbs=use
+// +kubebuilder:rbac:groups="security.openshift.io",resourceNames=nonroot-v2,resources=securitycontextconstraints,verbs=use
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete;
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
@@ -197,7 +197,7 @@ func (r *NovaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 	rbacRules := []rbacv1.PolicyRule{
 		{
 			APIGroups:     []string{"security.openshift.io"},
-			ResourceNames: []string{"anyuid"},
+			ResourceNames: []string{"nonroot-v2"},
 			Resources:     []string{"securitycontextconstraints"},
 			Verbs:         []string{"use"},
 		},

--- a/internal/controller/placement/api_controller.go
+++ b/internal/controller/placement/api_controller.go
@@ -97,7 +97,7 @@ type PlacementAPIReconciler struct {
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update;patch
 // service account permissions that are needed to grant permission to the above
-// +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid,resources=securitycontextconstraints,verbs=use
+// +kubebuilder:rbac:groups="security.openshift.io",resourceNames=nonroot-v2,resources=securitycontextconstraints,verbs=use
 // +kubebuilder:rbac:groups=topology.openstack.org,resources=topologies,verbs=get;list;watch;update
 
 // Reconcile reconcile placement API requests
@@ -190,7 +190,7 @@ func (r *PlacementAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	rbacRules := []rbacv1.PolicyRule{
 		{
 			APIGroups:     []string{"security.openshift.io"},
-			ResourceNames: []string{"anyuid"},
+			ResourceNames: []string{"nonroot-v2"},
 			Resources:     []string{"securitycontextconstraints"},
 			Verbs:         []string{"use"},
 		},

--- a/internal/cyborg/api/statefulset.go
+++ b/internal/cyborg/api/statefulset.go
@@ -158,7 +158,8 @@ func StatefulSet(
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: instance.Spec.ServiceAccount,
+					ServiceAccountName:           instance.Spec.ServiceAccount,
+					AutomountServiceAccountToken: ptr.To(false),
 					Containers: []corev1.Container{
 						{
 							Name: ComponentName + "-log",
@@ -176,6 +177,9 @@ func StatefulSet(
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: ptr.To(cyborg.CyborgUserID),
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
 							},
 							Env:          env.MergeEnvs([]corev1.EnvVar{}, envVars),
 							VolumeMounts: []corev1.VolumeMount{logVolumeMount},
@@ -190,6 +194,9 @@ func StatefulSet(
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: ptr.To(cyborg.CyborgUserID),
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
 							},
 							Env:            env.MergeEnvs([]corev1.EnvVar{}, envVars),
 							VolumeMounts:   volumeMounts,

--- a/internal/cyborg/conductor/statefulset.go
+++ b/internal/cyborg/conductor/statefulset.go
@@ -118,7 +118,8 @@ func StatefulSet(
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: instance.Spec.ServiceAccount,
+					ServiceAccountName:           instance.Spec.ServiceAccount,
+					AutomountServiceAccountToken: ptr.To(false),
 					Containers: []corev1.Container{
 						{
 							Name: ComponentName,
@@ -129,6 +130,9 @@ func StatefulSet(
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: ptr.To(cyborg.CyborgUserID),
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
 							},
 							Env:           env.MergeEnvs([]corev1.EnvVar{}, envVars),
 							VolumeMounts:  volumeMounts,

--- a/internal/cyborg/dbsync.go
+++ b/internal/cyborg/dbsync.go
@@ -125,8 +125,9 @@ func DbSyncJob(
 					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
-					RestartPolicy:      corev1.RestartPolicyOnFailure,
-					ServiceAccountName: instance.RbacResourceName(),
+					RestartPolicy:                corev1.RestartPolicyOnFailure,
+					ServiceAccountName:           instance.RbacResourceName(),
+					AutomountServiceAccountToken: ptr.To(false),
 					Containers: []corev1.Container{
 						{
 							Name: "cyborg-db-sync",
@@ -137,6 +138,9 @@ func DbSyncJob(
 							Image: instance.Spec.ConductorContainerImageURL,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: ptr.To(CyborgUserID),
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
 							},
 							Env:          env.MergeEnvs([]corev1.EnvVar{}, envVars),
 							VolumeMounts: volumeMounts,

--- a/internal/nova/api/deployment.go
+++ b/internal/nova/api/deployment.go
@@ -129,8 +129,9 @@ func StatefulSet(
 					Labels:      labels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: instance.Spec.ServiceAccount,
-					Volumes:            volumes,
+					ServiceAccountName:           instance.Spec.ServiceAccount,
+					AutomountServiceAccountToken: ptr.To(false),
+					Volumes:                      volumes,
 					Containers: []corev1.Container{
 						// the first container in a pod is the default selected
 						// by oc log so define the log stream container first.
@@ -149,6 +150,9 @@ func StatefulSet(
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: ptr.To(nova.NovaUserID),
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
 							},
 							Env:            env,
 							VolumeMounts:   []corev1.VolumeMount{nova.GetLogVolumeMount()},
@@ -165,6 +169,9 @@ func StatefulSet(
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: ptr.To(nova.NovaUserID),
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
 							},
 							Env:            env,
 							VolumeMounts:   volumeMounts,

--- a/internal/nova/celldelete.go
+++ b/internal/nova/celldelete.go
@@ -61,9 +61,10 @@ func CellDeleteJob(
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					RestartPolicy:      corev1.RestartPolicyOnFailure,
-					ServiceAccountName: instance.RbacResourceName(),
-					Volumes:            volumes,
+					RestartPolicy:                corev1.RestartPolicyOnFailure,
+					ServiceAccountName:           instance.RbacResourceName(),
+					AutomountServiceAccountToken: ptr.To(false),
+					Volumes:                      volumes,
 					Containers: []corev1.Container{
 						{
 							Name: "nova-manage",
@@ -74,6 +75,9 @@ func CellDeleteJob(
 							Image: cell.Spec.ConductorContainerImageURL,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: ptr.To(NovaUserID),
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
 							},
 							Env:          env,
 							VolumeMounts: volumeMounts,

--- a/internal/nova/cellmapping.go
+++ b/internal/nova/cellmapping.go
@@ -60,9 +60,10 @@ func CellMappingJob(
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					RestartPolicy:      corev1.RestartPolicyOnFailure,
-					ServiceAccountName: instance.RbacResourceName(),
-					Volumes:            volumes,
+					RestartPolicy:                corev1.RestartPolicyOnFailure,
+					ServiceAccountName:           instance.RbacResourceName(),
+					AutomountServiceAccountToken: ptr.To(false),
+					Volumes:                      volumes,
 					Containers: []corev1.Container{
 						{
 							Name: "nova-manage",
@@ -73,6 +74,9 @@ func CellMappingJob(
 							Image: cell.Spec.ConductorContainerImageURL,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: ptr.To(NovaUserID),
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
 							},
 							Env:          env,
 							VolumeMounts: volumeMounts,

--- a/internal/nova/compute/deployment.go
+++ b/internal/nova/compute/deployment.go
@@ -95,8 +95,9 @@ func StatefulSet(
 					Labels:      labels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: instance.Spec.ServiceAccount,
-					Volumes:            volumes,
+					ServiceAccountName:           instance.Spec.ServiceAccount,
+					AutomountServiceAccountToken: ptr.To(false),
+					Volumes:                      volumes,
 					Containers: []corev1.Container{
 						{
 							Name: instance.Name + "-compute",
@@ -107,6 +108,9 @@ func StatefulSet(
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: ptr.To(nova.NovaUserID),
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
 							},
 							Env:           env,
 							VolumeMounts:  volumeMounts,

--- a/internal/nova/conductor/dbpurge.go
+++ b/internal/nova/conductor/dbpurge.go
@@ -81,9 +81,10 @@ func DBPurgeCronJob(
 					Completions: ptr.To[int32](1),
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
-							RestartPolicy:      corev1.RestartPolicyOnFailure,
-							ServiceAccountName: instance.Spec.ServiceAccount,
-							Volumes:            volumes,
+							RestartPolicy:                corev1.RestartPolicyOnFailure,
+							ServiceAccountName:           instance.Spec.ServiceAccount,
+							AutomountServiceAccountToken: ptr.To(false),
+							Volumes:                      volumes,
 							Containers: []corev1.Container{
 								{
 									Name: "nova-manage",
@@ -94,6 +95,9 @@ func DBPurgeCronJob(
 									Image: instance.Spec.ContainerImage,
 									SecurityContext: &corev1.SecurityContext{
 										RunAsUser: ptr.To(nova.NovaUserID),
+										SeccompProfile: &corev1.SeccompProfile{
+											Type: corev1.SeccompProfileTypeRuntimeDefault,
+										},
 									},
 									Env:          env,
 									VolumeMounts: volumeMounts,

--- a/internal/nova/conductor/dbsync.go
+++ b/internal/nova/conductor/dbsync.go
@@ -80,9 +80,10 @@ func CellDBSyncJob(
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					RestartPolicy:      corev1.RestartPolicyOnFailure,
-					ServiceAccountName: instance.Spec.ServiceAccount,
-					Volumes:            volumes,
+					RestartPolicy:                corev1.RestartPolicyOnFailure,
+					ServiceAccountName:           instance.Spec.ServiceAccount,
+					AutomountServiceAccountToken: ptr.To(false),
+					Volumes:                      volumes,
 					Containers: []corev1.Container{
 						{
 							Name: instance.Name + "-db-sync",
@@ -93,6 +94,9 @@ func CellDBSyncJob(
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: ptr.To(nova.NovaUserID),
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
 							},
 							Env:          env,
 							VolumeMounts: volumeMounts,

--- a/internal/nova/conductor/deployment.go
+++ b/internal/nova/conductor/deployment.go
@@ -102,8 +102,9 @@ func StatefulSet(
 					Labels:      labels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: instance.Spec.ServiceAccount,
-					Volumes:            volumes,
+					ServiceAccountName:           instance.Spec.ServiceAccount,
+					AutomountServiceAccountToken: ptr.To(false),
+					Volumes:                      volumes,
 					Containers: []corev1.Container{
 						{
 							Name: instance.Name + "-conductor",
@@ -114,6 +115,9 @@ func StatefulSet(
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: ptr.To(nova.NovaUserID),
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
 							},
 							Env:           env,
 							VolumeMounts:  volumeMounts,

--- a/internal/nova/host_discover.go
+++ b/internal/nova/host_discover.go
@@ -73,9 +73,10 @@ func HostDiscoveryJob(
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					RestartPolicy:      corev1.RestartPolicyOnFailure,
-					ServiceAccountName: instance.Spec.ServiceAccount,
-					Volumes:            volumes,
+					RestartPolicy:                corev1.RestartPolicyOnFailure,
+					ServiceAccountName:           instance.Spec.ServiceAccount,
+					AutomountServiceAccountToken: ptr.To(false),
+					Volumes:                      volumes,
 					Containers: []corev1.Container{
 						{
 							Name: "nova-manage",
@@ -86,6 +87,9 @@ func HostDiscoveryJob(
 							Image: instance.Spec.ConductorContainerImageURL,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: ptr.To(NovaUserID),
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
 							},
 							Env:          env,
 							VolumeMounts: volumeMounts,

--- a/internal/nova/metadata/deployment.go
+++ b/internal/nova/metadata/deployment.go
@@ -117,8 +117,9 @@ func StatefulSet(
 					Labels:      labels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: instance.Spec.ServiceAccount,
-					Volumes:            volumes,
+					ServiceAccountName:           instance.Spec.ServiceAccount,
+					AutomountServiceAccountToken: ptr.To(false),
+					Volumes:                      volumes,
 					Containers: []corev1.Container{
 						// the first container in a pod is the default selected
 						// by oc log so define the log stream container first.
@@ -137,6 +138,9 @@ func StatefulSet(
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: ptr.To(nova.NovaUserID),
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
 							},
 							Env:            env,
 							VolumeMounts:   []corev1.VolumeMount{nova.GetLogVolumeMount()},
@@ -153,6 +157,9 @@ func StatefulSet(
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: ptr.To(nova.NovaUserID),
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
 							},
 							Env:            env,
 							VolumeMounts:   volumeMounts,

--- a/internal/nova/novncproxy/deployment.go
+++ b/internal/nova/novncproxy/deployment.go
@@ -126,8 +126,9 @@ func StatefulSet(
 					Labels:      labels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: instance.Spec.ServiceAccount,
-					Volumes:            volumes,
+					ServiceAccountName:           instance.Spec.ServiceAccount,
+					AutomountServiceAccountToken: ptr.To(false),
+					Volumes:                      volumes,
 					Containers: []corev1.Container{
 						{
 							Name: instance.Name + "-novncproxy",
@@ -138,6 +139,9 @@ func StatefulSet(
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: ptr.To(nova.NovaUserID),
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
 							},
 							Env:            env,
 							VolumeMounts:   volumeMounts,

--- a/internal/nova/scheduler/deployment.go
+++ b/internal/nova/scheduler/deployment.go
@@ -103,8 +103,9 @@ func StatefulSet(
 					Labels:      labels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: instance.Spec.ServiceAccount,
-					Volumes:            volumes,
+					ServiceAccountName:           instance.Spec.ServiceAccount,
+					AutomountServiceAccountToken: ptr.To(false),
+					Volumes:                      volumes,
 					Containers: []corev1.Container{
 						{
 							Name: instance.Name + "-scheduler",
@@ -115,6 +116,9 @@ func StatefulSet(
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: ptr.To(nova.NovaUserID),
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
 							},
 							Env:           env,
 							VolumeMounts:  volumeMounts,

--- a/internal/placement/dbsync.go
+++ b/internal/placement/dbsync.go
@@ -60,8 +60,9 @@ func DbSyncJob(
 					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
-					RestartPolicy:      corev1.RestartPolicyOnFailure,
-					ServiceAccountName: instance.RbacResourceName(),
+					RestartPolicy:                corev1.RestartPolicyOnFailure,
+					ServiceAccountName:           instance.RbacResourceName(),
+					AutomountServiceAccountToken: ptr.To(false),
 					Containers: []corev1.Container{
 						{
 							Name: instance.Name + "-db-sync",
@@ -72,6 +73,9 @@ func DbSyncJob(
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: ptr.To(PlacementUserID),
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
 							},
 							Env:          env.MergeEnvs([]corev1.EnvVar{}, envVars),
 							VolumeMounts: volumeMounts,

--- a/internal/placement/deployment.go
+++ b/internal/placement/deployment.go
@@ -114,8 +114,9 @@ func Deployment(
 					Labels:      labels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: instance.RbacResourceName(),
-					Volumes:            volumes,
+					ServiceAccountName:           instance.RbacResourceName(),
+					AutomountServiceAccountToken: ptr.To(false),
+					Volumes:                      volumes,
 					Containers: []corev1.Container{
 						{
 							Name: instance.Name + "-log",
@@ -133,6 +134,9 @@ func Deployment(
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: ptr.To(PlacementUserID),
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
 							},
 							Env:            env.MergeEnvs([]corev1.EnvVar{}, envVars),
 							VolumeMounts:   volumeMounts,
@@ -149,6 +153,9 @@ func Deployment(
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: ptr.To(PlacementUserID),
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
 							},
 							Env:            env.MergeEnvs([]corev1.EnvVar{}, envVars),
 							VolumeMounts:   volumeMounts,

--- a/test/kuttl/test-suites/default/cell-tests/01-assert.yaml
+++ b/test/kuttl/test-suites/default/cell-tests/01-assert.yaml
@@ -139,7 +139,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    openshift.io/scc: anyuid
+    openshift.io/scc: nonroot-v2
   labels:
     service: nova-api
   name: nova-kuttl-api-0
@@ -174,7 +174,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    openshift.io/scc: anyuid
+    openshift.io/scc: nonroot-v2
   labels:
     service: nova-metadata
     statefulset.kubernetes.io/pod-name: nova-kuttl-metadata-0
@@ -198,7 +198,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    openshift.io/scc: anyuid
+    openshift.io/scc: nonroot-v2
   labels:
     cell: cell0
     service: nova-conductor
@@ -220,7 +220,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    openshift.io/scc: anyuid
+    openshift.io/scc: nonroot-v2
   labels:
     cell: cell1
     service: nova-conductor

--- a/test/kuttl/test-suites/default/cell-tests/02-assert.yaml
+++ b/test/kuttl/test-suites/default/cell-tests/02-assert.yaml
@@ -83,7 +83,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    openshift.io/scc: anyuid
+    openshift.io/scc: nonroot-v2
   labels:
     service: nova-api
   name: nova-kuttl-api-0
@@ -100,7 +100,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    openshift.io/scc: anyuid
+    openshift.io/scc: nonroot-v2
   labels:
     service: nova-metadata
     statefulset.kubernetes.io/pod-name: nova-kuttl-metadata-0

--- a/test/kuttl/test-suites/default/config-tests/01-assert.yaml
+++ b/test/kuttl/test-suites/default/config-tests/01-assert.yaml
@@ -83,7 +83,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    openshift.io/scc: anyuid
+    openshift.io/scc: nonroot-v2
   labels:
     service: nova-api
   name: nova-kuttl-api-0
@@ -100,7 +100,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    openshift.io/scc: anyuid
+    openshift.io/scc: nonroot-v2
   labels:
     service: nova-metadata
     statefulset.kubernetes.io/pod-name: nova-kuttl-metadata-0

--- a/test/kuttl/test-suites/default/config-tests/02-assert.yaml
+++ b/test/kuttl/test-suites/default/config-tests/02-assert.yaml
@@ -87,7 +87,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    openshift.io/scc: anyuid
+    openshift.io/scc: nonroot-v2
   labels:
     service: nova-api
   name: nova-kuttl-api-0
@@ -122,7 +122,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    openshift.io/scc: anyuid
+    openshift.io/scc: nonroot-v2
   labels:
     cell: cell0
     service: nova-conductor

--- a/test/kuttl/test-suites/default/cyborg-tests/01-assert.yaml
+++ b/test/kuttl/test-suites/default/cyborg-tests/01-assert.yaml
@@ -465,7 +465,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    openshift.io/scc: anyuid
+    openshift.io/scc: nonroot-v2
   labels:
     service: cyborg-api
   name: cyborg-kuttl-api-0
@@ -486,7 +486,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    openshift.io/scc: anyuid
+    openshift.io/scc: nonroot-v2
   labels:
     service: cyborg-conductor
   name: cyborg-kuttl-conductor-0

--- a/test/kuttl/test-suites/default/scale-tests/01-assert.yaml
+++ b/test/kuttl/test-suites/default/scale-tests/01-assert.yaml
@@ -139,7 +139,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    openshift.io/scc: anyuid
+    openshift.io/scc: nonroot-v2
   labels:
     service: nova-api
   name: nova-kuttl-api-0
@@ -174,7 +174,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    openshift.io/scc: anyuid
+    openshift.io/scc: nonroot-v2
   labels:
     service: nova-metadata
     statefulset.kubernetes.io/pod-name: nova-kuttl-metadata-0
@@ -198,7 +198,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    openshift.io/scc: anyuid
+    openshift.io/scc: nonroot-v2
   labels:
     cell: cell0
     service: nova-conductor
@@ -220,7 +220,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    openshift.io/scc: anyuid
+    openshift.io/scc: nonroot-v2
   labels:
     cell: cell1
     service: nova-conductor

--- a/test/kuttl/test-suites/default/scale-tests/02-assert.yaml
+++ b/test/kuttl/test-suites/default/scale-tests/02-assert.yaml
@@ -232,7 +232,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    openshift.io/scc: anyuid
+    openshift.io/scc: nonroot-v2
   labels:
     service: nova-api
   name: nova-kuttl-api-0
@@ -249,7 +249,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    openshift.io/scc: anyuid
+    openshift.io/scc: nonroot-v2
   labels:
     service: nova-api
     statefulset.kubernetes.io/pod-name: nova-kuttl-api-1
@@ -267,7 +267,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    openshift.io/scc: anyuid
+    openshift.io/scc: nonroot-v2
   labels:
     service: nova-api
     statefulset.kubernetes.io/pod-name: nova-kuttl-api-2
@@ -341,7 +341,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    openshift.io/scc: anyuid
+    openshift.io/scc: nonroot-v2
   labels:
     service: nova-metadata
     statefulset.kubernetes.io/pod-name: nova-kuttl-metadata-0
@@ -365,7 +365,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    openshift.io/scc: anyuid
+    openshift.io/scc: nonroot-v2
   labels:
     service: nova-metadata
     statefulset.kubernetes.io/pod-name: nova-kuttl-metadata-1
@@ -389,7 +389,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    openshift.io/scc: anyuid
+    openshift.io/scc: nonroot-v2
   labels:
     service: nova-metadata
     statefulset.kubernetes.io/pod-name: nova-kuttl-metadata-2
@@ -413,7 +413,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    openshift.io/scc: anyuid
+    openshift.io/scc: nonroot-v2
   labels:
     cell: cell0
     service: nova-conductor
@@ -435,7 +435,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    openshift.io/scc: anyuid
+    openshift.io/scc: nonroot-v2
   labels:
     cell: cell0
     service: nova-conductor
@@ -457,7 +457,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    openshift.io/scc: anyuid
+    openshift.io/scc: nonroot-v2
   labels:
     cell: cell0
     service: nova-conductor
@@ -479,7 +479,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    openshift.io/scc: anyuid
+    openshift.io/scc: nonroot-v2
   labels:
     cell: cell1
     service: nova-conductor
@@ -500,7 +500,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    openshift.io/scc: anyuid
+    openshift.io/scc: nonroot-v2
   labels:
     cell: cell1
     service: nova-conductor
@@ -521,7 +521,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    openshift.io/scc: anyuid
+    openshift.io/scc: nonroot-v2
   labels:
     cell: cell1
     service: nova-conductor

--- a/test/kuttl/test-suites/placement/common/assert_sample_deployment.yaml
+++ b/test/kuttl/test-suites/placement/common/assert_sample_deployment.yaml
@@ -194,7 +194,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    openshift.io/scc: anyuid
+    openshift.io/scc: nonroot-v2
   labels:
     service: placement
 status:

--- a/test/kuttl/test-suites/placement/common/errors_cleanup_placement.yaml
+++ b/test/kuttl/test-suites/placement/common/errors_cleanup_placement.yaml
@@ -23,7 +23,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    openshift.io/scc: anyuid
+    openshift.io/scc: nonroot-v2
   labels:
     service: placement
 ---


### PR DESCRIPTION
the Nova, PlacementAPI, and Cyborg controllers unconditionally granted use on the anyuid SCC to their workload service accounts, allowing a namespace-admin to launch arbitrary pods as UID 0 via the operator-created RoleBinding.

- Replace anyuid with nonroot-v2 in RBAC kubebuilder markers and runtime rbacRules for all three controllers (nova_controller.go, placement/api_controller.go, cyborg_controller.go)
- Add SeccompProfile RuntimeDefault to all Nova, Placement, and Cyborg container SecurityContexts
- Set AutomountServiceAccountToken: false on all Nova, Placement, and Cyborg pod specs
- Update kuttl assertions from openshift.io/scc: anyuid to nonroot-v2

Assisted-by: Claude Sonnet 4.5