### PR TITLE
enable periodic host discovery by default

### DIFF
--- a/templates/nova/nova.conf
+++ b/templates/nova/nova.conf
@@ -113,6 +113,7 @@ query_placement_for_availability_zone=true
 query_placement_for_image_type_support=true
 enable_isolated_aggregate_filtering=true
 image_metadata_prefilter=true
+discover_hosts_in_cells_interval=900
 
 {{end}}
 


### PR DESCRIPTION
Set [scheduler]discover_hosts_in_cells_interval=900 so nova-scheduler
automatically discovers new compute nodes every 15 minutes without any
manual intervention.