### PR TITLE
Adjust default config for threading mode in Nova services

### DIFF
--- a/templates/nova/nova.conf
+++ b/templates/nova/nova.conf
@@ -4,6 +4,14 @@
 # overall then serializing live migrations so set this to 1 explicitly
 max_concurrent_live_migrations=1
 state_path = /var/lib/nova
+# Note(ksambor) We want to monitor threads closely, at least in 19
+# so for debugging purposes, we want to collect logs at least once every
+# 5 minutes
+thread_pool_statistic_period=300
+concurrency_backend=threading
+{{if eq .service_name "nova-conductor" "nova-scheduler"}}
+executor_thread_pool_size=32
+{{end}}
 {{if eq .service_name "nova-api"}}
 allow_resize_to_same_host = true
 {{end}}
@@ -71,15 +79,6 @@ amqp_durable_queues=true
 amqp_durable_queues=false
 amqp_auto_delete=false
 {{- end -}}
-{{/*we might just want to make this always false*/}}
-{{ if eq .service_name "nova-api"}}
-# We cannot set this to true while is
-# https://review.opendev.org/c/openstack/oslo.log/+/852443 is not used in the
-# nova-api image otherwise logging from the heartbeat thread will cause hangs.
-heartbeat_in_pthread=false
-{{else}}
-heartbeat_in_pthread=false
-{{end}}
 
 {{ if eq .service_name "nova-api"}}
 [oslo_policy]


### PR DESCRIPTION
Performance tests show we never reach the default number of concurrent tasks executed in the thread pool, so we can lower it to 32. Since threading mode will be enabled across all services, we should begin collecting logs for monitoring. Additionally, heartbeat_in_pthread is deprecated and no longer needs to be set.