### PR TITLE
set AutomountServiceAccountToken=false on Nova, Placement and Cyborg pods

### DIFF
--- a/internal/cyborg/api/statefulset.go
+++ b/internal/cyborg/api/statefulset.go
@@ -158,7 +158,8 @@ func StatefulSet(
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: instance.Spec.ServiceAccount,
+					ServiceAccountName:           instance.Spec.ServiceAccount,
+					AutomountServiceAccountToken: ptr.To(false),
 					Containers: []corev1.Container{
 						{
 							Name: ComponentName + "-log",

--- a/internal/cyborg/conductor/statefulset.go
+++ b/internal/cyborg/conductor/statefulset.go
@@ -118,7 +118,8 @@ func StatefulSet(
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: instance.Spec.ServiceAccount,
+					ServiceAccountName:           instance.Spec.ServiceAccount,
+					AutomountServiceAccountToken: ptr.To(false),
 					Containers: []corev1.Container{
 						{
 							Name: ComponentName,

--- a/internal/cyborg/dbsync.go
+++ b/internal/cyborg/dbsync.go
@@ -125,8 +125,9 @@ func DbSyncJob(
 					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
-					RestartPolicy:      corev1.RestartPolicyOnFailure,
-					ServiceAccountName: instance.RbacResourceName(),
+					RestartPolicy:                corev1.RestartPolicyOnFailure,
+					ServiceAccountName:           instance.RbacResourceName(),
+					AutomountServiceAccountToken: ptr.To(false),
 					Containers: []corev1.Container{
 						{
 							Name: "cyborg-db-sync",

--- a/internal/nova/api/deployment.go
+++ b/internal/nova/api/deployment.go
@@ -129,8 +129,9 @@ func StatefulSet(
 					Labels:      labels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: instance.Spec.ServiceAccount,
-					Volumes:            volumes,
+					ServiceAccountName:           instance.Spec.ServiceAccount,
+					AutomountServiceAccountToken: ptr.To(false),
+					Volumes:                      volumes,
 					Containers: []corev1.Container{
 						// the first container in a pod is the default selected
 						// by oc log so define the log stream container first.

--- a/internal/nova/celldelete.go
+++ b/internal/nova/celldelete.go
@@ -61,9 +61,10 @@ func CellDeleteJob(
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					RestartPolicy:      corev1.RestartPolicyOnFailure,
-					ServiceAccountName: instance.RbacResourceName(),
-					Volumes:            volumes,
+					RestartPolicy:                corev1.RestartPolicyOnFailure,
+					ServiceAccountName:           instance.RbacResourceName(),
+					AutomountServiceAccountToken: ptr.To(false),
+					Volumes:                      volumes,
 					Containers: []corev1.Container{
 						{
 							Name: "nova-manage",

--- a/internal/nova/cellmapping.go
+++ b/internal/nova/cellmapping.go
@@ -60,9 +60,10 @@ func CellMappingJob(
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					RestartPolicy:      corev1.RestartPolicyOnFailure,
-					ServiceAccountName: instance.RbacResourceName(),
-					Volumes:            volumes,
+					RestartPolicy:                corev1.RestartPolicyOnFailure,
+					ServiceAccountName:           instance.RbacResourceName(),
+					AutomountServiceAccountToken: ptr.To(false),
+					Volumes:                      volumes,
 					Containers: []corev1.Container{
 						{
 							Name: "nova-manage",

--- a/internal/nova/compute/deployment.go
+++ b/internal/nova/compute/deployment.go
@@ -95,8 +95,9 @@ func StatefulSet(
 					Labels:      labels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: instance.Spec.ServiceAccount,
-					Volumes:            volumes,
+					ServiceAccountName:           instance.Spec.ServiceAccount,
+					AutomountServiceAccountToken: ptr.To(false),
+					Volumes:                      volumes,
 					Containers: []corev1.Container{
 						{
 							Name: instance.Name + "-compute",

--- a/internal/nova/conductor/dbpurge.go
+++ b/internal/nova/conductor/dbpurge.go
@@ -81,9 +81,10 @@ func DBPurgeCronJob(
 					Completions: ptr.To[int32](1),
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
-							RestartPolicy:      corev1.RestartPolicyOnFailure,
-							ServiceAccountName: instance.Spec.ServiceAccount,
-							Volumes:            volumes,
+							RestartPolicy:                corev1.RestartPolicyOnFailure,
+							ServiceAccountName:           instance.Spec.ServiceAccount,
+							AutomountServiceAccountToken: ptr.To(false),
+							Volumes:                      volumes,
 							Containers: []corev1.Container{
 								{
 									Name: "nova-manage",

--- a/internal/nova/conductor/dbsync.go
+++ b/internal/nova/conductor/dbsync.go
@@ -80,9 +80,10 @@ func CellDBSyncJob(
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					RestartPolicy:      corev1.RestartPolicyOnFailure,
-					ServiceAccountName: instance.Spec.ServiceAccount,
-					Volumes:            volumes,
+					RestartPolicy:                corev1.RestartPolicyOnFailure,
+					ServiceAccountName:           instance.Spec.ServiceAccount,
+					AutomountServiceAccountToken: ptr.To(false),
+					Volumes:                      volumes,
 					Containers: []corev1.Container{
 						{
 							Name: instance.Name + "-db-sync",

--- a/internal/nova/conductor/deployment.go
+++ b/internal/nova/conductor/deployment.go
@@ -102,8 +102,9 @@ func StatefulSet(
 					Labels:      labels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: instance.Spec.ServiceAccount,
-					Volumes:            volumes,
+					ServiceAccountName:           instance.Spec.ServiceAccount,
+					AutomountServiceAccountToken: ptr.To(false),
+					Volumes:                      volumes,
 					Containers: []corev1.Container{
 						{
 							Name: instance.Name + "-conductor",

--- a/internal/nova/host_discover.go
+++ b/internal/nova/host_discover.go
@@ -73,9 +73,10 @@ func HostDiscoveryJob(
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					RestartPolicy:      corev1.RestartPolicyOnFailure,
-					ServiceAccountName: instance.Spec.ServiceAccount,
-					Volumes:            volumes,
+					RestartPolicy:                corev1.RestartPolicyOnFailure,
+					ServiceAccountName:           instance.Spec.ServiceAccount,
+					AutomountServiceAccountToken: ptr.To(false),
+					Volumes:                      volumes,
 					Containers: []corev1.Container{
 						{
 							Name: "nova-manage",

--- a/internal/nova/metadata/deployment.go
+++ b/internal/nova/metadata/deployment.go
@@ -117,8 +117,9 @@ func StatefulSet(
 					Labels:      labels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: instance.Spec.ServiceAccount,
-					Volumes:            volumes,
+					ServiceAccountName:           instance.Spec.ServiceAccount,
+					AutomountServiceAccountToken: ptr.To(false),
+					Volumes:                      volumes,
 					Containers: []corev1.Container{
 						// the first container in a pod is the default selected
 						// by oc log so define the log stream container first.

--- a/internal/nova/novncproxy/deployment.go
+++ b/internal/nova/novncproxy/deployment.go
@@ -126,8 +126,9 @@ func StatefulSet(
 					Labels:      labels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: instance.Spec.ServiceAccount,
-					Volumes:            volumes,
+					ServiceAccountName:           instance.Spec.ServiceAccount,
+					AutomountServiceAccountToken: ptr.To(false),
+					Volumes:                      volumes,
 					Containers: []corev1.Container{
 						{
 							Name: instance.Name + "-novncproxy",

--- a/internal/nova/scheduler/deployment.go
+++ b/internal/nova/scheduler/deployment.go
@@ -103,8 +103,9 @@ func StatefulSet(
 					Labels:      labels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: instance.Spec.ServiceAccount,
-					Volumes:            volumes,
+					ServiceAccountName:           instance.Spec.ServiceAccount,
+					AutomountServiceAccountToken: ptr.To(false),
+					Volumes:                      volumes,
 					Containers: []corev1.Container{
 						{
 							Name: instance.Name + "-scheduler",

--- a/internal/placement/dbsync.go
+++ b/internal/placement/dbsync.go
@@ -60,8 +60,9 @@ func DbSyncJob(
 					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
-					RestartPolicy:      corev1.RestartPolicyOnFailure,
-					ServiceAccountName: instance.RbacResourceName(),
+					RestartPolicy:                corev1.RestartPolicyOnFailure,
+					ServiceAccountName:           instance.RbacResourceName(),
+					AutomountServiceAccountToken: ptr.To(false),
 					Containers: []corev1.Container{
 						{
 							Name: instance.Name + "-db-sync",

--- a/internal/placement/deployment.go
+++ b/internal/placement/deployment.go
@@ -114,8 +114,9 @@ func Deployment(
 					Labels:      labels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: instance.RbacResourceName(),
-					Volumes:            volumes,
+					ServiceAccountName:           instance.RbacResourceName(),
+					AutomountServiceAccountToken: ptr.To(false),
+					Volumes:                      volumes,
 					Containers: []corev1.Container{
 						{
 							Name: instance.Name + "-log",

--- a/test/functional/cyborg/cyborgapi_controller_test.go
+++ b/test/functional/cyborg/cyborgapi_controller_test.go
@@ -269,6 +269,8 @@ var _ = Describe("CyborgAPI controller", func() {
 				g.Expect(ss.Spec.Replicas).NotTo(BeNil())
 				g.Expect(*ss.Spec.Replicas).To(Equal(int32(1)))
 				g.Expect(ss.Spec.Template.Spec.ServiceAccountName).To(Equal(APITestSA))
+				g.Expect(ss.Spec.Template.Spec.AutomountServiceAccountToken).NotTo(BeNil())
+				g.Expect(*ss.Spec.Template.Spec.AutomountServiceAccountToken).To(BeFalse())
 				g.Expect(ss.Spec.Template.Spec.Containers).To(HaveLen(2))
 
 				// Log sidecar container (index 0)

--- a/test/functional/cyborg/cyborgconductor_controller_test.go
+++ b/test/functional/cyborg/cyborgconductor_controller_test.go
@@ -226,6 +226,8 @@ var _ = Describe("CyborgConductor controller", func() {
 				g.Expect(ss.Spec.Replicas).NotTo(BeNil())
 				g.Expect(*ss.Spec.Replicas).To(Equal(int32(1)))
 				g.Expect(ss.Spec.Template.Spec.ServiceAccountName).To(Equal(ConductorTestSA))
+				g.Expect(ss.Spec.Template.Spec.AutomountServiceAccountToken).NotTo(BeNil())
+				g.Expect(*ss.Spec.Template.Spec.AutomountServiceAccountToken).To(BeFalse())
 				g.Expect(ss.Spec.Template.Spec.Containers).To(HaveLen(1))
 
 				container := ss.Spec.Template.Spec.Containers[0]

--- a/test/functional/nova/compute_ironic_controller_test.go
+++ b/test/functional/nova/compute_ironic_controller_test.go
@@ -261,6 +261,8 @@ var _ = Describe("NovaCompute controller", func() {
 
 				ss := th.GetStatefulSet(cell1.NovaComputeStatefulSetName)
 				Expect(int(*ss.Spec.Replicas)).To(Equal(1))
+				Expect(ss.Spec.Template.Spec.AutomountServiceAccountToken).NotTo(BeNil())
+				Expect(*ss.Spec.Template.Spec.AutomountServiceAccountToken).To(BeFalse())
 				Expect(ss.Spec.Template.Spec.Volumes).To(HaveLen(1))
 				Expect(ss.Spec.Template.Spec.Containers).To(HaveLen(1))
 				Expect(ss.Spec.Selector.MatchLabels).To(Equal(map[string]string{"service": "nova-compute", "cell": "cell1"}))

--- a/test/functional/nova/conductor_controller_test.go
+++ b/test/functional/nova/conductor_controller_test.go
@@ -314,6 +314,8 @@ var _ = Describe("NovaConductor controller", func() {
 			)
 			job := th.GetJob(cell0.DBSyncJobName)
 			Expect(job.Spec.Template.Spec.ServiceAccountName).To(Equal("nova-sa"))
+			Expect(job.Spec.Template.Spec.AutomountServiceAccountToken).NotTo(BeNil())
+			Expect(*job.Spec.Template.Spec.AutomountServiceAccountToken).To(BeFalse())
 			Expect(job.Spec.Template.Spec.Volumes).To(HaveLen(2))
 			Expect(job.Spec.Template.Spec.InitContainers).To(BeEmpty())
 			Expect(job.Spec.Template.Spec.Containers).To(HaveLen(1))
@@ -380,6 +382,8 @@ var _ = Describe("NovaConductor controller", func() {
 				)
 				ss := th.GetStatefulSet(cell0.ConductorStatefulSetName)
 				Expect(ss.Spec.Template.Spec.ServiceAccountName).To(Equal("nova-sa"))
+				Expect(ss.Spec.Template.Spec.AutomountServiceAccountToken).NotTo(BeNil())
+				Expect(*ss.Spec.Template.Spec.AutomountServiceAccountToken).To(BeFalse())
 				Expect(ss.Spec.Template.Spec.Containers).To(HaveLen(1))
 				container := ss.Spec.Template.Spec.Containers[0]
 				Expect(container.LivenessProbe.Exec.Command).To(

--- a/test/functional/nova/metadata_controller_test.go
+++ b/test/functional/nova/metadata_controller_test.go
@@ -270,6 +270,8 @@ var _ = Describe("NovaMetadata controller", func() {
 
 				ss := th.GetStatefulSet(novaNames.MetadataStatefulSetName)
 				Expect(ss.Spec.Template.Spec.ServiceAccountName).To(Equal("nova-sa"))
+				Expect(ss.Spec.Template.Spec.AutomountServiceAccountToken).NotTo(BeNil())
+				Expect(*ss.Spec.Template.Spec.AutomountServiceAccountToken).To(BeFalse())
 				Expect(int(*ss.Spec.Replicas)).To(Equal(1))
 				Expect(ss.Spec.Template.Spec.Volumes).To(HaveLen(2))
 				Expect(ss.Spec.Template.Spec.Containers).To(HaveLen(2))

--- a/test/functional/nova/novaapi_controller_test.go
+++ b/test/functional/nova/novaapi_controller_test.go
@@ -416,6 +416,8 @@ endpoint_service_type = compute`))
 
 			ss := th.GetStatefulSet(novaNames.APIStatefulSetName)
 			Expect(ss.Spec.Template.Spec.ServiceAccountName).To(Equal("nova-sa"))
+			Expect(ss.Spec.Template.Spec.AutomountServiceAccountToken).NotTo(BeNil())
+			Expect(*ss.Spec.Template.Spec.AutomountServiceAccountToken).To(BeFalse())
 			Expect(int(*ss.Spec.Replicas)).To(Equal(1))
 			Expect(ss.Spec.Template.Spec.Volumes).To(HaveLen(2))
 			Expect(ss.Spec.Template.Spec.Containers).To(HaveLen(2))

--- a/test/functional/nova/novncproxy_test.go
+++ b/test/functional/nova/novncproxy_test.go
@@ -251,6 +251,8 @@ var _ = Describe("NovaNoVNCProxy controller", func() {
 
 				ss := th.GetStatefulSet(cell1.NoVNCProxyStatefulSetName)
 				Expect(ss.Spec.Template.Spec.ServiceAccountName).To(Equal("nova-sa"))
+				Expect(ss.Spec.Template.Spec.AutomountServiceAccountToken).NotTo(BeNil())
+				Expect(*ss.Spec.Template.Spec.AutomountServiceAccountToken).To(BeFalse())
 				Expect(int(*ss.Spec.Replicas)).To(Equal(1))
 				Expect(ss.Spec.Template.Spec.Volumes).To(HaveLen(1))
 				Expect(ss.Spec.Template.Spec.Containers).To(HaveLen(1))

--- a/test/functional/nova/scheduler_test.go
+++ b/test/functional/nova/scheduler_test.go
@@ -372,6 +372,8 @@ var _ = Describe("NovaScheduler controller", func() {
 
 			ss := th.GetStatefulSet(novaNames.SchedulerStatefulSetName)
 			Expect(ss.Spec.Template.Spec.ServiceAccountName).To(Equal("nova-sa"))
+			Expect(ss.Spec.Template.Spec.AutomountServiceAccountToken).NotTo(BeNil())
+			Expect(*ss.Spec.Template.Spec.AutomountServiceAccountToken).To(BeFalse())
 			Expect(int(*ss.Spec.Replicas)).To(Equal(1))
 			Expect(ss.Spec.Template.Spec.Volumes).To(HaveLen(1))
 			Expect(ss.Spec.Template.Spec.Containers).To(HaveLen(1))

--- a/test/functional/placement/api_controller_test.go
+++ b/test/functional/placement/api_controller_test.go
@@ -528,6 +528,8 @@ var _ = Describe("PlacementAPI controller", func() {
 			)
 
 			job := th.GetJob(names.DBSyncJobName)
+			Expect(job.Spec.Template.Spec.AutomountServiceAccountToken).NotTo(BeNil())
+			Expect(*job.Spec.Template.Spec.AutomountServiceAccountToken).To(BeFalse())
 			Expect(job.Spec.Template.Spec.Volumes).To(HaveLen(3))
 			Expect(job.Spec.Template.Spec.Containers).To(HaveLen(1))
 
@@ -565,6 +567,8 @@ var _ = Describe("PlacementAPI controller", func() {
 			Expect(int(*deployment.Spec.Replicas)).To(Equal(1))
 			Expect(deployment.Spec.Selector.MatchLabels).To(Equal(map[string]string{"service": "placement", "owner": names.PlacementAPIName.Name}))
 			Expect(deployment.Spec.Template.Spec.ServiceAccountName).To(Equal(names.ServiceAccountName.Name))
+			Expect(deployment.Spec.Template.Spec.AutomountServiceAccountToken).NotTo(BeNil())
+			Expect(*deployment.Spec.Template.Spec.AutomountServiceAccountToken).To(BeFalse())
 			Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(2))
 
 			th.SimulateDeploymentReplicaReady(names.DeploymentName)

--- a/test/kuttl/test-suites/default/cell-tests/01-assert.yaml
+++ b/test/kuttl/test-suites/default/cell-tests/01-assert.yaml
@@ -143,6 +143,8 @@ metadata:
   labels:
     service: nova-api
   name: nova-kuttl-api-0
+spec:
+  automountServiceAccountToken: false
 status:
   containerStatuses:
   - name: nova-kuttl-api-api
@@ -164,6 +166,8 @@ metadata:
     controller: true
     kind: StatefulSet
     name: nova-kuttl-scheduler
+spec:
+  automountServiceAccountToken: false
 status:
   containerStatuses:
   - name: nova-kuttl-scheduler-scheduler
@@ -185,6 +189,8 @@ metadata:
     controller: true
     kind: StatefulSet
     name: nova-kuttl-metadata
+spec:
+  automountServiceAccountToken: false
 status:
   containerStatuses:
   - name: nova-kuttl-metadata-log
@@ -210,6 +216,8 @@ metadata:
     controller: true
     kind: StatefulSet
     name: nova-kuttl-cell0-conductor
+spec:
+  automountServiceAccountToken: false
 status:
   containerStatuses:
   - name: nova-kuttl-cell0-conductor-conductor
@@ -231,6 +239,8 @@ metadata:
     controller: true
     kind: StatefulSet
     name: nova-kuttl-cell1-conductor
+spec:
+  automountServiceAccountToken: false
 status:
   containerStatuses:
   - name: nova-kuttl-cell1-conductor-conductor

--- a/test/kuttl/test-suites/default/cell-tests/02-assert.yaml
+++ b/test/kuttl/test-suites/default/cell-tests/02-assert.yaml
@@ -87,6 +87,8 @@ metadata:
   labels:
     service: nova-api
   name: nova-kuttl-api-0
+spec:
+  automountServiceAccountToken: false
 status:
   containerStatuses:
   - name: nova-kuttl-api-api
@@ -111,6 +113,8 @@ metadata:
     controller: true
     kind: StatefulSet
     name: nova-kuttl-metadata
+spec:
+  automountServiceAccountToken: false
 status:
   containerStatuses:
   - name: nova-kuttl-metadata-log

--- a/test/kuttl/test-suites/default/config-tests/01-assert.yaml
+++ b/test/kuttl/test-suites/default/config-tests/01-assert.yaml
@@ -87,6 +87,8 @@ metadata:
   labels:
     service: nova-api
   name: nova-kuttl-api-0
+spec:
+  automountServiceAccountToken: false
 status:
   containerStatuses:
   - name: nova-kuttl-api-api
@@ -111,6 +113,8 @@ metadata:
     controller: true
     kind: StatefulSet
     name: nova-kuttl-metadata
+spec:
+  automountServiceAccountToken: false
 status:
   containerStatuses:
   - name: nova-kuttl-metadata-log

--- a/test/kuttl/test-suites/default/config-tests/02-assert.yaml
+++ b/test/kuttl/test-suites/default/config-tests/02-assert.yaml
@@ -91,6 +91,8 @@ metadata:
   labels:
     service: nova-api
   name: nova-kuttl-api-0
+spec:
+  automountServiceAccountToken: false
 status:
   containerStatuses:
   - name: nova-kuttl-api-api
@@ -112,6 +114,8 @@ metadata:
     controller: true
     kind: StatefulSet
     name: nova-kuttl-scheduler
+spec:
+  automountServiceAccountToken: false
 status:
   containerStatuses:
   - name: nova-kuttl-scheduler-scheduler
@@ -134,6 +138,8 @@ metadata:
     controller: true
     kind: StatefulSet
     name: nova-kuttl-cell0-conductor
+spec:
+  automountServiceAccountToken: false
 status:
   containerStatuses:
   - name: nova-kuttl-cell0-conductor-conductor

--- a/test/kuttl/test-suites/default/cyborg-tests/01-assert.yaml
+++ b/test/kuttl/test-suites/default/cyborg-tests/01-assert.yaml
@@ -469,6 +469,8 @@ metadata:
   labels:
     service: cyborg-api
   name: cyborg-kuttl-api-0
+spec:
+  automountServiceAccountToken: false
 status:
   containerStatuses:
   - name: cyborg-api
@@ -490,6 +492,8 @@ metadata:
   labels:
     service: cyborg-conductor
   name: cyborg-kuttl-conductor-0
+spec:
+  automountServiceAccountToken: false
 status:
   containerStatuses:
   - name: cyborg-conductor

--- a/test/kuttl/test-suites/default/scale-tests/01-assert.yaml
+++ b/test/kuttl/test-suites/default/scale-tests/01-assert.yaml
@@ -143,6 +143,8 @@ metadata:
   labels:
     service: nova-api
   name: nova-kuttl-api-0
+spec:
+  automountServiceAccountToken: false
 status:
   containerStatuses:
   - name: nova-kuttl-api-api
@@ -164,6 +166,8 @@ metadata:
     controller: true
     kind: StatefulSet
     name: nova-kuttl-scheduler
+spec:
+  automountServiceAccountToken: false
 status:
   containerStatuses:
   - name: nova-kuttl-scheduler-scheduler
@@ -185,6 +189,8 @@ metadata:
     controller: true
     kind: StatefulSet
     name: nova-kuttl-metadata
+spec:
+  automountServiceAccountToken: false
 status:
   containerStatuses:
   - name: nova-kuttl-metadata-log
@@ -210,6 +216,8 @@ metadata:
     controller: true
     kind: StatefulSet
     name: nova-kuttl-cell0-conductor
+spec:
+  automountServiceAccountToken: false
 status:
   containerStatuses:
   - name: nova-kuttl-cell0-conductor-conductor
@@ -231,6 +239,8 @@ metadata:
     controller: true
     kind: StatefulSet
     name: nova-kuttl-cell1-conductor
+spec:
+  automountServiceAccountToken: false
 status:
   containerStatuses:
   - name: nova-kuttl-cell1-conductor-conductor

--- a/test/kuttl/test-suites/default/scale-tests/02-assert.yaml
+++ b/test/kuttl/test-suites/default/scale-tests/02-assert.yaml
@@ -236,6 +236,8 @@ metadata:
   labels:
     service: nova-api
   name: nova-kuttl-api-0
+spec:
+  automountServiceAccountToken: false
 status:
   containerStatuses:
   - name: nova-kuttl-api-api
@@ -254,6 +256,8 @@ metadata:
     service: nova-api
     statefulset.kubernetes.io/pod-name: nova-kuttl-api-1
   name: nova-kuttl-api-1
+spec:
+  automountServiceAccountToken: false
 status:
   containerStatuses:
   - name: nova-kuttl-api-api
@@ -272,6 +276,8 @@ metadata:
     service: nova-api
     statefulset.kubernetes.io/pod-name: nova-kuttl-api-2
   name: nova-kuttl-api-2
+spec:
+  automountServiceAccountToken: false
 status:
   containerStatuses:
   - name: nova-kuttl-api-api
@@ -293,6 +299,8 @@ metadata:
     controller: true
     kind: StatefulSet
     name: nova-kuttl-scheduler
+spec:
+  automountServiceAccountToken: false
 status:
   containerStatuses:
   - name: nova-kuttl-scheduler-scheduler
@@ -312,6 +320,8 @@ metadata:
     controller: true
     kind: StatefulSet
     name: nova-kuttl-scheduler
+spec:
+  automountServiceAccountToken: false
 status:
   containerStatuses:
   - name: nova-kuttl-scheduler-scheduler
@@ -331,6 +341,8 @@ metadata:
     controller: true
     kind: StatefulSet
     name: nova-kuttl-scheduler
+spec:
+  automountServiceAccountToken: false
 status:
   containerStatuses:
   - name: nova-kuttl-scheduler-scheduler
@@ -352,6 +364,8 @@ metadata:
     controller: true
     kind: StatefulSet
     name: nova-kuttl-metadata
+spec:
+  automountServiceAccountToken: false
 status:
   containerStatuses:
   - name: nova-kuttl-metadata-log
@@ -376,6 +390,8 @@ metadata:
     controller: true
     kind: StatefulSet
     name: nova-kuttl-metadata
+spec:
+  automountServiceAccountToken: false
 status:
   containerStatuses:
   - name: nova-kuttl-metadata-log
@@ -400,6 +416,8 @@ metadata:
     controller: true
     kind: StatefulSet
     name: nova-kuttl-metadata
+spec:
+  automountServiceAccountToken: false
 status:
   containerStatuses:
   - name: nova-kuttl-metadata-log
@@ -425,6 +443,8 @@ metadata:
     controller: true
     kind: StatefulSet
     name: nova-kuttl-cell0-conductor
+spec:
+  automountServiceAccountToken: false
 status:
   containerStatuses:
   - name: nova-kuttl-cell0-conductor-conductor
@@ -447,6 +467,8 @@ metadata:
     controller: true
     kind: StatefulSet
     name: nova-kuttl-cell0-conductor
+spec:
+  automountServiceAccountToken: false
 status:
   containerStatuses:
   - name: nova-kuttl-cell0-conductor-conductor
@@ -469,6 +491,8 @@ metadata:
     controller: true
     kind: StatefulSet
     name: nova-kuttl-cell0-conductor
+spec:
+  automountServiceAccountToken: false
 status:
   containerStatuses:
   - name: nova-kuttl-cell0-conductor-conductor
@@ -490,6 +514,8 @@ metadata:
     controller: true
     kind: StatefulSet
     name: nova-kuttl-cell1-conductor
+spec:
+  automountServiceAccountToken: false
 status:
   containerStatuses:
   - name: nova-kuttl-cell1-conductor-conductor
@@ -511,6 +537,8 @@ metadata:
     controller: true
     kind: StatefulSet
     name: nova-kuttl-cell1-conductor
+spec:
+  automountServiceAccountToken: false
 status:
   containerStatuses:
   - name: nova-kuttl-cell1-conductor-conductor
@@ -532,6 +560,8 @@ metadata:
     controller: true
     kind: StatefulSet
     name: nova-kuttl-cell1-conductor
+spec:
+  automountServiceAccountToken: false
 status:
   containerStatuses:
   - name: nova-kuttl-cell1-conductor-conductor

--- a/test/kuttl/test-suites/placement/common/assert_sample_deployment.yaml
+++ b/test/kuttl/test-suites/placement/common/assert_sample_deployment.yaml
@@ -197,6 +197,8 @@ metadata:
     openshift.io/scc: anyuid
   labels:
     service: placement
+spec:
+  automountServiceAccountToken: false
 status:
   phase: Running
 ---

--- a/test/kuttl/test-suites/placement/common/errors_cleanup_placement.yaml
+++ b/test/kuttl/test-suites/placement/common/errors_cleanup_placement.yaml
@@ -26,6 +26,8 @@ metadata:
     openshift.io/scc: anyuid
   labels:
     service: placement
+spec:
+  automountServiceAccountToken: false
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Disable automatic service-account token projection for all Nova, Placement and Cyborg workload pods. None of these pods need to call the Kubernetes API, so mounting the token is unnecessary and increases the blast radius of a container-escape compromise.